### PR TITLE
Fix domain, iOS/Android backend communication, and response decoding

### DIFF
--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -65,7 +65,7 @@ jobs:
           grep -E "error:" build.log | grep -v "^▸" | head -50 || echo "(none)"
           echo ""
           echo "=== Last 150 lines of raw log ==="
-          tail -150 build.log
+          tail -500 build.log
 
       - name: Upload build log
         if: failure()
@@ -193,7 +193,7 @@ jobs:
           grep -E "error:" xcodebuild.log | grep -v "^▸" | head -50 || echo "(none)"
           echo ""
           echo "=== Last 150 lines of raw log ==="
-          tail -150 xcodebuild.log
+          tail -500 xcodebuild.log
 
       - name: Upload test artifacts
         if: failure()

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -110,6 +110,12 @@ jobs:
           name: test-bundle
           path: "ios/Positive Only Social/build/Build/Products"
 
+      - name: List available test bundles
+        working-directory: "ios/Positive Only Social"
+        run: |
+          echo "=== xctestrun files ==="
+          find build/Build/Products -name "*.xctestrun"
+
       - name: Run Tests
         working-directory: "ios/Positive Only Social"
         run: |
@@ -118,6 +124,8 @@ jobs:
               TESTS=(
                 "Positive Only SocialTests"
               )
+              # Unit Tests xctestrun only covers the unit test target
+              XCTESTRUN=$(find build/Build/Products -name "*Unit*Tests*.xctestrun" | head -1)
               ;;
             UI_Tests_Alpha)
               TESTS=(
@@ -128,6 +136,8 @@ jobs:
                 "Positive Only SocialUITests/Positive_Only_SocialUITests/testFollowAndUnfollowFromPost"
                 "Positive Only SocialUITests/Positive_Only_SocialUITests/testLikeAndUnlikePost"
               )
+              # UI Tests xctestrun covers the UI test target
+              XCTESTRUN=$(find build/Build/Products -name "*UI*Tests*.xctestrun" | head -1)
               ;;
             UI_Tests_Beta)
               TESTS=(
@@ -138,16 +148,19 @@ jobs:
                 "Positive Only SocialUITests/Positive_Only_SocialUITests/testLaunchPerformance"
                 "Positive Only SocialUITests/Positive_Only_SocialUITests/testBlockAndUnblockUser"
               )
+              # UI Tests xctestrun covers the UI test target
+              XCTESTRUN=$(find build/Build/Products -name "*UI*Tests*.xctestrun" | head -1)
               ;;
           esac
+
+          # Fallback: if the pattern found nothing, take the first available file
+          XCTESTRUN=${XCTESTRUN:-$(find build/Build/Products -name "*.xctestrun" | head -1)}
+          echo "Using xctestrun: $XCTESTRUN"
 
           ONLY_TESTING_ARGS=()
           for t in "${TESTS[@]}"; do
             ONLY_TESTING_ARGS+=("-only-testing:$t")
           done
-
-          XCTESTRUN=$(find build/Build/Products -name "*.xctestrun" | head -1)
-          echo "Using xctestrun: $XCTESTRUN"
 
           xcodebuild test-without-building \
             -xctestrun "$XCTESTRUN" \

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -124,8 +124,8 @@ jobs:
               TESTS=(
                 "Positive Only SocialTests"
               )
-              # Unit Tests xctestrun only covers the unit test target
-              XCTESTRUN=$(find build/Build/Products -name "*Unit*Tests*.xctestrun" | head -1)
+              # "Positive Only Social Unit Tests" plan covers unit tests only
+              XCTESTRUN=$(find build/Build/Products -name "*.xctestrun" | grep "Unit Tests" | head -1)
               ;;
             UI_Tests_Alpha)
               TESTS=(
@@ -136,8 +136,8 @@ jobs:
                 "Positive Only SocialUITests/Positive_Only_SocialUITests/testFollowAndUnfollowFromPost"
                 "Positive Only SocialUITests/Positive_Only_SocialUITests/testLikeAndUnlikePost"
               )
-              # UI Tests xctestrun covers the UI test target
-              XCTESTRUN=$(find build/Build/Products -name "*UI*Tests*.xctestrun" | head -1)
+              # "Positive Only Social" (default) plan covers both unit and UI tests
+              XCTESTRUN=$(find build/Build/Products -name "*.xctestrun" | grep -v "Unit Tests" | head -1)
               ;;
             UI_Tests_Beta)
               TESTS=(
@@ -148,8 +148,8 @@ jobs:
                 "Positive Only SocialUITests/Positive_Only_SocialUITests/testLaunchPerformance"
                 "Positive Only SocialUITests/Positive_Only_SocialUITests/testBlockAndUnblockUser"
               )
-              # UI Tests xctestrun covers the UI test target
-              XCTESTRUN=$(find build/Build/Products -name "*UI*Tests*.xctestrun" | head -1)
+              # "Positive Only Social" (default) plan covers both unit and UI tests
+              XCTESTRUN=$(find build/Build/Products -name "*.xctestrun" | grep -v "Unit Tests" | head -1)
               ;;
           esac
 

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -61,6 +61,19 @@ jobs:
           | tee xcodebuild.log | xcpretty
           exit ${PIPESTATUS[0]}
 
+      - name: Show failed tests
+        if: failure()
+        working-directory: "ios/Positive Only Social"
+        run: |
+          echo "=== Failed test cases ==="
+          grep -E "Test Case .* failed|Test Suite .* failed at" xcodebuild.log || echo "(no test-case lines found — build may have failed before tests ran)"
+          echo ""
+          echo "=== Compiler errors ==="
+          grep -E "error:" xcodebuild.log | grep -v "^▸" | head -50 || echo "(none)"
+          echo ""
+          echo "=== Last 150 lines of raw log ==="
+          tail -150 xcodebuild.log
+
       - name: Upload test artifacts
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -122,8 +122,11 @@ jobs:
             ONLY_TESTING_ARGS+=("-only-testing:$t")
           done
 
+          XCTESTRUN=$(find build/Build/Products -name "*.xctestrun" | head -1)
+          echo "Using xctestrun: $XCTESTRUN"
+
           xcodebuild test-without-building \
-            -xctestrun build/Build/Products/*.xctestrun \
+            -xctestrun "$XCTESTRUN" \
             -destination "platform=iOS Simulator,name=iPhone 16,OS=26.2" \
             -resultBundlePath TestResults.xcresult \
             "${ONLY_TESTING_ARGS[@]}" \

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -187,40 +187,42 @@ jobs:
         working-directory: "ios/Positive Only Social"
         run: |
           echo "=== Failed test cases (xcodebuild.log) ==="
-          grep -iE "test case .* failed|test suite .* failed" xcodebuild.log || echo "(no test-case lines found — build may have failed before tests ran)"
+          grep -iE "test case .* failed|test suite .* failed" xcodebuild.log || echo "(no test-case lines found)"
           echo ""
           echo "=== Assertion failures (xcresult) ==="
+          cat > /tmp/parse_xcresult.py << 'PYEOF'
+          import json, sys
+
+          def walk(node):
+              if not isinstance(node, dict):
+                  return
+              if (node.get("_type", {}).get("_name") == "ActionTestSummary"
+                      and node.get("testStatus", {}).get("_value") == "Failure"):
+                  name = node.get("name", {}).get("_value", "(unknown)")
+                  print("FAILED: " + name)
+                  for s in node.get("failureSummaries", {}).get("_values", []):
+                      msg = s.get("message", {}).get("_value", "")
+                      loc = s.get("sourceCodeContext", {}).get("location", {})
+                      f   = loc.get("file", {}).get("_value", "").split("/")[-1]
+                      ln  = loc.get("line", {}).get("_value", "")
+                      print("  -> " + msg)
+                      if f:
+                          print("     at " + f + ":" + ln)
+              for v in node.values():
+                  if isinstance(v, dict):
+                      walk(v)
+                  elif isinstance(v, list):
+                      for item in v:
+                          walk(item)
+
+          try:
+              walk(json.load(sys.stdin))
+          except Exception as e:
+              print("(xcresult parse error: " + str(e) + ")")
+          PYEOF
           xcrun xcresulttool get --path TestResults.xcresult --format json 2>/dev/null \
-          | python3 -c "
-import json, sys
-
-def walk(node):
-    if not isinstance(node, dict):
-        return
-    if node.get('_type', {}).get('_name') == 'ActionTestSummary' \
-       and node.get('testStatus', {}).get('_value') == 'Failure':
-        name = node.get('name', {}).get('_value', '(unknown)')
-        print(f'FAILED: {name}')
-        for s in node.get('failureSummaries', {}).get('_values', []):
-            msg  = s.get('message', {}).get('_value', '')
-            loc  = s.get('sourceCodeContext', {}).get('location', {})
-            file = loc.get('file', {}).get('_value', '').split('/')[-1]
-            line = loc.get('line', {}).get('_value', '')
-            print(f'  -> {msg}')
-            if file:
-                print(f'     at {file}:{line}')
-    for v in node.values():
-        if isinstance(v, dict):
-            walk(v)
-        elif isinstance(v, list):
-            for item in v:
-                walk(item)
-
-try:
-    walk(json.load(sys.stdin))
-except Exception as e:
-    print(f'(xcresult parse error: {e})')
-" || echo "(xcresulttool unavailable or no xcresult found)"
+            | python3 /tmp/parse_xcresult.py \
+            || echo "(xcresulttool unavailable or no xcresult found)"
           echo ""
           echo "=== Compiler errors ==="
           grep -E "error:" xcodebuild.log | grep -v "^▸" | head -50 || echo "(none)"

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -220,9 +220,19 @@ jobs:
           except Exception as e:
               print("(xcresult parse error: " + str(e) + ")")
           PYEOF
-          xcrun xcresulttool get --path TestResults.xcresult --format json 2>/dev/null \
-            | python3 /tmp/parse_xcresult.py \
-            || echo "(xcresulttool unavailable or no xcresult found)"
+          xcrun xcresulttool get --path TestResults.xcresult --format json \
+            > /tmp/xcresult.json 2>/tmp/xcresult_err.txt || true
+          if [ -s /tmp/xcresult.json ]; then
+            python3 /tmp/parse_xcresult.py < /tmp/xcresult.json
+          else
+            echo "(xcresulttool produced no JSON — stderr below)"
+            cat /tmp/xcresult_err.txt || true
+            echo ""
+            echo "--- Trying legacy invocation ---"
+            xcrun xcresulttool get --path TestResults.xcresult \
+              > /tmp/xcresult_legacy.txt 2>&1 || true
+            head -30 /tmp/xcresult_legacy.txt || true
+          fi
           echo ""
           echo "=== Compiler errors ==="
           grep -E "error:" xcodebuild.log | grep -v "^▸" | head -50 || echo "(none)"

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -12,8 +12,8 @@ on:
       - '.github/workflows/ios-tests.yml'
 
 jobs:
-  test:
-    name: Run Unit and UI Tests
+  build:
+    name: Build for Testing
     runs-on: macos-15
 
     steps:
@@ -32,6 +32,46 @@ jobs:
           echo "Available runtime: $RUNTIME"
           xcrun simctl list devices available | grep iPhone
 
+      - name: Resolve Package Dependencies
+        working-directory: "ios/Positive Only Social"
+        run: |
+          xcodebuild -resolvePackageDependencies \
+            -project "Positive Only Social.xcodeproj" \
+            -scheme "Positive Only Social"
+
+      - name: Build for Testing
+        working-directory: "ios/Positive Only Social"
+        run: |
+          xcodebuild build-for-testing \
+            -project "Positive Only Social.xcodeproj" \
+            -scheme "Positive Only Social" \
+            -destination "platform=iOS Simulator,name=iPhone 16,OS=26.2" \
+            -derivedDataPath build \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO
+
+      - name: Upload Test Bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-bundle
+          path: "ios/Positive Only Social/build/Build/Products/"
+
+  test:
+    name: Test (${{ matrix.test-group }})
+    needs: build
+    runs-on: macos-15
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [Unit_Tests, UI_Tests_Alpha, UI_Tests_Beta]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Select Xcode version
+        run: sudo xcode-select -s /Applications/Xcode_26.3.app/Contents/Developer
+
       - name: Install xcpretty
         run: gem install xcpretty
 
@@ -40,24 +80,53 @@ jobs:
           xcrun simctl boot "iPhone 16" || true
           xcrun simctl bootstatus "iPhone 16" -b
 
-      - name: Resolve Package Dependencies
-        working-directory: "ios/Positive Only Social"
-        run: |
-          xcodebuild -resolvePackageDependencies \
-            -project "Positive Only Social.xcodeproj" \
-            -scheme "Positive Only Social"
+      - name: Download Test Bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: test-bundle
+          path: "ios/Positive Only Social/build/Build/Products"
 
       - name: Run Tests
         working-directory: "ios/Positive Only Social"
         run: |
-          xcodebuild test \
-            -project "Positive Only Social.xcodeproj" \
-            -scheme "Positive Only Social" \
+          case "${{ matrix.test-group }}" in
+            Unit_Tests)
+              TESTS=(
+                "Positive Only SocialTests"
+              )
+              ;;
+            UI_Tests_Alpha)
+              TESTS=(
+                "Positive Only SocialUITests/Positive_Only_SocialUITests/testAutomaticLoginAfterRememberMe"
+                "Positive Only SocialUITests/Positive_Only_SocialUITests/testDeleteAccount"
+                "Positive Only SocialUITests/Positive_Only_SocialUITests/testResetPassword"
+                "Positive Only SocialUITests/Positive_Only_SocialUITests/testFollowAndUnfollowFromSearch"
+                "Positive Only SocialUITests/Positive_Only_SocialUITests/testFollowAndUnfollowFromPost"
+                "Positive Only SocialUITests/Positive_Only_SocialUITests/testLikeAndUnlikePost"
+              )
+              ;;
+            UI_Tests_Beta)
+              TESTS=(
+                "Positive Only SocialUITests/Positive_Only_SocialUITests/testVerifyIdentity"
+                "Positive Only SocialUITests/Positive_Only_SocialUITests/testLikeAndUnlikeCommentOnPostAndThread"
+                "Positive Only SocialUITests/Positive_Only_SocialUITests/testReportPost"
+                "Positive Only SocialUITests/Positive_Only_SocialUITests/testReportComment"
+                "Positive Only SocialUITests/Positive_Only_SocialUITests/testLaunchPerformance"
+                "Positive Only SocialUITests/Positive_Only_SocialUITests/testBlockAndUnblockUser"
+              )
+              ;;
+          esac
+
+          ONLY_TESTING_ARGS=()
+          for t in "${TESTS[@]}"; do
+            ONLY_TESTING_ARGS+=("-only-testing:$t")
+          done
+
+          xcodebuild test-without-building \
+            -xctestrun build/Build/Products/*.xctestrun \
             -destination "platform=iOS Simulator,name=iPhone 16,OS=26.2" \
             -resultBundlePath TestResults.xcresult \
-            -parallel-testing-enabled YES \
-            CODE_SIGN_IDENTITY="" \
-            CODE_SIGNING_REQUIRED=NO \
+            "${ONLY_TESTING_ARGS[@]}" \
           | tee xcodebuild.log | xcpretty
           exit ${PIPESTATUS[0]}
 
@@ -78,7 +147,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: test-artifacts
+          name: test-artifacts-${{ matrix.test-group }}
           path: |
             ios/Positive Only Social/xcodebuild.log
             ios/Positive Only Social/TestResults.xcresult

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -186,13 +186,46 @@ jobs:
         if: failure()
         working-directory: "ios/Positive Only Social"
         run: |
-          echo "=== Failed test cases ==="
+          echo "=== Failed test cases (xcodebuild.log) ==="
           grep -iE "test case .* failed|test suite .* failed" xcodebuild.log || echo "(no test-case lines found — build may have failed before tests ran)"
+          echo ""
+          echo "=== Assertion failures (xcresult) ==="
+          xcrun xcresulttool get --path TestResults.xcresult --format json 2>/dev/null \
+          | python3 -c "
+import json, sys
+
+def walk(node):
+    if not isinstance(node, dict):
+        return
+    if node.get('_type', {}).get('_name') == 'ActionTestSummary' \
+       and node.get('testStatus', {}).get('_value') == 'Failure':
+        name = node.get('name', {}).get('_value', '(unknown)')
+        print(f'FAILED: {name}')
+        for s in node.get('failureSummaries', {}).get('_values', []):
+            msg  = s.get('message', {}).get('_value', '')
+            loc  = s.get('sourceCodeContext', {}).get('location', {})
+            file = loc.get('file', {}).get('_value', '').split('/')[-1]
+            line = loc.get('line', {}).get('_value', '')
+            print(f'  -> {msg}')
+            if file:
+                print(f'     at {file}:{line}')
+    for v in node.values():
+        if isinstance(v, dict):
+            walk(v)
+        elif isinstance(v, list):
+            for item in v:
+                walk(item)
+
+try:
+    walk(json.load(sys.stdin))
+except Exception as e:
+    print(f'(xcresult parse error: {e})')
+" || echo "(xcresulttool unavailable or no xcresult found)"
           echo ""
           echo "=== Compiler errors ==="
           grep -E "error:" xcodebuild.log | grep -v "^▸" | head -50 || echo "(none)"
           echo ""
-          echo "=== Last 150 lines of raw log ==="
+          echo "=== Last 500 lines of raw log ==="
           tail -500 xcodebuild.log
 
       - name: Upload test artifacts

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -32,12 +32,16 @@ jobs:
           echo "Available runtime: $RUNTIME"
           xcrun simctl list devices available | grep iPhone
 
+      - name: Install xcpretty
+        run: gem install xcpretty
+
       - name: Resolve Package Dependencies
         working-directory: "ios/Positive Only Social"
         run: |
           xcodebuild -resolvePackageDependencies \
             -project "Positive Only Social.xcodeproj" \
-            -scheme "Positive Only Social"
+            -scheme "Positive Only Social" \
+          | xcpretty
 
       - name: Build for Testing
         working-directory: "ios/Positive Only Social"
@@ -48,7 +52,26 @@ jobs:
             -destination "platform=iOS Simulator,name=iPhone 16,OS=26.2" \
             -derivedDataPath build \
             CODE_SIGN_IDENTITY="" \
-            CODE_SIGNING_REQUIRED=NO
+            CODE_SIGNING_REQUIRED=NO \
+          | tee build.log | xcpretty
+          exit ${PIPESTATUS[0]}
+
+      - name: Show build failures
+        if: failure()
+        working-directory: "ios/Positive Only Social"
+        run: |
+          echo "=== Compiler errors ==="
+          grep -E "error:" build.log | grep -v "^▸" | head -50 || echo "(none)"
+          echo ""
+          echo "=== Last 150 lines of raw log ==="
+          tail -150 build.log
+
+      - name: Upload build log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-log
+          path: "ios/Positive Only Social/build.log"
 
       - name: Upload Test Bundle
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -15,6 +15,7 @@ jobs:
   build:
     name: Build for Testing
     runs-on: macos-15
+    timeout-minutes: 30
 
     steps:
       - name: Checkout repository
@@ -84,6 +85,7 @@ jobs:
     name: Test (${{ matrix.test-group }})
     needs: build
     runs-on: macos-15
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -42,6 +42,7 @@ jobs:
             -project "Positive Only Social.xcodeproj" \
             -scheme "Positive Only Social" \
           | xcpretty
+          exit ${PIPESTATUS[0]}
 
       - name: Build for Testing
         working-directory: "ios/Positive Only Social"

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -87,7 +87,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-group: [Unit_Tests, UI_Tests_Alpha, UI_Tests_Beta]
+        test-group: [Unit_Tests, UI_Tests_Alpha, UI_Tests_Beta, UI_Tests_Gamma, UI_Tests_Delta]
 
     steps:
       - name: Checkout repository
@@ -132,6 +132,12 @@ jobs:
                 "Positive Only SocialUITests/Positive_Only_SocialUITests/testAutomaticLoginAfterRememberMe"
                 "Positive Only SocialUITests/Positive_Only_SocialUITests/testDeleteAccount"
                 "Positive Only SocialUITests/Positive_Only_SocialUITests/testResetPassword"
+              )
+              # "Positive Only Social" (default) plan covers both unit and UI tests
+              XCTESTRUN=$(find build/Build/Products -name "*.xctestrun" | grep -v "Unit Tests" | head -1)
+              ;;
+            UI_Tests_Beta)
+              TESTS=(
                 "Positive Only SocialUITests/Positive_Only_SocialUITests/testFollowAndUnfollowFromSearch"
                 "Positive Only SocialUITests/Positive_Only_SocialUITests/testFollowAndUnfollowFromPost"
                 "Positive Only SocialUITests/Positive_Only_SocialUITests/testLikeAndUnlikePost"
@@ -139,11 +145,17 @@ jobs:
               # "Positive Only Social" (default) plan covers both unit and UI tests
               XCTESTRUN=$(find build/Build/Products -name "*.xctestrun" | grep -v "Unit Tests" | head -1)
               ;;
-            UI_Tests_Beta)
+            UI_Tests_Gamma)
               TESTS=(
                 "Positive Only SocialUITests/Positive_Only_SocialUITests/testVerifyIdentity"
                 "Positive Only SocialUITests/Positive_Only_SocialUITests/testLikeAndUnlikeCommentOnPostAndThread"
                 "Positive Only SocialUITests/Positive_Only_SocialUITests/testReportPost"
+              )
+              # "Positive Only Social" (default) plan covers both unit and UI tests
+              XCTESTRUN=$(find build/Build/Products -name "*.xctestrun" | grep -v "Unit Tests" | head -1)
+              ;;
+            UI_Tests_Delta)
+              TESTS=(
                 "Positive Only SocialUITests/Positive_Only_SocialUITests/testReportComment"
                 "Positive Only SocialUITests/Positive_Only_SocialUITests/testLaunchPerformance"
                 "Positive Only SocialUITests/Positive_Only_SocialUITests/testBlockAndUnblockUser"
@@ -175,7 +187,7 @@ jobs:
         working-directory: "ios/Positive Only Social"
         run: |
           echo "=== Failed test cases ==="
-          grep -E "Test Case .* failed|Test Suite .* failed at" xcodebuild.log || echo "(no test-case lines found — build may have failed before tests ran)"
+          grep -iE "test case .* failed|test suite .* failed" xcodebuild.log || echo "(no test-case lines found — build may have failed before tests ran)"
           echo ""
           echo "=== Compiler errors ==="
           grep -E "error:" xcodebuild.log | grep -v "^▸" | head -50 || echo "(none)"

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -55,7 +55,7 @@ jobs:
             -scheme "Positive Only Social" \
             -destination "platform=iOS Simulator,name=iPhone 16,OS=26.2" \
             -resultBundlePath TestResults.xcresult \
-            -parallel-testing-enabled NO \
+            -parallel-testing-enabled YES \
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO \
           | tee xcodebuild.log | xcpretty

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/constants/Constants.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/constants/Constants.kt
@@ -2,5 +2,5 @@ package com.example.positiveonlysocial.data.constants
 
 object Constants {
     val isUnitTesting = false
-    const val BASE_URL = "https://smiling.social/user_index/"
+    const val BASE_URL = "https://api.smiling.social/user_index/"
 }

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/model/Models.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/model/Models.kt
@@ -75,7 +75,7 @@ data class Post(
     @SerializedName("post_identifier") val postIdentifier: String,
     @SerializedName("image_url") val imageUrl: String,
     val caption: String,
-    @SerializedName("authorUsername") val authorUsername: String,
+    @SerializedName("author_username") val authorUsername: String,
     val likeCount: Int? = 0
 )
 

--- a/backend/user_system/constants.py
+++ b/backend/user_system/constants.py
@@ -53,7 +53,7 @@ class Fields:
     is_adult = 'is_adult'
     series_identifier = "series_identifier"
     login_cookie_token = "login_cookie_token"
-    session_management_token = "token"
+    session_management_token = "session_management_token"
     post_identifier = "post_identifier"
     image_url = "image_url"
     caption = "caption"

--- a/backend/user_system/tests/test_delete_comment_view.py
+++ b/backend/user_system/tests/test_delete_comment_view.py
@@ -104,7 +104,7 @@ class DeleteCommentTests(PositiveOnlySocialTestCase):
         """
         # 1. Create a second user and log them in
         other_user_data = self.make_user_with_prefix(prefix='Delete_another_user_comment')
-        other_header = {'HTTP_AUTHORIZATION': f'Bearer {other_user_data["token"]}'}
+        other_header = {'HTTP_AUTHORIZATION': f'Bearer {other_user_data[Fields.session_management_token]}'}
 
         # 2. Try to delete the first user's comment
         response = self.client.post(self.delete_url, **other_header)

--- a/backend/user_system/tests/test_delete_post_view.py
+++ b/backend/user_system/tests/test_delete_post_view.py
@@ -1,5 +1,6 @@
 from django.urls import reverse
 from .test_parent_case import PositiveOnlySocialTestCase
+from ..constants import Fields
 from ..views import get_user_with_username
 
 invalid_session_management_token = '?'

--- a/backend/user_system/tests/test_delete_post_view.py
+++ b/backend/user_system/tests/test_delete_post_view.py
@@ -52,7 +52,7 @@ class DeletePostTests(PositiveOnlySocialTestCase):
         """
         # 1. Create a second user and log them in
         other_user_data = self.make_user_with_prefix()
-        other_header = {'HTTP_AUTHORIZATION': f'Bearer {other_user_data["token"]}'}
+        other_header = {'HTTP_AUTHORIZATION': f'Bearer {other_user_data[Fields.session_management_token]}'}
 
         # 2. Try to delete the first user's post (self.url)
         response = self.client.post(self.url, **other_header)

--- a/backend/user_system/tests/test_get_posts_in_feed_view.py
+++ b/backend/user_system/tests/test_get_posts_in_feed_view.py
@@ -116,4 +116,4 @@ class GetPostsInFeedTests(PositiveOnlySocialTestCase):
         self.assertEqual(response.status_code, 200)
         responses = response.json()
         for post in responses:
-            self.assertNotEqual(post[Fields.username], user_b.username)
+            self.assertNotEqual(post[Fields.author_username], user_b.username)

--- a/backend/user_system/tests/test_like_comment_view.py
+++ b/backend/user_system/tests/test_like_comment_view.py
@@ -1,6 +1,7 @@
 from django.urls import reverse
 
 from ..constants import Fields
+from .test_constants import UserFields
 from .test_parent_case import PositiveOnlySocialTestCase
 from ..models import Comment  # Import the Comment model for assertions
 
@@ -23,7 +24,7 @@ class LikeCommentTests(PositiveOnlySocialTestCase):
         super().comment_on_post_with_users()
 
         # Get the token for the "liker" user (assumed to be the 3rd user, index 2)
-        other_session_management_tokens = self.users.get(Fields.session_management_token, [])
+        other_session_management_tokens = self.users.get(UserFields.TOKEN, [])
         self.liker_session_management_token = other_session_management_tokens[2]
 
         # Create the auth headers for our two key users

--- a/backend/user_system/tests/test_like_post_view.py
+++ b/backend/user_system/tests/test_like_post_view.py
@@ -1,6 +1,7 @@
 from django.urls import reverse
 
 from ..constants import Fields
+from .test_constants import UserFields
 from .test_parent_case import PositiveOnlySocialTestCase
 from ..models import Post  # Import the Post model for assertions
 
@@ -24,7 +25,7 @@ class LikePostTests(PositiveOnlySocialTestCase):
         self.poster_header = {'HTTP_AUTHORIZATION': f'Bearer {self.poster_token}'}
 
         # 2. Set up the user who will do the liking ("liker")
-        liker_tokens = self.users.get(Fields.session_management_token, [])
+        liker_tokens = self.users.get(UserFields.TOKEN, [])
         self.liker_token = liker_tokens[1]
         self.liker_header = {'HTTP_AUTHORIZATION': f'Bearer {self.liker_token}'}
 

--- a/backend/user_system/tests/test_parent_case.py
+++ b/backend/user_system/tests/test_parent_case.py
@@ -197,7 +197,7 @@ class PositiveOnlySocialTestCase(TestCase):
             'username': username,
             'password': password,
             'email': email,
-            'token': data[Fields.session_management_token]
+            Fields.session_management_token: data[Fields.session_management_token]
         }
 
     def register_user_and_setup_local_fields(self, index=0, remember_me=false):

--- a/backend/user_system/tests/test_report_comment_view.py
+++ b/backend/user_system/tests/test_report_comment_view.py
@@ -1,6 +1,7 @@
 from django.urls import reverse
 
 from .test_parent_case import PositiveOnlySocialTestCase
+from .test_constants import UserFields
 from ..constants import Fields, MAX_BEFORE_HIDING_COMMENT
 from ..models import Comment
 
@@ -36,7 +37,7 @@ class ReportCommentTests(PositiveOnlySocialTestCase):
         self.valid_data = {'reason': self.reason}
 
         # 4. Get the first reporter's info (User 1)
-        self.reporter_token = self.users[Fields.session_management_token][1]
+        self.reporter_token = self.users[UserFields.TOKEN][1]
         self.reporter_header = {'HTTP_AUTHORIZATION': f'Bearer {self.reporter_token}'}
 
         # 5. Define the URL for all tests
@@ -159,7 +160,7 @@ class ReportCommentTests(PositiveOnlySocialTestCase):
         # Loop through all users *except* the commenter (User 0)
         # This will be MAX + 1 reports
         for i in range(1, MAX_BEFORE_HIDING_COMMENT + 2):
-            token = self.users[Fields.session_management_token][i]
+            token = self.users[UserFields.TOKEN][i]
             header = {'HTTP_AUTHORIZATION': f'Bearer {token}'}
 
             response = self.client.post(

--- a/backend/user_system/tests/test_toggle_block_view.py
+++ b/backend/user_system/tests/test_toggle_block_view.py
@@ -12,8 +12,7 @@ class ToggleBlockViewTests(PositiveOnlySocialTestCase):
         fields_a = self.register_and_login_user(prefix='user_a')
         self.user_a_username = fields_a['username']
         self.user_a = get_user_with_username(self.user_a_username)
-        # make_user_with_prefix returns a helper dict with 'token' key
-        self.user_a_header = {'HTTP_AUTHORIZATION': f"Bearer {fields_a['token']}"}
+        self.user_a_header = {'HTTP_AUTHORIZATION': f"Bearer {fields_a[Fields.session_management_token]}"}
 
         # Create User B (another user to block)
         fields_b = self.make_user_with_prefix(prefix='user_b')

--- a/backend/user_system/views.py
+++ b/backend/user_system/views.py
@@ -742,7 +742,7 @@ def get_posts_in_feed(request, batch):
             {
                 Fields.post_identifier: post.post_identifier,
                 Fields.image_url: get_compressed_image_url(post.image_url),
-                Fields.username: post.author.username,
+                Fields.author_username: post.author.username,
                 Fields.caption: post.caption
             }
             for post in batched_posts

--- a/ios/Positive Only Social/Positive Only Social/LoginView.swift
+++ b/ios/Positive Only Social/Positive Only Social/LoginView.swift
@@ -53,22 +53,8 @@ struct LoginView: View {
             isLoading = true
             do {
                 let responseData = try await api.loginUser(usernameOrEmail: usernameOrEmail, password: password, rememberMe: String(rememberMe), ip: "127.0.0.1")
-                
-                // Try to decode a backend error first
-                struct BackendError: Codable { let error: String }
-                if let backendError = try? JSONDecoder().decode(BackendError.self, from: responseData) {
-                    errorMessage = backendError.error
-                    showingErrorAlert = true
-                    isLoading = false
-                    return
-                }
 
-                // MARK: Decoding Logic (remains the same)
-                let decoder = JSONDecoder()
-                let wrapper = try decoder.decode(APIWrapperResponse.self, from: responseData)
-                guard let innerData = wrapper.responseList.data(using: .utf8) else { throw URLError(.cannotDecodeContentData) }
-                let loginResponse = try decoder.decode(DjangoLoginResponseObject.self, from: innerData)
-                let loginDetails = loginResponse.fields
+                let loginDetails = try JSONDecoder().decode(LoginResponseFields.self, from: responseData)
                 
                 // MARK: - Securely Store Token in Keychain
                 authManager.login(with: UserSession(sessionToken: loginDetails.sessionManagementToken, username: usernameOrEmail, isIdentityVerified: false))
@@ -87,6 +73,10 @@ struct LoginView: View {
                     try keychainHelper.delete(service: keychainService, account: rememberMeAccount)
                 }
                 
+            } catch let error as APIError {
+                errorMessage = error.errorDescription ?? "Login failed. Please check your credentials and try again."
+                showingErrorAlert = true
+                print("🔴 Login failed with error: \(error)")
             } catch {
                 errorMessage = "Login failed. Please check your credentials and try again."
                 showingErrorAlert = true

--- a/ios/Positive Only Social/Positive Only Social/LoginView.swift
+++ b/ios/Positive Only Social/Positive Only Social/LoginView.swift
@@ -74,7 +74,11 @@ struct LoginView: View {
                 }
                 
             } catch let error as APIError {
-                errorMessage = error.errorDescription ?? "Login failed. Please check your credentials and try again."
+                if case .serverError(_, let message) = error {
+                    errorMessage = message
+                } else {
+                    errorMessage = "Login failed. Please check your credentials and try again."
+                }
                 showingErrorAlert = true
                 print("🔴 Login failed with error: \(error)")
             } catch {

--- a/ios/Positive Only Social/Positive Only Social/RegisterView.swift
+++ b/ios/Positive Only Social/Positive Only Social/RegisterView.swift
@@ -167,7 +167,11 @@ struct RegisterView: View {
                 path = NavigationPath(["HomeView"])
 
             } catch let error as APIError {
-                errorMessage = error.errorDescription ?? "This username or email may already be taken. Please try again."
+                if case .serverError(_, let message) = error {
+                    errorMessage = message
+                } else {
+                    errorMessage = "This username or email may already be taken. Please try again."
+                }
                 showingErrorAlert = true
                 print("🔴 Registration failed: \(error)")
             } catch {

--- a/ios/Positive Only Social/Positive Only Social/RegisterView.swift
+++ b/ios/Positive Only Social/Positive Only Social/RegisterView.swift
@@ -156,24 +156,7 @@ struct RegisterView: View {
                     dateOfBirth: dateString
                 )
 
-                // Try to decode a backend error first
-                struct BackendError: Codable { let error: String }
-                if let backendError = try? JSONDecoder().decode(BackendError.self, from: responseData) {
-                    errorMessage = backendError.error
-                    showingErrorAlert = true
-                    isLoading = false
-                    return
-                }
-
-                // Decode the response to get the session token
-                let decoder = JSONDecoder()
-                let wrapper = try decoder.decode(APIWrapperResponse.self, from: responseData)
-                guard let innerData = wrapper.responseList.data(using: .utf8) else {
-                    throw URLError(.cannotDecodeContentData)
-                }
-                
-                let loginResponse = try decoder.decode(DjangoLoginResponseObject.self, from: innerData)
-                let loginDetails = loginResponse.fields
+                let loginDetails = try JSONDecoder().decode(LoginResponseFields.self, from: responseData)
 
                 // Securely save the new session token to the Keychain
                 authManager.login(with: UserSession(sessionToken: loginDetails.sessionManagementToken, username: username, isIdentityVerified: false))
@@ -183,6 +166,10 @@ struct RegisterView: View {
                 // Navigate to Home, replacing the stack so the user can't go back.
                 path = NavigationPath(["HomeView"])
 
+            } catch let error as APIError {
+                errorMessage = error.errorDescription ?? "This username or email may already be taken. Please try again."
+                showingErrorAlert = true
+                print("🔴 Registration failed: \(error)")
             } catch {
                 errorMessage = "This username or email may already be taken. Please try again."
                 showingErrorAlert = true

--- a/ios/Positive Only Social/Positive Only Social/RequestResetView.swift
+++ b/ios/Positive Only Social/Positive Only Social/RequestResetView.swift
@@ -66,15 +66,8 @@ struct RequestResetView: View {
         // defer { isLoading = false } // A defer block is even cleaner
         
         do {
-            let responseData = try await api.requestPasswordReset(usernameOrEmail: usernameOrEmail)
-            
-            // --- Decoding ---
-            // Your example shows a complex decoding process.
-            // For this endpoint, we'll just decode the simple success response.
-            // You can replace this with your own custom decoding logic.
-            let decoder = JSONDecoder()
-            _ = try decoder.decode(APIWrapperResponse.self, from: responseData)
-            
+            let _ = try await api.requestPasswordReset(usernameOrEmail: usernameOrEmail)
+
             print("✅ Reset request successful.")
             
             // Handle success

--- a/ios/Positive Only Social/Positive Only Social/ResetPasswordView.swift
+++ b/ios/Positive Only Social/Positive Only Social/ResetPasswordView.swift
@@ -79,7 +79,7 @@ struct ResetPasswordView: View {
         
         do {
             // Using the INSECURE method as requested
-            let responseData = try await api.resetPassword(
+            _ = try await api.resetPassword(
                 username: username,
                 email: email,
                 newPassword: newPassword

--- a/ios/Positive Only Social/Positive Only Social/ResetPasswordView.swift
+++ b/ios/Positive Only Social/Positive Only Social/ResetPasswordView.swift
@@ -85,25 +85,18 @@ struct ResetPasswordView: View {
                 newPassword: newPassword
             )
             
-            // Just check that it didn't throw an error
-            _ = try JSONDecoder().decode(APIWrapperResponse.self, from: responseData)
             print("✅ Password reset successful. Attempting auto-login...")
-            
+
             // 2. IMMEDIATELY Log in with the new password
-            // This retrieves the session token you need for the HomeView
             let loginData = try await api.loginUser(
                 usernameOrEmail: username.isEmpty ? email : username,
                 password: newPassword,
                 rememberMe: "false",
                 ip: "127.0.0.1"
             )
-            
+
             // 3. Decode the Login Response
-            let decoder = JSONDecoder()
-            let wrapper = try decoder.decode(APIWrapperResponse.self, from: loginData)
-            guard let innerData = wrapper.responseList.data(using: .utf8) else { throw URLError(.cannotDecodeContentData) }
-            let loginResponse = try decoder.decode(DjangoLoginResponseObject.self, from: innerData)
-            let loginDetails = loginResponse.fields
+            let loginDetails = try JSONDecoder().decode(LoginResponseFields.self, from: loginData)
             
             // 4. Update AuthManager
             // This is the magic trigger that swaps the view to HomeView

--- a/ios/Positive Only Social/Positive Only Social/VerifyResetView.swift
+++ b/ios/Positive Only Social/Positive Only Social/VerifyResetView.swift
@@ -82,10 +82,8 @@ struct VerifyResetView: View {
         }
         
         do {
-            let responseData = try await api.verifyPasswordReset(usernameOrEmail: usernameOrEmail, resetID: resetID)
-            
-            _ = try JSONDecoder().decode(APIWrapperResponse.self, from: responseData)
-            
+            let _ = try await api.verifyPasswordReset(usernameOrEmail: usernameOrEmail, resetID: resetID)
+
             print("✅ PIN verification successful.")
 
             isLoading = false

--- a/ios/Positive Only Social/Positive Only Social/WelcomeView.swift
+++ b/ios/Positive Only Social/Positive Only Social/WelcomeView.swift
@@ -89,11 +89,7 @@ struct WelcomeView: View {
                 )
                 
                 // 3. Decode the response to get the NEW tokens
-                let decoder = JSONDecoder()
-                let wrapper = try decoder.decode(APIWrapperResponse.self, from: responseData)
-                guard let innerData = wrapper.responseList.data(using: .utf8) else { throw URLError(.cannotDecodeContentData) }
-                let loginResponse = try decoder.decode(DjangoLoginResponseObject.self, from: innerData)
-                let loginDetails = loginResponse.fields
+                let loginDetails = try JSONDecoder().decode(LoginResponseFields.self, from: responseData)
 
                 // 4. Securely save the new session token
                 let oldSession = authManager.session

--- a/ios/Positive Only Social/Positive Only Social/api/Models.swift
+++ b/ios/Positive Only Social/Positive Only Social/api/Models.swift
@@ -9,26 +9,9 @@ import Foundation
 
 // MARK: - API Response Models
 
-/// The outermost JSON object, which contains the response list as a STRING.
-struct APIWrapperResponse: Codable {
-    let responseList: String
-
-    enum CodingKeys: String, CodingKey {
-        case responseList = "response_list"
-    }
-}
-
-/// The structure inside the `responseList` string, mirroring Django's serializer output.
-struct DjangoLoginResponseObject: Codable {
-    let model: String
-    let pk: Int?
-    let fields: LoginResponseFields
-}
-
-/// The actual data fields you care about.
+/// The actual data fields returned by the login/register endpoints.
 /// Properties are optional since "remember me" tokens may not be present.
 struct LoginResponseFields: Codable {
-    // This property can now be returned by both login methods
     let sessionManagementToken: String
     let seriesIdentifier: String?
     let loginCookieToken: String?
@@ -53,7 +36,7 @@ struct Post: Codable, Identifiable, Hashable {
         case postIdentifier = "post_identifier"
         case imageUrl = "image_url"
         case caption = "caption"
-        case authorUsername = "authorUsername"
+        case authorUsername = "author_username"
     }
 }
 

--- a/ios/Positive Only Social/Positive Only Social/api/RealAPI.swift
+++ b/ios/Positive Only Social/Positive Only Social/api/RealAPI.swift
@@ -12,9 +12,10 @@ import Foundation
 enum APIError: Error, LocalizedError {
     case invalidURL
     case badServerResponse(statusCode: Int)
+    case serverError(statusCode: Int, serverMessage: String)
     case requestFailed(Error)
     case decodingError(Error)
-    case encodingError(Error) // Added for JSON encoding failures
+    case encodingError(Error)
 
     var errorDescription: String? {
         switch self {
@@ -22,6 +23,8 @@ enum APIError: Error, LocalizedError {
             return "The URL provided was invalid."
         case .badServerResponse(let statusCode):
             return "The server returned an unsuccessful status code: \(statusCode)."
+        case .serverError(_, let message):
+            return message
         case .requestFailed(let error):
             return "The network request failed: \(error.localizedDescription)."
         case .decodingError(let error):
@@ -37,7 +40,7 @@ enum APIError: Error, LocalizedError {
 final class RealAPI: Networking {
     
     /// The base URL for all API endpoints. Remember to replace this with your actual server address.
-    private let baseURL = "https://smiling.social/user_index/"
+    private let baseURL = "https://api.smiling.social/user_index/"
     
     /// Defines the HTTP methods used by the API.
     private enum HTTPMethod: String {
@@ -54,11 +57,11 @@ final class RealAPI: Networking {
         let password: String
         let remember_me: String
         let ip: String
-        let dateOfBirth: String
+        let date_of_birth: String
     }
-    
+
     private struct VerifyIdentityBody: Encodable {
-        let dateOfBirth: String
+        let date_of_birth: String
     }
     
     private struct LoginBody: Encodable {
@@ -166,8 +169,12 @@ final class RealAPI: Networking {
             }
             
             guard (200...299).contains(httpResponse.statusCode) else {
-                // You could try to decode an error JSON body here if your API sends one
-                // let errorBody = String(data: data, encoding: .utf8)
+                // Try to extract the server's error message from the response body
+                struct ServerErrorBody: Decodable { let error: String? }
+                if let body = try? JSONDecoder().decode(ServerErrorBody.self, from: data),
+                   let message = body.error {
+                    throw APIError.serverError(statusCode: httpResponse.statusCode, serverMessage: message)
+                }
                 throw APIError.badServerResponse(statusCode: httpResponse.statusCode)
             }
             
@@ -184,7 +191,7 @@ final class RealAPI: Networking {
     
     /// Creates a user if they do not exist.
     func register(username: String, email: String, password: String, rememberMe: String, ip: String, dateOfBirth: String) async throws -> Data {
-        let body = RegisterBody(username: username, email: email, password: password, remember_me: rememberMe, ip: ip, dateOfBirth: dateOfBirth)
+        let body = RegisterBody(username: username, email: email, password: password, remember_me: rememberMe, ip: ip, date_of_birth: dateOfBirth)
         let requestBody = try encode(body)
         
         return try await performRequest(
@@ -279,7 +286,7 @@ final class RealAPI: Networking {
         
     /// Verifies the identity of the user
     func verifyIdentity(sessionManagementToken: String, dateOfBirth: String) async throws -> Data {
-        let body = VerifyIdentityBody(dateOfBirth: dateOfBirth)
+        let body = VerifyIdentityBody(date_of_birth: dateOfBirth)
         let requestBody = try encode(body)
         
         return try await performRequest(

--- a/ios/Positive Only Social/Positive Only Social/api/StatefulStubbedAPI.swift
+++ b/ios/Positive Only Social/Positive Only Social/api/StatefulStubbedAPI.swift
@@ -485,7 +485,7 @@ final class StatefulStubbedAPI: Networking {
                 post_identifier: $0.postIdentifier,
                 image_url: $0.imageURL,
                 caption: $0.caption,
-                author_username: authorUsername
+                authorUsername: authorUsername
             )
         }
         

--- a/ios/Positive Only Social/Positive Only Social/api/StatefulStubbedAPI.swift
+++ b/ios/Positive Only Social/Positive Only Social/api/StatefulStubbedAPI.swift
@@ -601,15 +601,15 @@ final class StatefulStubbedAPI: Networking {
 
         struct Fields: Codable {
             let comment_identifier, body, author_username: String
-            let comment_creation_time, comment_updated_time: String
+            let creation_time, updated_time: String
             let comment_likes: Int
         }
-        
+
         let dateFormatter = ISO8601DateFormatter()
         let fieldObjects = relevantComments.map { comment in
             Fields(comment_identifier: comment.commentIdentifier, body: comment.body, author_username: comment.authorUsername,
-                   comment_creation_time: dateFormatter.string(from: comment.createdDate),
-                   comment_updated_time: dateFormatter.string(from: comment.updatedDate),
+                   creation_time: dateFormatter.string(from: comment.createdDate),
+                   updated_time: dateFormatter.string(from: comment.updatedDate),
                    comment_likes: comment.likes.count)
         }
         return try createSerializedListResponse(fieldsList: fieldObjects)

--- a/ios/Positive Only Social/Positive Only Social/api/StatefulStubbedAPI.swift
+++ b/ios/Positive Only Social/Positive Only Social/api/StatefulStubbedAPI.swift
@@ -69,11 +69,6 @@ fileprivate struct MockComment {
     var updatedDate = Date()
 }
 
-fileprivate struct DjangoSerializedObject<F: Codable>: Codable {
-    var model: String = "app.response"
-    var pk: String? = nil
-    let fields: F
-}
 
 // MARK: - Stateful API Implementation
 final class StatefulStubbedAPI: Networking {
@@ -116,53 +111,18 @@ final class StatefulStubbedAPI: Networking {
     }
 
     // MARK: - Private Helpers
-    /// Creates a "single item" response, like for registration.
+    /// Returns a single-object JSON response matching the real backend format.
     private func createSerializedResponse<T: Codable>(fields: T) throws -> Data {
-        // 1. Create the single "inner" object
-        let serializedObject = DjangoSerializedObject(fields: fields)
-        
-        let encoder = JSONEncoder()
-
-        // 2. Encode the single object (NOT an array) into Data
-        let innerData = try encoder.encode(serializedObject)
-
-        // 3. Convert that inner Data into a String
-        guard let innerString = String(data: innerData, encoding: .utf8) else {
-            throw SerializationError()
-        }
-
-        // 4. Encode the final outer wrapper: {"response_list": "..."}
-        let outerWrapper = ["response_list": innerString]
-        return try encoder.encode(outerWrapper)
+        return try JSONEncoder().encode(fields)
     }
 
-    /// Creates a "list" response, which is the base for all your stubbed responses.
+    /// Returns a JSON array response matching the real backend format.
     private func createSerializedListResponse<T: Codable>(fieldsList: [T]) throws -> Data {
-        
-        // 1. Create the array of "inner" objects, now including the model
-        let serializedObjects = fieldsList.map {
-            DjangoSerializedObject(fields: $0)
-        }
-        
-        let encoder = JSONEncoder()
-
-        // 2. Encode the inner array ([DjangoSerializedObject]) into Data
-        let innerData = try encoder.encode(serializedObjects)
-
-        // 3. Convert that inner Data into a String (SAFELY)
-        //    This is the fix for your `!` crash.
-        guard let innerString = String(data: innerData, encoding: .utf8) else {
-            throw SerializationError()
-        }
-
-        // 4. Encode the final outer wrapper: {"response_list": "..."}
-        let outerWrapper = ["response_list": innerString]
-        return try encoder.encode(outerWrapper)
+        return try JSONEncoder().encode(fieldsList)
     }
 
     private func createEmptySuccessResponse() throws -> Data {
-        struct EmptyFields: Codable {}
-        return try createSerializedResponse(fields: EmptyFields())
+        return try JSONEncoder().encode(["message": "ok"])
     }
     private func simulateNetwork() async { try? await Task.sleep(for: .seconds(simulatedLatency)) }
     private func generateToken() -> String { UUID().uuidString.replacingOccurrences(of: "-", with: "") }
@@ -184,7 +144,11 @@ final class StatefulStubbedAPI: Networking {
             let cookie = MockLoginCookie(seriesIdentifier: UUID().uuidString, token: generateToken(), userId: newUser.id)
             loginCookies.append(cookie)
             struct Fields: Codable { let series_identifier, login_cookie_token, session_management_token: String }
-            return try createSerializedResponse(fields: Fields(series_identifier: cookie.seriesIdentifier, login_cookie_token: cookie.token, session_management_token: newSession.managementToken))
+            return try createSerializedResponse(fields: Fields(
+                series_identifier: cookie.seriesIdentifier,
+                login_cookie_token: cookie.token,
+                session_management_token: newSession.managementToken
+            ))
         } else {
             struct Fields: Codable { let session_management_token: String }
             return try createSerializedResponse(fields: Fields(session_management_token: newSession.managementToken))
@@ -195,17 +159,21 @@ final class StatefulStubbedAPI: Networking {
         await simulateNetwork()
         guard let user = findUser(byUsernameOrEmail: usernameOrEmail) else { throw APIError.badServerResponse(statusCode: 400) }
         if user.passwordHash != password { throw APIError.badServerResponse(statusCode: 400) }
-        
+
         sessions.removeAll { $0.userId == user.id }
         let newSession = MockSession(managementToken: generateToken(), userId: user.id, ip: ip)
         sessions.append(newSession)
-        
+
         let wantsRememberMe = Bool(rememberMe.lowercased()) ?? false
         if wantsRememberMe {
             let cookie = MockLoginCookie(seriesIdentifier: UUID().uuidString, token: generateToken(), userId: user.id)
             loginCookies.append(cookie)
             struct Fields: Codable { let series_identifier, login_cookie_token, session_management_token: String }
-            return try createSerializedResponse(fields: Fields(series_identifier: cookie.seriesIdentifier, login_cookie_token: cookie.token, session_management_token: newSession.managementToken))
+            return try createSerializedResponse(fields: Fields(
+                series_identifier: cookie.seriesIdentifier,
+                login_cookie_token: cookie.token,
+                session_management_token: newSession.managementToken
+            ))
         } else {
             struct Fields: Codable { let session_management_token: String }
             return try createSerializedResponse(fields: Fields(session_management_token: newSession.managementToken))
@@ -235,13 +203,14 @@ final class StatefulStubbedAPI: Networking {
         let newSession = MockSession(managementToken: generateToken(), userId: user.id, ip: ip)
         sessions.append(newSession)
 
-        // 3. Return both the new cookie and the new session token
         struct Fields: Codable {
             let login_cookie_token: String
             let session_management_token: String
         }
-        let fields = Fields(login_cookie_token: newCookieToken, session_management_token: newSession.managementToken)
-        return try createSerializedResponse(fields: fields)
+        return try createSerializedResponse(fields: Fields(
+            login_cookie_token: newCookieToken,
+            session_management_token: newSession.managementToken
+        ))
     }
 
 
@@ -408,12 +377,12 @@ final class StatefulStubbedAPI: Networking {
         let paginatedPosts = Array(relevantPosts[startIndex..<endIndex])
         // --- END PAGINATION LOGIC ---
 
-        struct Fields: Codable { let post_identifier: String; let image_url: String; let caption: String; let authorUsername: String}
+        struct Fields: Codable { let post_identifier: String; let image_url: String; let caption: String; let author_username: String }
         
         let fieldObjects = paginatedPosts.map {
             let post = $0
             let authorUsername = users.first(where: { $0.id == post.authorId })?.username ?? "Unknown User"
-            return Fields(post_identifier: $0.postIdentifier, image_url: $0.imageURL, caption: $0.caption, authorUsername: authorUsername)
+            return Fields(post_identifier: $0.postIdentifier, image_url: $0.imageURL, caption: $0.caption, author_username: authorUsername)
         }
         
         return try createSerializedListResponse(fieldsList: fieldObjects)
@@ -458,12 +427,12 @@ final class StatefulStubbedAPI: Networking {
         // --- END PAGINATION LOGIC ---
 
         // 5. Format the response (matching getPostsInFeed)
-        struct Fields: Codable { let post_identifier: String; let image_url: String; let caption: String; let authorUsername: String}
+        struct Fields: Codable { let post_identifier: String; let image_url: String; let caption: String; let author_username: String }
         
         let fieldObjects = paginatedPosts.map {
             let post = $0
             let authorUsername = users.first(where: { $0.id == post.authorId })?.username ?? "Unknown User"
-            return Fields(post_identifier: $0.postIdentifier, image_url: $0.imageURL, caption: $0.caption, authorUsername: authorUsername)
+            return Fields(post_identifier: $0.postIdentifier, image_url: $0.imageURL, caption: $0.caption, author_username: authorUsername)
         }
         
         // 6. Return the serialized list
@@ -516,7 +485,7 @@ final class StatefulStubbedAPI: Networking {
                 post_identifier: $0.postIdentifier,
                 image_url: $0.imageURL,
                 caption: $0.caption,
-                authorUsername: authorUsername
+                author_username: authorUsername
             )
         }
         
@@ -703,8 +672,6 @@ final class StatefulStubbedAPI: Networking {
         }
         
         userFollows.remove(at: followIndex)
-        
-        return try createEmptySuccessResponse()
         return try createEmptySuccessResponse()
     }
 

--- a/ios/Positive Only Social/Positive Only Social/api/StatefulStubbedAPI.swift
+++ b/ios/Positive Only Social/Positive Only Social/api/StatefulStubbedAPI.swift
@@ -475,9 +475,9 @@ final class StatefulStubbedAPI: Networking {
             let post_identifier: String
             let image_url: String
             let caption: String
-            let authorUsername: String
+            let author_username: String
         }
-        
+
         let fieldObjects = paginatedPosts.map {
             let post = $0
             let authorUsername = users.first(where: { $0.id == post.authorId })?.username ?? "Unknown User"
@@ -485,7 +485,7 @@ final class StatefulStubbedAPI: Networking {
                 post_identifier: $0.postIdentifier,
                 image_url: $0.imageURL,
                 caption: $0.caption,
-                authorUsername: authorUsername
+                author_username: authorUsername
             )
         }
         

--- a/ios/Positive Only Social/Positive Only Social/preview/PreviewHelpers.swift
+++ b/ios/Positive Only Social/Positive Only Social/preview/PreviewHelpers.swift
@@ -34,52 +34,15 @@ class MockKeychainHelper: KeychainHelperProtocol {
 // MARK: - Mocked API
 
 struct MockedAPI: Networking {
-    
-    // MARK: - Helpers for Double Encoding
-    
-    // Used for single objects and list items. Includes model/pk to satisfy DjangoLoginResponseObject.
-    private struct DjangoSingleResponse<T: Codable>: Codable {
-        let model: String
-        let pk: Int
-        let fields: T
-        
-        enum CodingKeys: String, CodingKey { case model, pk, fields }
-        
-        init(model: String = "", pk: Int = 0, fields: T) {
-            self.model = model
-            self.pk = pk
-            self.fields = fields
-        }
+
+    // MARK: - Encoding Helpers
+
+    private func encode<T: Encodable>(_ value: T) throws -> Data {
+        return try JSONEncoder().encode(value)
     }
-    
-    private struct APIWrapper: Codable {
-        let response_list: String
-    }
-    
-    private func encodeSingle<T: Codable>(_ item: T) throws -> Data {
-        let djangoObj = DjangoSingleResponse(fields: item)
-        let innerData = try JSONEncoder().encode(djangoObj)
-        guard let innerString = String(data: innerData, encoding: .utf8) else {
-            throw URLError(.cannotDecodeContentData)
-        }
-        let wrapper = APIWrapper(response_list: innerString)
-        return try JSONEncoder().encode(wrapper)
-    }
-    
-    private func encodeList<T: Codable>(_ items: [T]) throws -> Data {
-        let djangoList = items.map { DjangoSingleResponse(fields: $0) }
-        let innerData = try JSONEncoder().encode(djangoList)
-        guard let innerString = String(data: innerData, encoding: .utf8) else {
-            throw URLError(.cannotDecodeContentData)
-        }
-        let wrapper = APIWrapper(response_list: innerString)
-        return try JSONEncoder().encode(wrapper)
-    }
-    
+
     private func encodeGenericSuccess() throws -> Data {
-        let innerString = "{}"
-        let wrapper = APIWrapper(response_list: innerString)
-        return try JSONEncoder().encode(wrapper)
+        return try JSONEncoder().encode(["message": "ok"])
     }
 
     // MARK: - User & Session Management
@@ -90,7 +53,7 @@ struct MockedAPI: Networking {
             seriesIdentifier: "mock_series_id",
             loginCookieToken: "mock_login_cookie"
         )
-        return try encodeSingle(response)
+        return try encode(response)
     }
 
     func loginUser(usernameOrEmail: String, password: String, rememberMe: String, ip: String) async throws -> Data {
@@ -99,7 +62,7 @@ struct MockedAPI: Networking {
             seriesIdentifier: "mock_series_id",
             loginCookieToken: "mock_login_cookie"
         )
-        return try encodeSingle(response)
+        return try encode(response)
     }
 
     func loginUserWithRememberMe(sessionManagementToken: String, seriesIdentifier: String, loginCookieToken: String, ip: String) async throws -> Data {
@@ -108,7 +71,7 @@ struct MockedAPI: Networking {
             seriesIdentifier: "mock_series_id",
             loginCookieToken: "new_mock_cookie"
         )
-        return try encodeSingle(response)
+        return try encode(response)
     }
     
     func verifyIdentity(sessionManagementToken: String, dateOfBirth: String) async throws -> Data {
@@ -174,21 +137,21 @@ struct MockedAPI: Networking {
             Post(postIdentifier: "1", imageUrl: "https://picsum.photos/400/300", caption: "Beautiful sunset!", authorUsername: "nature_lover"),
             Post(postIdentifier: "2", imageUrl: "https://picsum.photos/400/301", caption: "My new puppy", authorUsername: "dog_fan")
         ]
-        return try encodeList(posts)
+        return try encode(posts)
     }
 
     func getPostsForFollowedUsers(sessionManagementToken: String, batch: Int) async throws -> Data {
         let posts = [
             Post(postIdentifier: "3", imageUrl: "https://picsum.photos/400/302", caption: "Coffee time", authorUsername: "coffee_addict")
         ]
-        return try encodeList(posts)
+        return try encode(posts)
     }
 
     func getPostsForUser(sessionManagementToken: String, username: String, batch: Int) async throws -> Data {
         let posts = [
             Post(postIdentifier: "4", imageUrl: "https://picsum.photos/400/303", caption: "Just me", authorUsername: username)
         ]
-        return try encodeList(posts)
+        return try encode(posts)
     }
 
     func getPostDetails(postIdentifier: String) async throws -> Data {
@@ -208,7 +171,7 @@ struct MockedAPI: Networking {
             post_likes: 100,
             author_username: "mock_author"
         )
-        return try encodeSingle(detail)
+        return try encode(detail)
     }
     
     // MARK: - Comment Management
@@ -243,7 +206,7 @@ struct MockedAPI: Networking {
             ThreadIDResponse(comment_thread_identifier: "thread_1"),
             ThreadIDResponse(comment_thread_identifier: "thread_2")
         ]
-        return try encodeList(threads)
+        return try encode(threads)
     }
 
     func getCommentsForThread(commentThreadIdentifier: String, batch: Int) async throws -> Data {
@@ -252,30 +215,30 @@ struct MockedAPI: Networking {
             let comment_identifier: String
             let body: String
             let author_username: String
-            let comment_creation_time: String
-            let comment_updated_time: String
+            let creation_time: String
+            let updated_time: String
             let comment_likes: Int
         }
-        
+
         let comments = [
             CommentResponse(
                 comment_identifier: "c1",
                 body: "Great post!",
                 author_username: "fan_1",
-                comment_creation_time: "2023-01-01T12:00:00Z",
-                comment_updated_time: "2023-01-01T12:00:00Z",
+                creation_time: "2023-01-01T12:00:00Z",
+                updated_time: "2023-01-01T12:00:00Z",
                 comment_likes: 5
             ),
             CommentResponse(
                 comment_identifier: "c2",
                 body: "I agree!",
                 author_username: "fan_2",
-                comment_creation_time: "2023-01-01T12:05:00Z",
-                comment_updated_time: "2023-01-01T12:05:00Z",
+                creation_time: "2023-01-01T12:05:00Z",
+                updated_time: "2023-01-01T12:05:00Z",
                 comment_likes: 2
             )
         ]
-        return try encodeList(comments)
+        return try encode(comments)
     }
 
     func replyToCommentThread(sessionManagementToken: String, postIdentifier: String, commentThreadIdentifier: String, commentText: String) async throws -> Data {
@@ -289,7 +252,7 @@ struct MockedAPI: Networking {
             User(username: "search_result_1", identityIsVerified: true),
             User(username: "search_result_2", identityIsVerified: false)
         ]
-        return try encodeList(users)
+        return try encode(users)
     }
     
     func getProfileDetails(sessionManagementToken: String, username: String) async throws -> Data {
@@ -300,7 +263,7 @@ struct MockedAPI: Networking {
             followingCount: 50,
             isFollowing: false
         )
-        return try encodeSingle(profile)
+        return try encode(profile)
     }
 }
 

--- a/ios/Positive Only Social/Positive Only Social/viewmodels/FeedViewModel.swift
+++ b/ios/Positive Only Social/Positive Only Social/viewmodels/FeedViewModel.swift
@@ -37,9 +37,7 @@ final class FeedViewModel: ObservableObject {
                 let userSession = try keychainHelper.load(UserSession.self, from: "positive-only-social.Positive-Only-Social", account: account) ?? UserSession(sessionToken: "123", username: "test", isIdentityVerified: false)
                 
                 let responseData = try await api.getPostsInFeed(sessionManagementToken: userSession.sessionToken, batch: currentPage)
-                let wrapper = try JSONDecoder().decode(APIWrapperResponse.self, from: responseData)
-                guard let innerData = wrapper.responseList.data(using: .utf8) else { return }
-                let newPosts = try JSONDecoder().decode([DjangoObject<Post>].self, from: innerData).map { $0.fields }
+                let newPosts = try JSONDecoder().decode([Post].self, from: responseData)
                 
                 if newPosts.isEmpty {
                     canLoadMore = false

--- a/ios/Positive Only Social/Positive Only Social/viewmodels/FollowingFeedViewModel.swift
+++ b/ios/Positive Only Social/Positive Only Social/viewmodels/FollowingFeedViewModel.swift
@@ -41,10 +41,8 @@ final class FollowingFeedViewModel: ObservableObject {
                 // Call the API endpoint for followed users
                 let responseData = try await api.getPostsForFollowedUsers(sessionManagementToken: userSession.sessionToken, batch: currentPage)
                 // --- END KEY CHANGE ---
-                
-                let wrapper = try JSONDecoder().decode(APIWrapperResponse.self, from: responseData)
-                guard let innerData = wrapper.responseList.data(using: .utf8) else { return }
-                let newPosts = try JSONDecoder().decode([DjangoObject<Post>].self, from: innerData).map { $0.fields }
+
+                let newPosts = try JSONDecoder().decode([Post].self, from: responseData)
                 
                 if newPosts.isEmpty {
                     canLoadMore = false

--- a/ios/Positive Only Social/Positive Only Social/viewmodels/HomeViewModel.swift
+++ b/ios/Positive Only Social/Positive Only Social/viewmodels/HomeViewModel.swift
@@ -106,23 +106,12 @@ final class HomeViewModel: ObservableObject {
     // Decodes the API response for get_posts_for_user
     private func fetchPosts(for username: String, token: String, page: Int) async throws -> [Post] {
         let responseData = try await api.getPostsForUser(sessionManagementToken: token, username: username, batch: page)
-        let wrapper = try JSONDecoder().decode(APIWrapperResponse.self, from: responseData)
-        guard let innerData = wrapper.responseList.data(using: .utf8) else { return [] }
-        let responseArray = try JSONDecoder().decode([DjangoObject<Post>].self, from: innerData)
-        return responseArray.map { $0.fields }
+        return try JSONDecoder().decode([Post].self, from: responseData)
     }
-    
+
     // Decodes the API response for get_users_matching_fragment
     private func searchForUsers(fragment: String, token: String) async throws -> [User] {
         let responseData = try await api.getUsersMatchingFragment(sessionManagementToken: token, usernameFragment: fragment)
-        let wrapper = try JSONDecoder().decode(APIWrapperResponse.self, from: responseData)
-        guard let innerData = wrapper.responseList.data(using: .utf8) else { return [] }
-        let responseArray = try JSONDecoder().decode([DjangoObject<User>].self, from: innerData)
-        return responseArray.map { $0.fields }
+        return try JSONDecoder().decode([User].self, from: responseData)
     }
-}
-
-// A generic helper to decode the Django serializer format
-struct DjangoObject<T: Codable>: Codable {
-    let fields: T
 }

--- a/ios/Positive Only Social/Positive Only Social/viewmodels/PostDetailViewModel.swift
+++ b/ios/Positive Only Social/Positive Only Social/viewmodels/PostDetailViewModel.swift
@@ -99,7 +99,7 @@ final class PostDetailViewModel: ObservableObject {
                                     authorUsername: field.author_username,
                                     body: field.body,
                                     likeCount: field.comment_likes,
-                                    createdDate: ISO8601DateFormatter().date(from: field.creation_time) ?? Date()
+                                    createdDate: Self.parseDate(field.creation_time)
                                 )
                             }
                         }
@@ -398,5 +398,28 @@ final class PostDetailViewModel: ObservableObject {
 
     private func decodeList<T: Decodable>(from data: Data, type: T.Type) throws -> [T] {
         return try JSONDecoder().decode([T].self, from: data)
+    }
+
+    // MARK: - Date Parsing
+
+    /// Parses an ISO8601 date string produced by Django, which typically includes
+    /// fractional seconds and a `+00:00` timezone offset (e.g. "2024-01-15T10:30:45.123456+00:00").
+    /// Falls back to parsing without fractional seconds for older rows, then to `Date()`.
+    private static let isoDateFormatterWithFractional: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+
+    private static let isoDateFormatterNoFractional: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }()
+
+    private static func parseDate(_ string: String) -> Date {
+        return isoDateFormatterWithFractional.date(from: string)
+            ?? isoDateFormatterNoFractional.date(from: string)
+            ?? Date()
     }
 }

--- a/ios/Positive Only Social/Positive Only Social/viewmodels/PostDetailViewModel.swift
+++ b/ios/Positive Only Social/Positive Only Social/viewmodels/PostDetailViewModel.swift
@@ -95,12 +95,11 @@ final class PostDetailViewModel: ObservableObject {
                             return commentFields.map { field in
                                 CommentViewData(
                                     id: field.comment_identifier,
-                                    threadId: threadId, // We know this from the context
+                                    threadId: threadId,
                                     authorUsername: field.author_username,
                                     body: field.body,
                                     likeCount: field.comment_likes,
-                                    // Handle date conversion
-                                    createdDate: ISO8601DateFormatter().date(from: field.comment_creation_time) ?? Date()
+                                    createdDate: ISO8601DateFormatter().date(from: field.creation_time) ?? Date()
                                 )
                             }
                         }
@@ -388,37 +387,16 @@ final class PostDetailViewModel: ObservableObject {
         let comment_identifier: String
         let body: String
         let author_username: String
-        let comment_creation_time: String
-        let comment_updated_time: String
+        let creation_time: String
+        let updated_time: String
         let comment_likes: Int
-    }
-    
-    // These helpers handle the specific double-encoded JSON from your stub
-    private struct APIResponseWrapper: Decodable {
-        let response_list: String
-    }
-    
-    private struct DjangoSerializedObject<F: Decodable>: Decodable {
-        let fields: F
     }
 
     private func decodeSingle<T: Decodable>(from data: Data, type: T.Type) throws -> T {
-        let decoder = JSONDecoder()
-        let wrapper = try decoder.decode(APIResponseWrapper.self, from: data)
-        guard let innerData = wrapper.response_list.data(using: .utf8) else {
-            throw SerializationError()
-        }
-        let serializedObject = try decoder.decode(DjangoSerializedObject<T>.self, from: innerData)
-        return serializedObject.fields
+        return try JSONDecoder().decode(T.self, from: data)
     }
 
     private func decodeList<T: Decodable>(from data: Data, type: T.Type) throws -> [T] {
-        let decoder = JSONDecoder()
-        let wrapper = try decoder.decode(APIResponseWrapper.self, from: data)
-        guard let innerData = wrapper.response_list.data(using: .utf8) else {
-            throw SerializationError()
-        }
-        let serializedObjects = try decoder.decode([DjangoSerializedObject<T>].self, from: innerData)
-        return serializedObjects.map { $0.fields }
+        return try JSONDecoder().decode([T].self, from: data)
     }
 }

--- a/ios/Positive Only Social/Positive Only Social/viewmodels/PostDetailViewModel.swift
+++ b/ios/Positive Only Social/Positive Only Social/viewmodels/PostDetailViewModel.swift
@@ -306,7 +306,7 @@ final class PostDetailViewModel: ObservableObject {
                 _ = try await api.reportComment(sessionManagementToken: token, postIdentifier: postIdentifier, commentThreadIdentifier: comment.threadId, commentIdentifier: comment.id, reason: reason)
                 
                 await MainActor.run {
-                    reportedCommentIds.insert(comment.id)
+                    _ = reportedCommentIds.insert(comment.id)
                 }
             } catch {
                 print("Failed to report comment: \(error)")
@@ -405,21 +405,14 @@ final class PostDetailViewModel: ObservableObject {
     /// Parses an ISO8601 date string produced by Django, which typically includes
     /// fractional seconds and a `+00:00` timezone offset (e.g. "2024-01-15T10:30:45.123456+00:00").
     /// Falls back to parsing without fractional seconds for older rows, then to `Date()`.
-    private static let isoDateFormatterWithFractional: ISO8601DateFormatter = {
-        let f = ISO8601DateFormatter()
-        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        return f
-    }()
-
-    private static let isoDateFormatterNoFractional: ISO8601DateFormatter = {
-        let f = ISO8601DateFormatter()
-        f.formatOptions = [.withInternetDateTime]
-        return f
-    }()
-
-    private static func parseDate(_ string: String) -> Date {
-        return isoDateFormatterWithFractional.date(from: string)
-            ?? isoDateFormatterNoFractional.date(from: string)
-            ?? Date()
+    /// Marked `nonisolated` so it can be called from async task groups without actor hopping.
+    /// Formatters are created locally to avoid sharing non-Sendable NSObject state across isolation domains.
+    private nonisolated static func parseDate(_ string: String) -> Date {
+        let withFractional = ISO8601DateFormatter()
+        withFractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = withFractional.date(from: string) { return date }
+        let withoutFractional = ISO8601DateFormatter()
+        withoutFractional.formatOptions = [.withInternetDateTime]
+        return withoutFractional.date(from: string) ?? Date()
     }
 }

--- a/ios/Positive Only Social/Positive Only Social/viewmodels/PostDetailViewModel.swift
+++ b/ios/Positive Only Social/Positive Only Social/viewmodels/PostDetailViewModel.swift
@@ -407,12 +407,22 @@ final class PostDetailViewModel: ObservableObject {
     /// Falls back to parsing without fractional seconds for older rows, then to `Date()`.
     /// Marked `nonisolated` so it can be called from async task groups without actor hopping.
     /// Formatters are created locally to avoid sharing non-Sendable NSObject state across isolation domains.
+    /// Parses an ISO8601 date string produced by Django, which typically includes
+    /// fractional seconds and a `+00:00` timezone offset (e.g. "2024-01-15T10:30:45.123456+00:00").
+    /// Falls back to parsing without fractional seconds for older rows, then to `Date()`.
+    /// Uses `Date.ISO8601FormatStyle` (a value type) to avoid allocating `NSObject`-backed
+    /// formatters on each call — safe to call from any isolation domain without extra cost.
     private nonisolated static func parseDate(_ string: String) -> Date {
-        let withFractional = ISO8601DateFormatter()
-        withFractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        if let date = withFractional.date(from: string) { return date }
-        let withoutFractional = ISO8601DateFormatter()
-        withoutFractional.formatOptions = [.withInternetDateTime]
-        return withoutFractional.date(from: string) ?? Date()
+        if let date = try? Date(string, strategy: .iso8601.year().month().day()
+            .time(includingFractionalSeconds: true)
+            .timeZone(separator: .omitted)) {
+            return date
+        }
+        if let date = try? Date(string, strategy: .iso8601.year().month().day()
+            .time(includingFractionalSeconds: false)
+            .timeZone(separator: .omitted)) {
+            return date
+        }
+        return Date()
     }
 }

--- a/ios/Positive Only Social/Positive Only Social/viewmodels/ProfileViewModel.swift
+++ b/ios/Positive Only Social/Positive Only Social/viewmodels/ProfileViewModel.swift
@@ -56,10 +56,7 @@ class ProfileViewModel: ObservableObject {
                     username: user.username,
                     batch: batch
                 )
-                
-                let wrapper = try JSONDecoder().decode(APIWrapperResponse.self, from: responseData)
-                guard let innerData = wrapper.responseList.data(using: .utf8) else { return }
-                let newPosts = try JSONDecoder().decode([DjangoObject<Post>].self, from: innerData).map { $0.fields }
+                let newPosts = try JSONDecoder().decode([Post].self, from: responseData)
                 
                 if newPosts.isEmpty {
                     // No more posts to load
@@ -88,10 +85,7 @@ class ProfileViewModel: ObservableObject {
                 let userSession = try keychainHelper.load(UserSession.self, from: "positive-only-social.Positive-Only-Social", account: account) ?? UserSession(sessionToken: "123", username: "test", isIdentityVerified: false)
                 
                 let responseData = try await api.getProfileDetails(sessionManagementToken: userSession.sessionToken, username: user.username)
-                
-                let wrapper = try JSONDecoder().decode(APIWrapperResponse.self, from: responseData)
-                guard let innerData = wrapper.responseList.data(using: .utf8) else { return }
-                let details = try JSONDecoder().decode(DjangoObject<ProfileDetailsResponse>.self, from: innerData).fields
+                let details = try JSONDecoder().decode(ProfileDetailsResponse.self, from: responseData)
                 
                 self.profileDetails = details
                 self.isFollowing = details.isFollowing // Set initial follow state

--- a/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_AuthenticationManager.swift
+++ b/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_AuthenticationManager.swift
@@ -78,7 +78,7 @@ struct Positive_Only_SocialTests_AuthenticationManager {
         
         // And: We wait for the background Task in login() to complete.
         // A tiny sleep is needed to let the new Task execute and update the state.
-        try await Task.sleep(for: .seconds(TestConstants.shortTimeout))s
+        try await Task.sleep(for: .seconds(TestConstants.shortTimeout))
         
         // Then: The published property is updated to true
         #expect(sut.isLoggedIn == true, "isLoggedIn should be true after calling login()")

--- a/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_AuthenticationManager.swift
+++ b/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_AuthenticationManager.swift
@@ -44,7 +44,7 @@ struct Positive_Only_SocialTests_AuthenticationManager {
         // Clean things up
         sut.logout()
         
-        try await Task.sleep(nanoseconds: 1_000_000_000) // 1 second
+        try await Task.sleep(for: .seconds(TestConstants.shortTimeout))
     }
 
     @Test mutating func testInit_WhenKeychainHasToken_isLoggedInIsTrue() async throws {
@@ -62,7 +62,7 @@ struct Positive_Only_SocialTests_AuthenticationManager {
         // Clean things up
         sut.logout()
         
-        try await Task.sleep(nanoseconds: 1_000_000_000) // 1 second
+        try await Task.sleep(for: .seconds(TestConstants.shortTimeout))
     }
 
     @Test mutating func testLogin_SetsIsLoggedInToTrue() async throws {
@@ -78,7 +78,7 @@ struct Positive_Only_SocialTests_AuthenticationManager {
         
         // And: We wait for the background Task in login() to complete.
         // A tiny sleep is needed to let the new Task execute and update the state.
-        try await Task.sleep(nanoseconds: 1_000_000_000) // 1 seconds
+        try await Task.sleep(for: .seconds(TestConstants.shortTimeout))s
         
         // Then: The published property is updated to true
         #expect(sut.isLoggedIn == true, "isLoggedIn should be true after calling login()")
@@ -86,7 +86,7 @@ struct Positive_Only_SocialTests_AuthenticationManager {
         // Clean things up
         sut.logout()
         
-        try await Task.sleep(nanoseconds: 1_000_000_000) // 1 second
+        try await Task.sleep(for: .seconds(TestConstants.shortTimeout))
     }
     
     @Test mutating func testLogout_SetsIsLoggedInToFalse_AndClearsKeychain() async throws {
@@ -98,7 +98,7 @@ struct Positive_Only_SocialTests_AuthenticationManager {
         sut = AuthenticationManager(shouldAutoLogin: true, keychainHelper: keychain)
         
         // Wait to login
-        try await Task.sleep(nanoseconds: 1_000_000_000) // 1 second
+        try await Task.sleep(for: .seconds(TestConstants.shortTimeout))
         
         #expect(sut.isLoggedIn == true) // Verify initial logged-in state
         
@@ -107,7 +107,7 @@ struct Positive_Only_SocialTests_AuthenticationManager {
         
         // And: We wait for the background Task in logout() to complete.
         // A tiny sleep is needed to let the new Task execute and update the state.
-        try await Task.sleep(nanoseconds: 1_000_000_000) // 1 second
+        try await Task.sleep(for: .seconds(TestConstants.shortTimeout))
         
         // Then: The published property is updated to false
         #expect(sut.isLoggedIn == false, "isLoggedIn should be false after logout")
@@ -119,7 +119,7 @@ struct Positive_Only_SocialTests_AuthenticationManager {
         // Clean things up
         sut.logout()
         
-        try await Task.sleep(nanoseconds: 1_000_000_000) // 1 second
+        try await Task.sleep(for: .seconds(TestConstants.shortTimeout))
     }
 
 }

--- a/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_FeedViewModel.swift
+++ b/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_FeedViewModel.swift
@@ -24,8 +24,8 @@ struct Positive_Only_SocialTests_FeedViewModel {
     
     init() {
         // This 'init' runs before *each* @Test
-        keychainHelper = KeychainHelper()
-        
+        keychainHelper = MockKeychainHelper()
+
         // 1. Set up the mocks
         stubAPI = StatefulStubbedAPI()
     }

--- a/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_FeedViewModel.swift
+++ b/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_FeedViewModel.swift
@@ -39,15 +39,8 @@ struct Positive_Only_SocialTests_FeedViewModel {
     /// This is needed because we must decode the nested JSON response.
     private func registerUserAndGetToken(username: String) async throws -> String {
         let data = try await stubAPI.register(username: username, email: "\(username)@test.com", password: "123", rememberMe: "false", ip: "127.0.0.1", dateOfBirth: "1970-01-01")
-        struct RegFields: Codable { let session_management_token: String }
-        struct DjangoRegObject: Codable { let fields: RegFields }
-
-        let wrapper = try JSONDecoder().decode(APIWrapperResponse.self, from: data)
-        let responseString = String(describing: wrapper.responseList)
-        let innerData = responseString.data(using: String.Encoding.utf8)!
-        let djangoObject = try JSONDecoder().decode(DjangoRegObject.self, from: innerData)
-        
-        return djangoObject.fields.session_management_token
+        struct RegFields: Decodable { let session_management_token: String }
+        return try JSONDecoder().decode(RegFields.self, from: data).session_management_token
     }
 
     // --- Test Cases ---

--- a/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_FeedViewModel.swift
+++ b/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_FeedViewModel.swift
@@ -32,7 +32,7 @@ struct Positive_Only_SocialTests_FeedViewModel {
     
     // A small helper to pause the test and let the ViewModel's 'Task' complete
     private func yield() async {
-        try? await Task.sleep(nanoseconds: 1_000_000_000) // 1 seconds
+        try? await Task.sleep(for: .seconds(TestConstants.shortTimeout))
     }
     
     /// Helper to register a user with the stub API and return their session token.

--- a/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_FollowingFeedViewModel.swift
+++ b/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_FollowingFeedViewModel.swift
@@ -31,7 +31,7 @@ struct Positive_Only_SocialTests_FollowingFeedViewModel {
     // --- Test Helpers ---
     
     private func yield() async {
-        try? await Task.sleep(nanoseconds: 2_000_000_000) // 2 seconds
+        try? await Task.sleep(for: .seconds(TestConstants.shortTimeout))
     }
     
     /// Helper to register a user with the stub API and return their session token.

--- a/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_FollowingFeedViewModel.swift
+++ b/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_FollowingFeedViewModel.swift
@@ -22,8 +22,8 @@ struct Positive_Only_SocialTests_FollowingFeedViewModel {
     // --- Test Setup ---
     
     init() {
-        keychainHelper = KeychainHelper()
-        
+        keychainHelper = MockKeychainHelper()
+
         // This 'init' runs before *each* @Test
         stubAPI = StatefulStubbedAPI()
     }

--- a/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_FollowingFeedViewModel.swift
+++ b/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_FollowingFeedViewModel.swift
@@ -38,14 +38,8 @@ struct Positive_Only_SocialTests_FollowingFeedViewModel {
     private func registerUserAndGetToken(username: String) async throws -> String {
         let data = try await stubAPI.register(username: username, email: "\(username)@test.com", password: "123", rememberMe: "false", ip: "127.0.0.1", dateOfBirth: "1970-01-01")
         
-        struct RegFields: Codable { let session_management_token: String }
-        struct DjangoRegObject: Codable { let fields: RegFields }
-
-        let wrapper = try JSONDecoder().decode(APIWrapperResponse.self, from: data)
-        let innerData = wrapper.responseList.data(using: .utf8)!
-        let djangoObject = try JSONDecoder().decode(DjangoRegObject.self, from: innerData)
-        
-        return djangoObject.fields.session_management_token
+        struct RegFields: Decodable { let session_management_token: String }
+        return try JSONDecoder().decode(RegFields.self, from: data).session_management_token
     }
 
     // --- Test Cases ---

--- a/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_HomeViewModel.swift
+++ b/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_HomeViewModel.swift
@@ -29,7 +29,7 @@ struct Positive_Only_SocialTests_HomeViewModel {
     // --- Test Helpers ---
     
     /// Helper to pause the test and let async/debounce tasks complete.
-    private func yield(for duration: Duration = .seconds(2)) async {
+    private func yield(for duration: Duration = .seconds(TestConstants.shortTimeout)) async {
         try? await Task.sleep(for: duration)
     }
     

--- a/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_HomeViewModel.swift
+++ b/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_HomeViewModel.swift
@@ -37,14 +37,8 @@ struct Positive_Only_SocialTests_HomeViewModel {
     private func registerUserAndGetToken(username: String) async throws -> String {
         let data = try await stubAPI.register(username: username, email: "\(username)@test.com", password: "123", rememberMe: "false", ip: "127.0.0.1", dateOfBirth: "1970-01-01")
         
-        struct RegFields: Codable { let session_management_token: String }
-        struct DjangoRegObject: Codable { let fields: RegFields }
-        
-        let wrapper: APIWrapperResponse = try JSONDecoder().decode(APIWrapperResponse.self, from: data)
-        let innerData = wrapper.responseList.data(using: .utf8)!
-        let djangoObject = try JSONDecoder().decode(DjangoRegObject.self, from: innerData)
-        
-        return djangoObject.fields.session_management_token
+        struct RegFields: Decodable { let session_management_token: String }
+        return try JSONDecoder().decode(RegFields.self, from: data).session_management_token
     }
     
     /// Helper to log in the "testuser" and save their token to the keychain

--- a/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_HomeViewModel.swift
+++ b/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_HomeViewModel.swift
@@ -22,7 +22,7 @@ struct Positive_Only_SocialTests_HomeViewModel {
     // --- Test Setup ---
     init() {
         
-        keychainHelper = KeychainHelper()
+        keychainHelper = MockKeychainHelper()
         stubAPI = StatefulStubbedAPI()
     }
 

--- a/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_PostDetailViewModel.swift
+++ b/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_PostDetailViewModel.swift
@@ -28,7 +28,7 @@ struct Positive_Only_SocialTests_PostDetailViewModel {
 
     // --- Test Setup ---
     init() {
-        keychainHelper = KeychainHelper()
+        keychainHelper = MockKeychainHelper()
         stubAPI = StatefulStubbedAPI()
     }
 

--- a/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_PostDetailViewModel.swift
+++ b/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_PostDetailViewModel.swift
@@ -32,19 +32,6 @@ struct Positive_Only_SocialTests_PostDetailViewModel {
         stubAPI = StatefulStubbedAPI()
     }
 
-    // --- Local Decoder Structs (for test setup) ---
-    // These mirror the structs used by the stub API to decode responses
-    
-    /// A generic wrapper for the stub API's double-encoded JSON
-    private struct APIWrapperResponse: Decodable {
-        let response_list: String
-    }
-    
-    /// A generic wrapper for the "fields" object inside the JSON
-    private struct DjangoObject<F: Decodable>: Decodable {
-        let fields: F
-    }
-    
     // MARK: - Test Helpers
     
     /// Helper to pause the test and let async/debounce tasks complete.
@@ -58,12 +45,7 @@ struct Positive_Only_SocialTests_PostDetailViewModel {
         let data = try await stubAPI.register(username: username, email: "\(username)@test.com", password: "123", rememberMe: "false", ip: "127.0.0.1", dateOfBirth: "1970-01-01")
         
         struct RegFields: Decodable { let session_management_token: String }
-        
-        let wrapper = try JSONDecoder().decode(APIWrapperResponse.self, from: data)
-        let innerData = wrapper.response_list.data(using: .utf8)!
-        let djangoObject = try JSONDecoder().decode(DjangoObject<RegFields>.self, from: innerData)
-        
-        return djangoObject.fields.session_management_token
+        return try JSONDecoder().decode(RegFields.self, from: data).session_management_token
     }
     
     /// Helper to log in the "testuser" and save their token to the keychain
@@ -79,12 +61,7 @@ struct Positive_Only_SocialTests_PostDetailViewModel {
         let data = try await stubAPI.makePost(sessionManagementToken: token, imageURL: "my.image/1", caption: caption)
         
         struct PostFields: Decodable { let post_identifier: String }
-        
-        let wrapper = try JSONDecoder().decode(APIWrapperResponse.self, from: data)
-        let innerData = wrapper.response_list.data(using: .utf8)!
-        let djangoObject = try JSONDecoder().decode(DjangoObject<PostFields>.self, from: innerData)
-        
-        return djangoObject.fields.post_identifier
+        return try JSONDecoder().decode(PostFields.self, from: data).post_identifier
     }
     
     /// Helper to create a comment and return its thread and comment identifiers
@@ -96,11 +73,8 @@ struct Positive_Only_SocialTests_PostDetailViewModel {
             let comment_identifier: String
         }
         
-        let wrapper = try JSONDecoder().decode(APIWrapperResponse.self, from: data)
-        let innerData = wrapper.response_list.data(using: .utf8)!
-        let djangoObject = try JSONDecoder().decode(DjangoObject<CommentFields>.self, from: innerData)
-        
-        return (djangoObject.fields.comment_thread_identifier, djangoObject.fields.comment_identifier)
+        let decoded = try JSONDecoder().decode(CommentFields.self, from: data)
+        return (decoded.comment_thread_identifier, decoded.comment_identifier)
     }
 
     /// Helper to reply to a comment and return its new comment identifier
@@ -108,12 +82,7 @@ struct Positive_Only_SocialTests_PostDetailViewModel {
         let data = try await stubAPI.replyToCommentThread(sessionManagementToken: token, postIdentifier: postID, commentThreadIdentifier: threadID, commentText: body)
         
         struct ReplyFields: Decodable { let comment_identifier: String }
-        
-        let wrapper = try JSONDecoder().decode(APIWrapperResponse.self, from: data)
-        let innerData = wrapper.response_list.data(using: .utf8)!
-        let djangoObject = try JSONDecoder().decode(DjangoObject<ReplyFields>.self, from: innerData)
-        
-        return djangoObject.fields.comment_identifier
+        return try JSONDecoder().decode(ReplyFields.self, from: data).comment_identifier
     }
     
     /// A master helper to set up a full environment for testing

--- a/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_PostDetailViewModel.swift
+++ b/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_PostDetailViewModel.swift
@@ -35,8 +35,7 @@ struct Positive_Only_SocialTests_PostDetailViewModel {
     // MARK: - Test Helpers
     
     /// Helper to pause the test and let async/debounce tasks complete.
-    private func yield(for duration: Duration = .seconds(0.5)) async {
-        // Using a slightly shorter yield as VM tasks are not debounced
+    private func yield(for duration: Duration = .seconds(TestConstants.shortTimeout)) async {
         try? await Task.sleep(for: duration)
     }
     

--- a/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_ProfileViewModel.swift
+++ b/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_ProfileViewModel.swift
@@ -28,8 +28,7 @@ struct Positive_Only_SocialTests_ProfileViewModel {
     // --- Test Helpers ---
     
     /// Helper to pause the test and let async tasks complete.
-    private func yield(for duration: Duration = .seconds(2)) async {
-        // Using a slightly shorter yield as VM tasks don't have a debounce
+    private func yield(for duration: Duration = .seconds(TestConstants.shortTimeout)) async {
         try? await Task.sleep(for: duration)
     }
     

--- a/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_ProfileViewModel.swift
+++ b/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_ProfileViewModel.swift
@@ -21,7 +21,7 @@ struct Positive_Only_SocialTests_ProfileViewModel {
     
     // --- Test Setup ---
     init() {
-        keychainHelper = KeychainHelper()
+        keychainHelper = MockKeychainHelper()
         stubAPI = StatefulStubbedAPI()
     }
 

--- a/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_ProfileViewModel.swift
+++ b/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_ProfileViewModel.swift
@@ -37,14 +37,8 @@ struct Positive_Only_SocialTests_ProfileViewModel {
     private func registerUser(username: String) async throws -> (token: String, user: User) {
         let data = try await stubAPI.register(username: username, email: "\(username)@test.com", password: "123", rememberMe: "false", ip: "127.0.0.1", dateOfBirth: "1970-01-01")
         
-        struct RegFields: Codable { let session_management_token: String }
-        struct DjangoRegObject: Codable { let fields: RegFields }
-        
-        let wrapper: APIWrapperResponse = try JSONDecoder().decode(APIWrapperResponse.self, from: data)
-        let innerData = wrapper.responseList.data(using: .utf8)!
-        let djangoObject = try JSONDecoder().decode(DjangoRegObject.self, from: innerData)
-        
-        let token = djangoObject.fields.session_management_token
+        struct RegFields: Decodable { let session_management_token: String }
+        let token = try JSONDecoder().decode(RegFields.self, from: data).session_management_token
         // Create the simple User object that the VM needs
         let user = User(username: username, identityIsVerified: false)
         return (token, user)

--- a/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_SettingsViewModel.swift
+++ b/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_SettingsViewModel.swift
@@ -21,7 +21,7 @@ struct Positive_Only_SocialTests_SettingsViewModel {
     
     // --- Test Setup ---
     init() {
-        keychainHelper = KeychainHelper()
+        keychainHelper = MockKeychainHelper()
         stubAPI = StatefulStubbedAPI()
     }
 

--- a/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_SettingsViewModel.swift
+++ b/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_SettingsViewModel.swift
@@ -36,14 +36,8 @@ struct Positive_Only_SocialTests_SettingsViewModel {
     private func registerUserAndGetToken(username: String) async throws -> String {
         let data = try await stubAPI.register(username: username, email: "\(username)@test.com", password: "123", rememberMe: "false", ip: "127.0.0.1", dateOfBirth: "1970-01-01")
         
-        struct RegFields: Codable { let session_management_token: String }
-        struct DjangoRegObject: Codable { let fields: RegFields }
-        
-        let wrapper: APIWrapperResponse = try JSONDecoder().decode(APIWrapperResponse.self, from: data)
-        let innerData = wrapper.responseList.data(using: .utf8)!
-        let djangoObject = try JSONDecoder().decode(DjangoRegObject.self, from: innerData)
-        
-        return djangoObject.fields.session_management_token
+        struct RegFields: Decodable { let session_management_token: String }
+        return try JSONDecoder().decode(RegFields.self, from: data).session_management_token
     }
     
     /// Helper to log in a user and save their token to the keychain

--- a/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_SettingsViewModel.swift
+++ b/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_SettingsViewModel.swift
@@ -28,7 +28,7 @@ struct Positive_Only_SocialTests_SettingsViewModel {
     // --- Test Helpers ---
     
     /// Helper to pause the test and let async tasks complete.
-    private func yield(for duration: Duration = .seconds(1)) async {
+    private func yield(for duration: Duration = .seconds(TestConstants.shortTimeout)) async {
         try? await Task.sleep(for: duration)
     }
     

--- a/ios/Positive Only Social/Positive Only SocialTests/TestConstants.swift
+++ b/ios/Positive Only Social/Positive Only SocialTests/TestConstants.swift
@@ -1,0 +1,16 @@
+//
+//  TestConstants.swift
+//  Positive Only Social
+//
+
+import Foundation
+
+/// Centralized timeout constants used across all unit and UI tests.
+enum TestConstants {
+    /// 3 seconds — element existence checks and simple UI state transitions.
+    static let shortTimeout: TimeInterval = 3
+    /// 10 seconds — async reload cycles and network-dependent UI updates.
+    static let timeout: TimeInterval = 10
+    /// 30 seconds — heavyweight operations such as app launch or multi-step flows.
+    static let longTimeout: TimeInterval = 30
+}

--- a/ios/Positive Only Social/Positive Only SocialUITests/Positive_Only_SocialUITests.swift
+++ b/ios/Positive Only Social/Positive Only SocialUITests/Positive_Only_SocialUITests.swift
@@ -357,7 +357,7 @@ final class Positive_Only_SocialUITests: XCTestCase {
         // Should be one comment total
         let commentElements = app.staticTexts.matching(identifier: "CommentText")
         expectation(for: NSPredicate(format: "count == 1"), evaluatedWith: commentElements, handler: nil)
-        waitForExpectations(timeout: elementTimeout, handler: nil)
+        waitForExpectations(timeout: 10, handler: nil)
         XCTAssert(commentElements.count == 1, "Expected to find 1 comment, but found \(commentElements.count)")
         
         assertOnPostDetailView(app: app)
@@ -415,7 +415,7 @@ final class Positive_Only_SocialUITests: XCTestCase {
         // Should be two comments total
         let commentElements = app.staticTexts.matching(identifier: "CommentText")
         expectation(for: NSPredicate(format: "count == 2"), evaluatedWith: commentElements, handler: nil)
-        waitForExpectations(timeout: elementTimeout, handler: nil)
+        waitForExpectations(timeout: 10, handler: nil)
         XCTAssert(commentElements.count == 2, "Expected to find 2 comments, but found \(commentElements.count)")
         
         assertOnPostDetailView(app: app)

--- a/ios/Positive Only Social/Positive Only SocialUITests/Positive_Only_SocialUITests.swift
+++ b/ios/Positive Only Social/Positive Only SocialUITests/Positive_Only_SocialUITests.swift
@@ -638,7 +638,7 @@ final class Positive_Only_SocialUITests: XCTestCase {
         
         // Wait up to 5 seconds for the label to update
         expectation(for: existsPredicate, evaluatedWith: followersLabel, handler: nil)
-        waitForExpectations(timeout: 5.0, handler: nil)
+        waitForExpectations(timeout: TestConstants.timeout, handler: nil)
         
         // 4. Tap Unfollow
         XCTAssertTrue(followButton.waitForExistence(timeout: TestConstants.shortTimeout))
@@ -647,7 +647,7 @@ final class Positive_Only_SocialUITests: XCTestCase {
         // 5. WAIT for it to go back to "0"
         let zeroPredicate = NSPredicate(format: "label == '0'")
         expectation(for: zeroPredicate, evaluatedWith: followersLabel, handler: nil)
-        waitForExpectations(timeout: 5.0, handler: nil)
+        waitForExpectations(timeout: TestConstants.timeout, handler: nil)
         
         let backButton = app.navigationBars.firstMatch.buttons.element(boundBy: 0)
         XCTAssertTrue(backButton.waitForExistence(timeout: TestConstants.shortTimeout))
@@ -734,7 +734,7 @@ final class Positive_Only_SocialUITests: XCTestCase {
         
         // Wait up to 5 seconds for the label to update
         expectation(for: existsPredicate, evaluatedWith: followersLabel, handler: nil)
-        waitForExpectations(timeout: 5.0, handler: nil)
+        waitForExpectations(timeout: TestConstants.timeout, handler: nil)
         
         // 4. Tap Unfollow
         XCTAssertTrue(followButton.waitForExistence(timeout: TestConstants.shortTimeout))
@@ -743,7 +743,7 @@ final class Positive_Only_SocialUITests: XCTestCase {
         // 5. WAIT for it to go back to "0"
         let zeroPredicate = NSPredicate(format: "label == '0'")
         expectation(for: zeroPredicate, evaluatedWith: followersLabel, handler: nil)
-        waitForExpectations(timeout: 5.0, handler: nil)
+        waitForExpectations(timeout: TestConstants.timeout, handler: nil)
         
         /// We refollow so that we can check that the post now shows up in the "Following" Feed
         XCTAssertTrue(followButton.waitForExistence(timeout: TestConstants.shortTimeout))

--- a/ios/Positive Only Social/Positive Only SocialUITests/Positive_Only_SocialUITests.swift
+++ b/ios/Positive Only Social/Positive Only SocialUITests/Positive_Only_SocialUITests.swift
@@ -39,6 +39,20 @@ final class Positive_Only_SocialUITests: XCTestCase {
         testUsername = "\(baseName)_user"
         otherTestUsername = "\(baseName)_other_user"
         newTestUsername = "\(baseName)_new_user"
+
+        // Automatically dismiss any "Save Password" / "Update Password" system
+        // dialogs (presented by SpringBoard, not the app) that would otherwise
+        // block interactions. The monitor fires the next time the test tries to
+        // interact with a UI element while the system dialog is in front.
+        addUIInterruptionMonitor(withDescription: "Save Password dialog") { alert -> Bool in
+            for title in ["Not Now", "Never for This Website", "Cancel"] {
+                if alert.buttons[title].exists {
+                    alert.buttons[title].tap()
+                    return true
+                }
+            }
+            return false
+        }
     }
 
     override func tearDownWithError() throws {
@@ -80,6 +94,16 @@ final class Positive_Only_SocialUITests: XCTestCase {
         }
 
         XCTAssertTrue(element.hasFocus || app.keyboards.count > 0, "Element did not gain keyboard focus.")
+
+        // Clear any pre-existing content so that a retry never appends to
+        // stale text.  Triple-tap selects all text in a field on iOS; the
+        // following typeText call then replaces the selection.
+        let existing = (element.value as? String) ?? ""
+        if !existing.isEmpty {
+            element.tap(withNumberOfTaps: 3, numberOfTouches: 1)
+            RunLoop.current.run(until: NSDate(timeIntervalSinceNow: 0.3) as Date)
+        }
+
         element.typeText(text)
     }
     

--- a/ios/Positive Only Social/Positive Only SocialUITests/Positive_Only_SocialUITests.swift
+++ b/ios/Positive Only Social/Positive Only SocialUITests/Positive_Only_SocialUITests.swift
@@ -15,7 +15,6 @@ final class Positive_Only_SocialUITests: XCTestCase {
     var newTestUsername: String = ""
     let strongPassword: String = "StrongPassword123!"
     let newStrongPassword: String = "NewStrongPassword456!"
-    let elementTimeout: TimeInterval = 3
 
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -50,7 +49,7 @@ final class Positive_Only_SocialUITests: XCTestCase {
     }
     
     // MARK: Helpers
-    private func yield(duration: Duration = .seconds(1)) async {
+    private func yield(duration: Duration = .seconds(TestConstants.shortTimeout)) async {
         try? await Task.sleep(for: duration)
     }
     
@@ -60,7 +59,7 @@ final class Positive_Only_SocialUITests: XCTestCase {
         while (true && attempt < maxAttempts) {
             RunLoop.current.run(until: NSDate(timeIntervalSinceNow: 1.0) as Date)
             if app.keyboards.buttons["Return"].exists {
-                XCTAssertTrue(app.keyboards.buttons["Return"].waitForExistence(timeout: elementTimeout))
+                XCTAssertTrue(app.keyboards.buttons["Return"].waitForExistence(timeout: TestConstants.shortTimeout))
                 app.keyboards.buttons["Return"].tap()
                 break
             }
@@ -89,64 +88,64 @@ final class Positive_Only_SocialUITests: XCTestCase {
         let welcomeText = app.staticTexts["Welcome! 👋"]
         
         // Use a robust existence check with a reasonable timeout.
-        XCTAssertTrue(welcomeText.waitForExistence(timeout: elementTimeout), "The Welcome! 👋 text (NeedsAuthView) did not appear in time.")
+        XCTAssertTrue(welcomeText.waitForExistence(timeout: TestConstants.shortTimeout), "The Welcome! 👋 text (NeedsAuthView) did not appear in time.")
 
-        XCTAssertTrue(app.buttons["RegisterText"].waitForExistence(timeout: elementTimeout), "Register button is not empty")
-        XCTAssertTrue(app.buttons["LoginText"].waitForExistence(timeout: elementTimeout), "Login button is not empty")
+        XCTAssertTrue(app.buttons["RegisterText"].waitForExistence(timeout: TestConstants.shortTimeout), "Register button is not empty")
+        XCTAssertTrue(app.buttons["LoginText"].waitForExistence(timeout: TestConstants.shortTimeout), "Login button is not empty")
     }
     
     private func assertOnRegisterView(app: XCUIApplication) {
-        XCTAssertTrue(app.textFields["UsernameTextField"].waitForExistence(timeout: elementTimeout), "Username field not present")
-        XCTAssertTrue(app.textFields["EmailTextField"].waitForExistence(timeout: elementTimeout), "Email field not present")
-        XCTAssertTrue(app.secureTextFields["PasswordSecureField"].waitForExistence(timeout: elementTimeout), "Password field not present")
-        XCTAssertTrue(app.secureTextFields["ConfirmPasswordSecureField"].waitForExistence(timeout: elementTimeout), "Confirm Password field not present")
-        XCTAssertTrue(app.datePickers["DateOfBirthPicker"].waitForExistence(timeout: elementTimeout), "Date of birth picker not present")
-        XCTAssertTrue(app.buttons["RegisterButton"].waitForExistence(timeout: elementTimeout), "Register button not present")
+        XCTAssertTrue(app.textFields["UsernameTextField"].waitForExistence(timeout: TestConstants.shortTimeout), "Username field not present")
+        XCTAssertTrue(app.textFields["EmailTextField"].waitForExistence(timeout: TestConstants.shortTimeout), "Email field not present")
+        XCTAssertTrue(app.secureTextFields["PasswordSecureField"].waitForExistence(timeout: TestConstants.shortTimeout), "Password field not present")
+        XCTAssertTrue(app.secureTextFields["ConfirmPasswordSecureField"].waitForExistence(timeout: TestConstants.shortTimeout), "Confirm Password field not present")
+        XCTAssertTrue(app.datePickers["DateOfBirthPicker"].waitForExistence(timeout: TestConstants.shortTimeout), "Date of birth picker not present")
+        XCTAssertTrue(app.buttons["RegisterButton"].waitForExistence(timeout: TestConstants.shortTimeout), "Register button not present")
     }
     
     private func assertOnLoginView(app: XCUIApplication) {
-        XCTAssertTrue(app.staticTexts["Login"].waitForExistence(timeout: elementTimeout), "Login text did not appear in time.")
+        XCTAssertTrue(app.staticTexts["Login"].waitForExistence(timeout: TestConstants.shortTimeout), "Login text did not appear in time.")
 
-        XCTAssertTrue(app.textFields["UsernameOrEmailTextField"].waitForExistence(timeout: elementTimeout), "Username or email field not present")
-        XCTAssertTrue(app.secureTextFields["PasswordSecureField"].waitForExistence(timeout: elementTimeout), "Password field not present")
-        XCTAssertTrue(app.buttons["LoginButton"].waitForExistence(timeout: elementTimeout), "Login button not present")
-        XCTAssertTrue(app.switches["RememberMeToggle"].waitForExistence(timeout: elementTimeout), "Remember me toggle not present")
-        XCTAssertTrue(app.buttons["ForgotPasswordButton"].waitForExistence(timeout: elementTimeout), "Forgot password button not present")
+        XCTAssertTrue(app.textFields["UsernameOrEmailTextField"].waitForExistence(timeout: TestConstants.shortTimeout), "Username or email field not present")
+        XCTAssertTrue(app.secureTextFields["PasswordSecureField"].waitForExistence(timeout: TestConstants.shortTimeout), "Password field not present")
+        XCTAssertTrue(app.buttons["LoginButton"].waitForExistence(timeout: TestConstants.shortTimeout), "Login button not present")
+        XCTAssertTrue(app.switches["RememberMeToggle"].waitForExistence(timeout: TestConstants.shortTimeout), "Remember me toggle not present")
+        XCTAssertTrue(app.buttons["ForgotPasswordButton"].waitForExistence(timeout: TestConstants.shortTimeout), "Forgot password button not present")
     }
     
     private func assertOnHomeView(app: XCUIApplication) {
-        XCTAssertTrue(app.buttons["Home"].waitForExistence(timeout: elementTimeout), "Home tab not present")
-        XCTAssertTrue(app.buttons["Feed"].waitForExistence(timeout: elementTimeout), "Feed tab not present")
-        XCTAssertTrue(app.buttons["Post"].waitForExistence(timeout: elementTimeout), "New post tab not present")
-        XCTAssertTrue(app.buttons["Settings"].waitForExistence(timeout: elementTimeout), "Settings tab not present")
+        XCTAssertTrue(app.buttons["Home"].waitForExistence(timeout: TestConstants.shortTimeout), "Home tab not present")
+        XCTAssertTrue(app.buttons["Feed"].waitForExistence(timeout: TestConstants.shortTimeout), "Feed tab not present")
+        XCTAssertTrue(app.buttons["Post"].waitForExistence(timeout: TestConstants.shortTimeout), "New post tab not present")
+        XCTAssertTrue(app.buttons["Settings"].waitForExistence(timeout: TestConstants.shortTimeout), "Settings tab not present")
     }
     
     private func assertOnSettingsView(app: XCUIApplication) {
-        XCTAssertTrue(app.buttons["LogoutButton"].waitForExistence(timeout: elementTimeout), "Logout button not present")
-        XCTAssertTrue(app.buttons["DeleteAccountButton"].waitForExistence(timeout: elementTimeout), "Delete Account button not present")
+        XCTAssertTrue(app.buttons["LogoutButton"].waitForExistence(timeout: TestConstants.shortTimeout), "Logout button not present")
+        XCTAssertTrue(app.buttons["DeleteAccountButton"].waitForExistence(timeout: TestConstants.shortTimeout), "Delete Account button not present")
     }
     
     private func assertOnProfileView(app: XCUIApplication) {
-        XCTAssertTrue(app.buttons["FollowButton"].waitForExistence(timeout: elementTimeout), "Follow button not present")
-        XCTAssertTrue(app.staticTexts["Following"].waitForExistence(timeout: elementTimeout), "Following stat item not present")
-        XCTAssertTrue(app.staticTexts["Followers"].waitForExistence(timeout: elementTimeout), "Followers stat item not present")
-        XCTAssertTrue(app.staticTexts["Posts"].waitForExistence(timeout: elementTimeout), "Posts stat item not present")
+        XCTAssertTrue(app.buttons["FollowButton"].waitForExistence(timeout: TestConstants.shortTimeout), "Follow button not present")
+        XCTAssertTrue(app.staticTexts["Following"].waitForExistence(timeout: TestConstants.shortTimeout), "Following stat item not present")
+        XCTAssertTrue(app.staticTexts["Followers"].waitForExistence(timeout: TestConstants.shortTimeout), "Followers stat item not present")
+        XCTAssertTrue(app.staticTexts["Posts"].waitForExistence(timeout: TestConstants.shortTimeout), "Posts stat item not present")
     }
     
     private func assertOnNewPostView(app: XCUIApplication) {
-        XCTAssertTrue(app.buttons["SelectAPhotoPicker"].waitForExistence(timeout: elementTimeout), "Select a photo picker not present")
-        XCTAssertTrue(app.textViews["CaptionTextEditor"].waitForExistence(timeout: elementTimeout), "Caption text editor not present")
-        XCTAssertTrue(app.buttons["SharePostButton"].waitForExistence(timeout: elementTimeout), "Share post button is not empty")
+        XCTAssertTrue(app.buttons["SelectAPhotoPicker"].waitForExistence(timeout: TestConstants.shortTimeout), "Select a photo picker not present")
+        XCTAssertTrue(app.textViews["CaptionTextEditor"].waitForExistence(timeout: TestConstants.shortTimeout), "Caption text editor not present")
+        XCTAssertTrue(app.buttons["SharePostButton"].waitForExistence(timeout: TestConstants.shortTimeout), "Share post button is not empty")
     }
     
     private func assertOnFeedView(app: XCUIApplication) {
-        XCTAssertTrue(app.segmentedControls["FeedTypePicker"].waitForExistence(timeout: elementTimeout), "Feed type picker not present")
+        XCTAssertTrue(app.segmentedControls["FeedTypePicker"].waitForExistence(timeout: TestConstants.shortTimeout), "Feed type picker not present")
     }
     
     private func assertOnPostDetailView(app: XCUIApplication) {
-        XCTAssertTrue(app.buttons["PostCommentButton"].waitForExistence(timeout: elementTimeout), "Post comment button not present")
-        XCTAssertTrue(app.buttons["PostImage"].waitForExistence(timeout: elementTimeout), "Post image not present in time")
-        XCTAssertTrue(app.textFields["AddACommentTextFieldToPost"].waitForExistence(timeout: elementTimeout), "Add a comment text field not present")
+        XCTAssertTrue(app.buttons["PostCommentButton"].waitForExistence(timeout: TestConstants.shortTimeout), "Post comment button not present")
+        XCTAssertTrue(app.buttons["PostImage"].waitForExistence(timeout: TestConstants.shortTimeout), "Post image not present in time")
+        XCTAssertTrue(app.textFields["AddACommentTextFieldToPost"].waitForExistence(timeout: TestConstants.shortTimeout), "Add a comment text field not present")
     }
     
     private func ifOnHomeDeleteAccount(app: XCUIApplication) throws {
@@ -160,10 +159,10 @@ final class Positive_Only_SocialUITests: XCTestCase {
         let welcomeText = app.staticTexts["Welcome! 👋"]
         
         // Use a robust existence check with a reasonable timeout.
-        XCTAssertTrue(welcomeText.waitForExistence(timeout: elementTimeout), "The Welcome! 👋 text (NeedsAuthView) did not appear in time.")
+        XCTAssertTrue(welcomeText.waitForExistence(timeout: TestConstants.shortTimeout), "The Welcome! 👋 text (NeedsAuthView) did not appear in time.")
         
         let registerButton = app.buttons["RegisterText"]
-        XCTAssertTrue(registerButton.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(registerButton.waitForExistence(timeout: TestConstants.shortTimeout))
         registerButton.tap()
         
         assertOnRegisterView(app: app)
@@ -171,32 +170,32 @@ final class Positive_Only_SocialUITests: XCTestCase {
         dismissKeyboardIfPresent(app)
         
         let usernameField = app.textFields["UsernameTextField"]
-        XCTAssertTrue(usernameField.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(usernameField.waitForExistence(timeout: TestConstants.shortTimeout))
         usernameField.tap()
         typeText(element: usernameField, text: username)
         
         let emailField = app.textFields["EmailTextField"]
-        XCTAssertTrue(emailField.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(emailField.waitForExistence(timeout: TestConstants.shortTimeout))
         emailField.tap()
         typeText(element: emailField, text: "\(username)@test.com")
         
         let passwordField = app.secureTextFields["PasswordSecureField"]
-        XCTAssertTrue(passwordField.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(passwordField.waitForExistence(timeout: TestConstants.shortTimeout))
         passwordField.tap()
         typeText(element: passwordField, text: password)
         
         let confirmPasswordField = app.secureTextFields["ConfirmPasswordSecureField"]
-        XCTAssertTrue(confirmPasswordField.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(confirmPasswordField.waitForExistence(timeout: TestConstants.shortTimeout))
         confirmPasswordField.tap()
         typeText(element: confirmPasswordField, text: password)
         
         let otherRegisterButton = app.buttons["RegisterButton"]
-        XCTAssertTrue(otherRegisterButton.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(otherRegisterButton.waitForExistence(timeout: TestConstants.shortTimeout))
         otherRegisterButton.tap()
         
         let privacyPolicyAlert = app.alerts["Privacy Policy"]
-        XCTAssertTrue(privacyPolicyAlert.waitForExistence(timeout: elementTimeout))
-        XCTAssertTrue(privacyPolicyAlert.buttons["Ok"].waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(privacyPolicyAlert.waitForExistence(timeout: TestConstants.shortTimeout))
+        XCTAssertTrue(privacyPolicyAlert.buttons["Ok"].waitForExistence(timeout: TestConstants.shortTimeout))
         privacyPolicyAlert.buttons["Ok"].tap()
         
         assertOnHomeView(app: app)
@@ -206,7 +205,7 @@ final class Positive_Only_SocialUITests: XCTestCase {
     
     private func dismissSavePassword(app: XCUIApplication) {
         let notNowButton = app.buttons["Not Now"]
-        if notNowButton.waitForExistence(timeout: elementTimeout) {
+        if notNowButton.waitForExistence(timeout: TestConstants.shortTimeout) {
             notNowButton.tap()
         }
     }
@@ -217,7 +216,7 @@ final class Positive_Only_SocialUITests: XCTestCase {
         try logoutUserFromHome(app: app)
         
         let loginButton = app.buttons["LoginText"]
-        XCTAssertTrue(loginButton.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(loginButton.waitForExistence(timeout: TestConstants.shortTimeout))
         loginButton.tap()
         
         assertOnLoginView(app: app)
@@ -225,12 +224,12 @@ final class Positive_Only_SocialUITests: XCTestCase {
         dismissKeyboardIfPresent(app)
         
         let usernameOrEmailTextField = app.textFields["UsernameOrEmailTextField"]
-        XCTAssertTrue(usernameOrEmailTextField.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(usernameOrEmailTextField.waitForExistence(timeout: TestConstants.shortTimeout))
         usernameOrEmailTextField.tap()
         typeText(element: usernameOrEmailTextField, text: username)
         
         let passwordSecureField = app.secureTextFields["PasswordSecureField"]
-        XCTAssertTrue(passwordSecureField.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(passwordSecureField.waitForExistence(timeout: TestConstants.shortTimeout))
         passwordSecureField.tap()
         typeText(element: passwordSecureField, text: password)
         
@@ -248,7 +247,7 @@ final class Positive_Only_SocialUITests: XCTestCase {
         }
         
         let loginButton2 = app.buttons["LoginButton"]
-        XCTAssertTrue(loginButton2.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(loginButton2.waitForExistence(timeout: TestConstants.shortTimeout))
         loginButton2.tap()
         
         assertOnHomeView(app: app)
@@ -258,18 +257,18 @@ final class Positive_Only_SocialUITests: XCTestCase {
     
     private func logoutUserFromHome(app: XCUIApplication) throws {
         let settingsTab = app.buttons["Settings"]
-        XCTAssertTrue(settingsTab.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(settingsTab.waitForExistence(timeout: TestConstants.shortTimeout))
         settingsTab.tap()
         
         assertOnSettingsView(app: app)
         
         let logoutButton = app.buttons["LogoutButton"]
-        XCTAssertTrue(logoutButton.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(logoutButton.waitForExistence(timeout: TestConstants.shortTimeout))
         logoutButton.tap()
         
         /// Don't know why but there is a hierarchy of confirm logout buttons
         let confirmLogoutButton = app.buttons["ConfirmLogoutButton"].firstMatch
-        XCTAssertTrue(confirmLogoutButton.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(confirmLogoutButton.waitForExistence(timeout: TestConstants.shortTimeout))
         confirmLogoutButton.tap()
         
         assertOnWelcomeView(app: app)
@@ -277,17 +276,17 @@ final class Positive_Only_SocialUITests: XCTestCase {
     
     private func deleteAccountFromHome(app: XCUIApplication) throws {
         let settingsTab = app.buttons["Settings"]
-        XCTAssertTrue(settingsTab.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(settingsTab.waitForExistence(timeout: TestConstants.shortTimeout))
         settingsTab.tap()
         
         assertOnSettingsView(app: app)
         
         let deleteAccountButton = app.buttons["DeleteAccountButton"]
-        XCTAssertTrue(deleteAccountButton.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(deleteAccountButton.waitForExistence(timeout: TestConstants.shortTimeout))
         deleteAccountButton.tap()
         
         let confirmDeleteAccountButton = app.buttons["ConfirmDeleteAccountButton"].firstMatch
-        XCTAssertTrue(confirmDeleteAccountButton.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(confirmDeleteAccountButton.waitForExistence(timeout: TestConstants.shortTimeout))
         confirmDeleteAccountButton.tap()
         
         assertOnWelcomeView(app: app)
@@ -298,23 +297,23 @@ final class Positive_Only_SocialUITests: XCTestCase {
         assertOnHomeView(app: app)
         
         let newPostTab = app.buttons["Post"]
-        XCTAssertTrue(newPostTab.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(newPostTab.waitForExistence(timeout: TestConstants.shortTimeout))
         newPostTab.tap()
         
         assertOnNewPostView(app: app)
         
         let captionTextEditor = app.textViews["CaptionTextEditor"]
-        XCTAssertTrue(captionTextEditor.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(captionTextEditor.waitForExistence(timeout: TestConstants.shortTimeout))
         captionTextEditor.tap()
         typeText(element: captionTextEditor, text: postText)
         
         // Find the photo picker's main view (identifier may vary)
         let picker = app.buttons["SelectAPhotoPicker"]
-        XCTAssertTrue(picker.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(picker.waitForExistence(timeout: TestConstants.shortTimeout))
         picker.tap()
 
         let sharePostButton = app.buttons["SharePostButton"]
-        XCTAssertTrue(sharePostButton.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(sharePostButton.waitForExistence(timeout: TestConstants.shortTimeout))
         sharePostButton.tap()
 
         assertOnHomeView(app: app)
@@ -326,7 +325,7 @@ final class Positive_Only_SocialUITests: XCTestCase {
         assertOnHomeView(app: app)
         
         let feedTab = app.buttons["Feed"]
-        XCTAssertTrue(feedTab.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(feedTab.waitForExistence(timeout: TestConstants.shortTimeout))
         feedTab.tap()
         
         assertOnFeedView(app: app)
@@ -338,18 +337,18 @@ final class Positive_Only_SocialUITests: XCTestCase {
         // Now, get the specific element at index 0 (the first one)
         let firstPostElement = allPostsQuery.element(boundBy: 0)
         
-        XCTAssertTrue(firstPostElement.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(firstPostElement.waitForExistence(timeout: TestConstants.shortTimeout))
         firstPostElement.tap()
         
         assertOnPostDetailView(app: app)
         
         let addACommentTextField = app.textFields["AddACommentTextFieldToPost"]
-        XCTAssertTrue(addACommentTextField.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(addACommentTextField.waitForExistence(timeout: TestConstants.shortTimeout))
         addACommentTextField.tap()
         typeText(element: addACommentTextField, text: commentText)
         
         let postCommentButton = app.buttons["PostCommentButton"]
-        XCTAssertTrue(postCommentButton.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(postCommentButton.waitForExistence(timeout: TestConstants.shortTimeout))
         postCommentButton.tap()
         
         dismissKeyboardIfPresent(app)
@@ -357,7 +356,7 @@ final class Positive_Only_SocialUITests: XCTestCase {
         // Should be one comment total
         let commentElements = app.staticTexts.matching(identifier: "CommentText")
         expectation(for: NSPredicate(format: "count == 1"), evaluatedWith: commentElements, handler: nil)
-        waitForExpectations(timeout: 10, handler: nil)
+        waitForExpectations(timeout: TestConstants.timeout, handler: nil)
         XCTAssert(commentElements.count == 1, "Expected to find 1 comment, but found \(commentElements.count)")
         
         assertOnPostDetailView(app: app)
@@ -369,7 +368,7 @@ final class Positive_Only_SocialUITests: XCTestCase {
         assertOnHomeView(app: app)
         
         let feedTab = app.buttons["Feed"]
-        XCTAssertTrue(feedTab.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(feedTab.waitForExistence(timeout: TestConstants.shortTimeout))
         feedTab.tap()
         
         assertOnFeedView(app: app)
@@ -381,26 +380,26 @@ final class Positive_Only_SocialUITests: XCTestCase {
         // Now, get the specific element at index 0 (the first one)
         let firstPostElement = allPostsQuery.element(boundBy: 0)
         
-        XCTAssertTrue(firstPostElement.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(firstPostElement.waitForExistence(timeout: TestConstants.shortTimeout))
         firstPostElement.tap()
         
         assertOnPostDetailView(app: app)
         
         // Wait for comments to load
         let replyButton = app.buttons["ReplyToCommentThreadButton"]
-        XCTAssertTrue(replyButton.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(replyButton.waitForExistence(timeout: TestConstants.shortTimeout))
         
         // Tap the Reply button to open the sheet
         replyButton.tap()
         
         // Wait for the reply sheet to appear
         let replySheet = app.navigationBars["Post Reply"]
-        XCTAssertTrue(replySheet.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(replySheet.waitForExistence(timeout: TestConstants.shortTimeout))
         
         // Find the TextEditor in the sheet
         // TextEditor appears as a textView in the accessibility hierarchy
         let replyTextEditor = app.textViews.firstMatch
-        XCTAssertTrue(replyTextEditor.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(replyTextEditor.waitForExistence(timeout: TestConstants.shortTimeout))
         
         // Tap and type the reply
         replyTextEditor.tap()
@@ -408,14 +407,14 @@ final class Positive_Only_SocialUITests: XCTestCase {
         
         // Tap the Send button
         let sendButton = app.buttons["Send"]
-        XCTAssertTrue(sendButton.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(sendButton.waitForExistence(timeout: TestConstants.shortTimeout))
         XCTAssertTrue(sendButton.isEnabled)
         sendButton.tap()
         
         // Should be two comments total
         let commentElements = app.staticTexts.matching(identifier: "CommentText")
         expectation(for: NSPredicate(format: "count == 2"), evaluatedWith: commentElements, handler: nil)
-        waitForExpectations(timeout: 10, handler: nil)
+        waitForExpectations(timeout: TestConstants.timeout, handler: nil)
         XCTAssert(commentElements.count == 2, "Expected to find 2 comments, but found \(commentElements.count)")
         
         assertOnPostDetailView(app: app)
@@ -444,50 +443,50 @@ final class Positive_Only_SocialUITests: XCTestCase {
         try loginUser(app: app, username: testUsername, password: strongPassword, rememberMe: true)
 
         let settingsTab = app.buttons["Settings"]
-        XCTAssertTrue(settingsTab.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(settingsTab.waitForExistence(timeout: TestConstants.shortTimeout))
         settingsTab.tap()
         
         assertOnSettingsView(app: app)
         
         let deleteAccountButton = app.buttons["DeleteAccountButton"]
-        XCTAssertTrue(deleteAccountButton.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(deleteAccountButton.waitForExistence(timeout: TestConstants.shortTimeout))
         deleteAccountButton.tap()
         
         let confirmDeleteAccountButton = app.buttons["ConfirmDeleteAccountButton"].firstMatch
-        XCTAssertTrue(confirmDeleteAccountButton.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(confirmDeleteAccountButton.waitForExistence(timeout: TestConstants.shortTimeout))
         confirmDeleteAccountButton.tap()
         
         assertOnWelcomeView(app: app)
         
         let loginButton = app.buttons["LoginText"]
-        XCTAssertTrue(loginButton.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(loginButton.waitForExistence(timeout: TestConstants.shortTimeout))
         loginButton.tap()
         
         assertOnLoginView(app: app)
         
         let usernameOrEmailTextField = app.textFields["UsernameOrEmailTextField"]
-        XCTAssertTrue(usernameOrEmailTextField.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(usernameOrEmailTextField.waitForExistence(timeout: TestConstants.shortTimeout))
         usernameOrEmailTextField.tap()
         typeText(element: usernameOrEmailTextField, text: testUsername)
         
         let passwordSecureField = app.secureTextFields["PasswordSecureField"]
-        XCTAssertTrue(passwordSecureField.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(passwordSecureField.waitForExistence(timeout: TestConstants.shortTimeout))
         passwordSecureField.tap()
         typeText(element: passwordSecureField, text: strongPassword)
         
         let loginButton2 = app.buttons["LoginButton"]
-        XCTAssertTrue(loginButton2.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(loginButton2.waitForExistence(timeout: TestConstants.shortTimeout))
         loginButton2.tap()
         
-        XCTAssertTrue(app.buttons["LoginFailedOkButton"].waitForExistence(timeout: elementTimeout), "Login should have failed")
+        XCTAssertTrue(app.buttons["LoginFailedOkButton"].waitForExistence(timeout: TestConstants.shortTimeout), "Login should have failed")
         
-        XCTAssertTrue(app.buttons["LoginFailedOkButton"].firstMatch.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(app.buttons["LoginFailedOkButton"].firstMatch.waitForExistence(timeout: TestConstants.shortTimeout))
         app.buttons["LoginFailedOkButton"].firstMatch.tap()
         
         dismissSavePassword(app: app)
         
         let backButton = app.navigationBars.firstMatch.buttons.element(boundBy: 0)
-        XCTAssertTrue(backButton.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(backButton.waitForExistence(timeout: TestConstants.shortTimeout))
         backButton.tap()
         
         dismissSavePassword(app: app)
@@ -507,60 +506,60 @@ final class Positive_Only_SocialUITests: XCTestCase {
         assertOnWelcomeView(app: app)
         
         let loginButton = app.buttons["LoginText"]
-        XCTAssertTrue(loginButton.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(loginButton.waitForExistence(timeout: TestConstants.shortTimeout))
         loginButton.tap()
         
         assertOnLoginView(app: app)
         
         let forgotPasswordButton = app.buttons["ForgotPasswordButton"]
-        XCTAssertTrue(forgotPasswordButton.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(forgotPasswordButton.waitForExistence(timeout: TestConstants.shortTimeout))
         forgotPasswordButton.tap()
         
         // Assert we are on request reset view
-        XCTAssertTrue(app.buttons["RequestResetButton"].waitForExistence(timeout: elementTimeout), "Request reset button should exist")
-        XCTAssertTrue(app.textFields["UsernameOrEmailTextField"].waitForExistence(timeout: elementTimeout), "Username or email text field should exist")
+        XCTAssertTrue(app.buttons["RequestResetButton"].waitForExistence(timeout: TestConstants.shortTimeout), "Request reset button should exist")
+        XCTAssertTrue(app.textFields["UsernameOrEmailTextField"].waitForExistence(timeout: TestConstants.shortTimeout), "Username or email text field should exist")
         
         let usernameOrEmailTextField = app.textFields["UsernameOrEmailTextField"]
-        XCTAssertTrue(usernameOrEmailTextField.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(usernameOrEmailTextField.waitForExistence(timeout: TestConstants.shortTimeout))
         usernameOrEmailTextField.tap()
         typeText(element: usernameOrEmailTextField, text: testUsername)
         
         let requestResetButton = app.buttons["RequestResetButton"]
-        XCTAssertTrue(requestResetButton.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(requestResetButton.waitForExistence(timeout: TestConstants.shortTimeout))
         requestResetButton.tap()
         
         // Assert we are on the verify reset view
-        XCTAssertTrue(app.buttons["VerifyButton"].waitForExistence(timeout: elementTimeout), "Verify button should exist")
-        XCTAssertTrue(app.textFields["6DigitPinTextField"].waitForExistence(timeout: elementTimeout), "6 Digit pin field should exist")
+        XCTAssertTrue(app.buttons["VerifyButton"].waitForExistence(timeout: TestConstants.shortTimeout), "Verify button should exist")
+        XCTAssertTrue(app.textFields["6DigitPinTextField"].waitForExistence(timeout: TestConstants.shortTimeout), "6 Digit pin field should exist")
         
         let sixDigitPinTextField = app.textFields["6DigitPinTextField"]
-        XCTAssertTrue(sixDigitPinTextField.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(sixDigitPinTextField.waitForExistence(timeout: TestConstants.shortTimeout))
         sixDigitPinTextField.tap()
         // We hardcode the test value in StatefulStubbedAPI
         typeText(element: sixDigitPinTextField, text: "100000")
         
         let verifyButton = app.buttons["VerifyButton"]
-        XCTAssertTrue(verifyButton.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(verifyButton.waitForExistence(timeout: TestConstants.shortTimeout))
         verifyButton.tap()
         
         // Assert we are on the reset password view
-        XCTAssertTrue(app.buttons["ResetPasswordAndLoginButton"].waitForExistence(timeout: elementTimeout), "Reset password and login button should exist")
-        XCTAssertTrue(app.textFields["UsernameTextField"].waitForExistence(timeout: elementTimeout), "Username text field should exist")
-        XCTAssertTrue(app.textFields["EmailTextField"].waitForExistence(timeout: elementTimeout), "Email text field should exist")
-        XCTAssertTrue(app.secureTextFields["NewPasswordSecureField"].waitForExistence(timeout: elementTimeout), "New password text field should exist")
+        XCTAssertTrue(app.buttons["ResetPasswordAndLoginButton"].waitForExistence(timeout: TestConstants.shortTimeout), "Reset password and login button should exist")
+        XCTAssertTrue(app.textFields["UsernameTextField"].waitForExistence(timeout: TestConstants.shortTimeout), "Username text field should exist")
+        XCTAssertTrue(app.textFields["EmailTextField"].waitForExistence(timeout: TestConstants.shortTimeout), "Email text field should exist")
+        XCTAssertTrue(app.secureTextFields["NewPasswordSecureField"].waitForExistence(timeout: TestConstants.shortTimeout), "New password text field should exist")
         
         let emailTextField = app.textFields["EmailTextField"]
-        XCTAssertTrue(emailTextField.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(emailTextField.waitForExistence(timeout: TestConstants.shortTimeout))
         emailTextField.tap()
         typeText(element: emailTextField, text: "\(testUsername)@test.com")
         
         let passwordTextField = app.secureTextFields["NewPasswordSecureField"]
-        XCTAssertTrue(passwordTextField.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(passwordTextField.waitForExistence(timeout: TestConstants.shortTimeout))
         passwordTextField.tap()
         typeText(element: passwordTextField, text: newStrongPassword)
         
         let resetPasswordAndLoginButton = app.buttons["ResetPasswordAndLoginButton"]
-        XCTAssertTrue(resetPasswordAndLoginButton.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(resetPasswordAndLoginButton.waitForExistence(timeout: TestConstants.shortTimeout))
         resetPasswordAndLoginButton.tap()
         
         dismissSavePassword(app: app)
@@ -574,23 +573,23 @@ final class Positive_Only_SocialUITests: XCTestCase {
         assertOnWelcomeView(app: app)
         
         let loginButton2 = app.buttons["LoginText"]
-        XCTAssertTrue(loginButton2.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(loginButton2.waitForExistence(timeout: TestConstants.shortTimeout))
         loginButton2.tap()
         
         assertOnLoginView(app: app)
         
         let usernameOrEmailTextField2 = app.textFields["UsernameOrEmailTextField"]
-        XCTAssertTrue(usernameOrEmailTextField.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(usernameOrEmailTextField.waitForExistence(timeout: TestConstants.shortTimeout))
         usernameOrEmailTextField.tap()
         typeText(element: usernameOrEmailTextField2, text: testUsername)
         
         let passwordSecureField = app.secureTextFields["PasswordSecureField"]
-        XCTAssertTrue(passwordSecureField.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(passwordSecureField.waitForExistence(timeout: TestConstants.shortTimeout))
         passwordSecureField.tap()
         typeText(element: passwordSecureField, text: newStrongPassword)
         
         let loginButton3 = app.buttons["LoginButton"]
-        XCTAssertTrue(loginButton3.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(loginButton3.waitForExistence(timeout: TestConstants.shortTimeout))
         loginButton3.tap()
         
         dismissSavePassword(app: app)
@@ -612,12 +611,12 @@ final class Positive_Only_SocialUITests: XCTestCase {
         try loginUser(app: app, username: testUsername, password: strongPassword, rememberMe: false)
         
         let userSearchField = app.searchFields["Search for Users"]
-        XCTAssertTrue(userSearchField.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(userSearchField.waitForExistence(timeout: TestConstants.shortTimeout))
         userSearchField.tap()
         typeText(element: userSearchField, text: otherTestUsername)
         
         let userLink = app.buttons[otherTestUsername]
-        XCTAssertTrue(userLink.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(userLink.waitForExistence(timeout: TestConstants.shortTimeout))
         userLink.tap()
         
         assertOnProfileView(app: app)
@@ -630,7 +629,7 @@ final class Positive_Only_SocialUITests: XCTestCase {
         XCTAssertEqual(followersLabel.label, "0")
         
         // 2. Tap Follow
-        XCTAssertTrue(followButton.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(followButton.waitForExistence(timeout: TestConstants.shortTimeout))
         followButton.tap()
         
         // 3. WAIT for the change (Async logic)
@@ -642,7 +641,7 @@ final class Positive_Only_SocialUITests: XCTestCase {
         waitForExpectations(timeout: 5.0, handler: nil)
         
         // 4. Tap Unfollow
-        XCTAssertTrue(followButton.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(followButton.waitForExistence(timeout: TestConstants.shortTimeout))
         followButton.tap()
         
         // 5. WAIT for it to go back to "0"
@@ -651,12 +650,12 @@ final class Positive_Only_SocialUITests: XCTestCase {
         waitForExpectations(timeout: 5.0, handler: nil)
         
         let backButton = app.navigationBars.firstMatch.buttons.element(boundBy: 0)
-        XCTAssertTrue(backButton.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(backButton.waitForExistence(timeout: TestConstants.shortTimeout))
         backButton.tap()
         
         let homeButton = app.buttons["Home"]
         if homeButton.exists {
-            XCTAssertTrue(homeButton.waitForExistence(timeout: elementTimeout))
+            XCTAssertTrue(homeButton.waitForExistence(timeout: TestConstants.shortTimeout))
             homeButton.tap()
         }
         
@@ -677,7 +676,7 @@ final class Positive_Only_SocialUITests: XCTestCase {
         try loginUser(app: app, username: otherTestUsername, password: strongPassword, rememberMe: false)
         
         let feedTab = app.buttons["Feed"]
-        XCTAssertTrue(feedTab.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(feedTab.waitForExistence(timeout: TestConstants.shortTimeout))
         feedTab.tap()
         
         assertOnFeedView(app: app)
@@ -685,25 +684,25 @@ final class Positive_Only_SocialUITests: XCTestCase {
         // Make sure there is one post in For You and no posts in Following
         // 1. Find the Picker container
         let feedPicker = app.segmentedControls["FeedTypePicker"]
-        XCTAssertTrue(feedPicker.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(feedPicker.waitForExistence(timeout: TestConstants.shortTimeout))
 
         // 2. Find the button INSIDE the picker
         let followingSegment = feedPicker.buttons["Following"]
-        XCTAssertTrue(followingSegment.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(followingSegment.waitForExistence(timeout: TestConstants.shortTimeout))
         followingSegment.tap()
         
         let allPostsQuery = app.buttons.matching(identifier: "FollowingPostImage")
         expectation(for: NSPredicate(format: "count == 0"), evaluatedWith: allPostsQuery, handler: nil)
-        waitForExpectations(timeout: elementTimeout, handler: nil)
+        waitForExpectations(timeout: TestConstants.shortTimeout, handler: nil)
         XCTAssertEqual(allPostsQuery.count, 0)
         
         let forYouPickerTab = feedPicker.buttons["For You"]
-        XCTAssertTrue(forYouPickerTab.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(forYouPickerTab.waitForExistence(timeout: TestConstants.shortTimeout))
         forYouPickerTab.tap()
         
         let allPostsQuery2 = app.buttons.matching(identifier: "ForYouPostImage")
         expectation(for: NSPredicate(format: "count == 1"), evaluatedWith: allPostsQuery2, handler: nil)
-        waitForExpectations(timeout: elementTimeout, handler: nil)
+        waitForExpectations(timeout: TestConstants.shortTimeout, handler: nil)
         XCTAssertEqual(allPostsQuery2.count, 1)
         
         // First, get the query for all elements matching our identifier.
@@ -713,7 +712,7 @@ final class Positive_Only_SocialUITests: XCTestCase {
         // Now, get the specific element at index 0 (the first one)
         let firstPostAuthorElement = allPostAuthorsQuery.element(boundBy: 0)
 
-        XCTAssertTrue(firstPostAuthorElement.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(firstPostAuthorElement.waitForExistence(timeout: TestConstants.shortTimeout))
         firstPostAuthorElement.tap()
 
         assertOnProfileView(app: app)
@@ -726,7 +725,7 @@ final class Positive_Only_SocialUITests: XCTestCase {
         XCTAssertEqual(followersLabel.label, "0")
         
         // 2. Tap Follow
-        XCTAssertTrue(followButton.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(followButton.waitForExistence(timeout: TestConstants.shortTimeout))
         followButton.tap()
         
         // 3. WAIT for the change (Async logic)
@@ -738,7 +737,7 @@ final class Positive_Only_SocialUITests: XCTestCase {
         waitForExpectations(timeout: 5.0, handler: nil)
         
         // 4. Tap Unfollow
-        XCTAssertTrue(followButton.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(followButton.waitForExistence(timeout: TestConstants.shortTimeout))
         followButton.tap()
         
         // 5. WAIT for it to go back to "0"
@@ -747,12 +746,12 @@ final class Positive_Only_SocialUITests: XCTestCase {
         waitForExpectations(timeout: 5.0, handler: nil)
         
         /// We refollow so that we can check that the post now shows up in the "Following" Feed
-        XCTAssertTrue(followButton.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(followButton.waitForExistence(timeout: TestConstants.shortTimeout))
         followButton.tap()
         
         // Go back to FeedView
         let backButton = app.navigationBars.firstMatch.buttons.element(boundBy: 0)
-        XCTAssertTrue(backButton.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(backButton.waitForExistence(timeout: TestConstants.shortTimeout))
         backButton.tap()
         
         assertOnFeedView(app: app)
@@ -760,30 +759,30 @@ final class Positive_Only_SocialUITests: XCTestCase {
         // Make sure there is one post in For You and one post in Following
         // 1. Find the Picker container
         let feedPicker2 = app.segmentedControls["FeedTypePicker"]
-        XCTAssertTrue(feedPicker2.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(feedPicker2.waitForExistence(timeout: TestConstants.shortTimeout))
 
         // 2. Find the button INSIDE the picker
         let followingSegment2 = feedPicker2.buttons["Following"]
-        XCTAssertTrue(followingSegment2.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(followingSegment2.waitForExistence(timeout: TestConstants.shortTimeout))
         followingSegment2.tap()
         
         let allPostsQuery3 = app.buttons.matching(identifier: "FollowingPostImage")
         expectation(for: NSPredicate(format: "count == 1"), evaluatedWith: allPostsQuery3, handler: nil)
-        waitForExpectations(timeout: elementTimeout, handler: nil)
+        waitForExpectations(timeout: TestConstants.shortTimeout, handler: nil)
         XCTAssertEqual(allPostsQuery3.count, 1)
         
         let forYouPickerTab2 = feedPicker2.buttons["For You"]
-        XCTAssertTrue(forYouPickerTab2.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(forYouPickerTab2.waitForExistence(timeout: TestConstants.shortTimeout))
         forYouPickerTab2.tap()
         
         let allPostsQuery4 = app.buttons.matching(identifier: "ForYouPostImage")
         expectation(for: NSPredicate(format: "count == 1"), evaluatedWith: allPostsQuery4, handler: nil)
-        waitForExpectations(timeout: elementTimeout, handler: nil)
+        waitForExpectations(timeout: TestConstants.shortTimeout, handler: nil)
         XCTAssertEqual(allPostsQuery4.count, 1)
         
         let homeButton = app.buttons["Home"]
         if homeButton.exists {
-            XCTAssertTrue(homeButton.waitForExistence(timeout: elementTimeout))
+            XCTAssertTrue(homeButton.waitForExistence(timeout: TestConstants.shortTimeout))
             homeButton.tap()
         }
         
@@ -804,7 +803,7 @@ final class Positive_Only_SocialUITests: XCTestCase {
         try loginUser(app: app, username: otherTestUsername, password: strongPassword, rememberMe: false)
         
         let feedTab = app.buttons["Feed"]
-        XCTAssertTrue(feedTab.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(feedTab.waitForExistence(timeout: TestConstants.shortTimeout))
         feedTab.tap()
         
         assertOnFeedView(app: app)
@@ -816,30 +815,30 @@ final class Positive_Only_SocialUITests: XCTestCase {
         // Now, get the specific element at index 0 (the first one)
         let firstPostElement = allPostsQuery.element(boundBy: 0)
 
-        XCTAssertTrue(firstPostElement.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(firstPostElement.waitForExistence(timeout: TestConstants.shortTimeout))
         firstPostElement.tap()
 
         assertOnPostDetailView(app: app)
         
         let postImage = app.buttons["PostImage"]
-        XCTAssertTrue(postImage.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(postImage.waitForExistence(timeout: TestConstants.shortTimeout))
         postImage.doubleTap()
         
         let postLikesText = app.staticTexts["PostLikesText"]
         XCTAssertEqual(postLikesText.label, "1 likes")
         
-        XCTAssertTrue(postImage.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(postImage.waitForExistence(timeout: TestConstants.shortTimeout))
         postImage.doubleTap()
         
         XCTAssertEqual(postLikesText.label, "0 likes")
         
         let backButton = app.navigationBars.firstMatch.buttons.element(boundBy: 0)
-        XCTAssertTrue(backButton.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(backButton.waitForExistence(timeout: TestConstants.shortTimeout))
         backButton.tap()
         
         let homeButton = app.buttons["Home"]
         if homeButton.exists {
-            XCTAssertTrue(homeButton.waitForExistence(timeout: elementTimeout))
+            XCTAssertTrue(homeButton.waitForExistence(timeout: TestConstants.shortTimeout))
             homeButton.tap()
         }
         
@@ -854,25 +853,25 @@ final class Positive_Only_SocialUITests: XCTestCase {
         try loginUser(app: app, username: testUsername, password: strongPassword, rememberMe: false)
         
         let settingsTab = app.buttons["Settings"]
-        XCTAssertTrue(settingsTab.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(settingsTab.waitForExistence(timeout: TestConstants.shortTimeout))
         settingsTab.tap()
         
         assertOnSettingsView(app: app)
         
         let verifyIdentityButton = app.buttons["VerifyIdentityButton"]
-        XCTAssertTrue(verifyIdentityButton.waitForExistence(timeout: elementTimeout), "Verify Identity button should be present for new user")
+        XCTAssertTrue(verifyIdentityButton.waitForExistence(timeout: TestConstants.shortTimeout), "Verify Identity button should be present for new user")
         verifyIdentityButton.tap()
         
         let submitVerificationButton = app.buttons["SubmitVerificationButton"]
-        XCTAssertTrue(submitVerificationButton.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(submitVerificationButton.waitForExistence(timeout: TestConstants.shortTimeout))
         
         // We just tap verify to send the default date (today)
         submitVerificationButton.tap()
         
         // Wait for success alert
         let successAlert = app.alerts["Identity Verified"]
-        XCTAssertTrue(successAlert.waitForExistence(timeout: elementTimeout))
-        XCTAssertTrue(successAlert.buttons["OK"].waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(successAlert.waitForExistence(timeout: TestConstants.shortTimeout))
+        XCTAssertTrue(successAlert.buttons["OK"].waitForExistence(timeout: TestConstants.shortTimeout))
         successAlert.buttons["OK"].tap()
         
         // Verify Identity submit button should be gone. This is a proxy for the dialog being gone.
@@ -880,7 +879,7 @@ final class Positive_Only_SocialUITests: XCTestCase {
         
         let homeButton = app.buttons["Home"]
         if homeButton.exists {
-            XCTAssertTrue(homeButton.waitForExistence(timeout: elementTimeout))
+            XCTAssertTrue(homeButton.waitForExistence(timeout: TestConstants.shortTimeout))
             homeButton.tap()
         }
         
@@ -903,13 +902,13 @@ final class Positive_Only_SocialUITests: XCTestCase {
         makeCommentOnPost(app: app, commentText: "Comment On a Post")
         
         let firstBackButton = app.navigationBars.buttons.element(boundBy: 0)
-        XCTAssertTrue(firstBackButton.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(firstBackButton.waitForExistence(timeout: TestConstants.shortTimeout))
         firstBackButton.tap()
         
         assertOnFeedView(app: app)
         
         let homeButton = app.buttons["Home"]
-        XCTAssertTrue(homeButton.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(homeButton.waitForExistence(timeout: TestConstants.shortTimeout))
         homeButton.tap()
         
         assertOnHomeView(app: app)
@@ -917,13 +916,13 @@ final class Positive_Only_SocialUITests: XCTestCase {
         makeCommentOnThread(app: app, commentText: "Comment On a Thread")
         
         let backButton2 = app.navigationBars.buttons.element(boundBy: 0)
-        XCTAssertTrue(backButton2.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(backButton2.waitForExistence(timeout: TestConstants.shortTimeout))
         backButton2.tap()
         
         assertOnFeedView(app: app)
         
         let homeButton2 = app.buttons["Home"]
-        XCTAssertTrue(homeButton2.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(homeButton2.waitForExistence(timeout: TestConstants.shortTimeout))
         homeButton2.tap()
         
         assertOnHomeView(app: app)
@@ -933,7 +932,7 @@ final class Positive_Only_SocialUITests: XCTestCase {
         try loginUser(app: app, username: newTestUsername, password: strongPassword, rememberMe: false)
         
         let feedTab = app.buttons["Feed"]
-        XCTAssertTrue(feedTab.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(feedTab.waitForExistence(timeout: TestConstants.shortTimeout))
         feedTab.tap()
         
         assertOnFeedView(app: app)
@@ -945,7 +944,7 @@ final class Positive_Only_SocialUITests: XCTestCase {
         // Now, get the specific element at index 0 (the first one)
         let firstPostElement = allPostsQuery.element(boundBy: 0)
 
-        XCTAssertTrue(firstPostElement.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(firstPostElement.waitForExistence(timeout: TestConstants.shortTimeout))
         firstPostElement.tap()
 
         assertOnPostDetailView(app: app)
@@ -953,14 +952,14 @@ final class Positive_Only_SocialUITests: XCTestCase {
         // First we like and unlike the comment post comment
         let postCommentStackQuery = app.buttons.matching(identifier: "CommentStack")
         let postCommentStack = postCommentStackQuery.element(boundBy: 0)
-        XCTAssertTrue(postCommentStack.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(postCommentStack.waitForExistence(timeout: TestConstants.shortTimeout))
         postCommentStack.doubleTap()
         
         let postCommentLikesTextQuery = app.staticTexts.matching(identifier: "CommentLikesCount")
         let postCommentLikesText = postCommentLikesTextQuery.element(boundBy: 0)
         XCTAssertEqual(postCommentLikesText.label, "1 likes")
         
-        XCTAssertTrue(postCommentStack.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(postCommentStack.waitForExistence(timeout: TestConstants.shortTimeout))
         postCommentStack.doubleTap()
         
         XCTAssertEqual(postCommentLikesText.label, "0 likes")
@@ -968,25 +967,25 @@ final class Positive_Only_SocialUITests: XCTestCase {
         // Then we like and unlike the comment thread comment
         let postCommentStackQuery2 = app.buttons.matching(identifier: "CommentStack")
         let postCommentStack2 = postCommentStackQuery2.element(boundBy: 1)
-        XCTAssertTrue(postCommentStack2.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(postCommentStack2.waitForExistence(timeout: TestConstants.shortTimeout))
         postCommentStack2.doubleTap()
         
         let postCommentLikesTextQuery2 = app.staticTexts.matching(identifier: "CommentLikesCount")
         let postCommentLikesText2 = postCommentLikesTextQuery2.element(boundBy: 1)
         XCTAssertEqual(postCommentLikesText2.label, "1 likes")
         
-        XCTAssertTrue(postCommentStack2.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(postCommentStack2.waitForExistence(timeout: TestConstants.shortTimeout))
         postCommentStack2.doubleTap()
         
         XCTAssertEqual(postCommentLikesText2.label, "0 likes")
         
         let backButton = app.navigationBars.firstMatch.buttons.element(boundBy: 0)
-        XCTAssertTrue(backButton.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(backButton.waitForExistence(timeout: TestConstants.shortTimeout))
         backButton.tap()
         
         let homeButton3 = app.buttons["Home"]
         if homeButton3.exists {
-            XCTAssertTrue(homeButton3.waitForExistence(timeout: elementTimeout))
+            XCTAssertTrue(homeButton3.waitForExistence(timeout: TestConstants.shortTimeout))
             homeButton3.tap()
         }
         
@@ -1009,13 +1008,13 @@ final class Positive_Only_SocialUITests: XCTestCase {
         makeCommentOnPost(app: app, commentText: "Comment On a Post")
         
         let backButton = app.navigationBars.buttons.element(boundBy: 0)
-        XCTAssertTrue(backButton.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(backButton.waitForExistence(timeout: TestConstants.shortTimeout))
         backButton.tap()
         
         assertOnFeedView(app: app)
         
         let homeButton = app.buttons["Home"]
-        XCTAssertTrue(homeButton.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(homeButton.waitForExistence(timeout: TestConstants.shortTimeout))
         homeButton.tap()
         
         assertOnHomeView(app: app)
@@ -1025,7 +1024,7 @@ final class Positive_Only_SocialUITests: XCTestCase {
         try loginUser(app: app, username: newTestUsername, password: strongPassword, rememberMe: false)
         
         let feedTab = app.buttons["Feed"]
-        XCTAssertTrue(feedTab.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(feedTab.waitForExistence(timeout: TestConstants.shortTimeout))
         feedTab.tap()
         
         assertOnFeedView(app: app)
@@ -1037,35 +1036,35 @@ final class Positive_Only_SocialUITests: XCTestCase {
         // Now, get the specific element at index 0 (the first one)
         let firstPostElement = allPostsQuery.element(boundBy: 0)
 
-        XCTAssertTrue(firstPostElement.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(firstPostElement.waitForExistence(timeout: TestConstants.shortTimeout))
         firstPostElement.tap()
 
         assertOnPostDetailView(app: app)
         
         let postImage = app.buttons["PostImage"]
         // 2 second press
-        XCTAssertTrue(postImage.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(postImage.waitForExistence(timeout: TestConstants.shortTimeout))
         postImage.press(forDuration: 2)
         
         let reasonTextField = app.textFields["ProvideAReasonTextField"]
-        XCTAssertTrue(reasonTextField.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(reasonTextField.waitForExistence(timeout: TestConstants.shortTimeout))
         reasonTextField.tap()
         typeText(element: reasonTextField, text: "Report post")
         
         let reportButton = app.buttons["SubmitReportButton"]
-        XCTAssertTrue(reportButton.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(reportButton.waitForExistence(timeout: TestConstants.shortTimeout))
         reportButton.tap()
         
         let reportedCommentIcon = app.images["ReportedPostIcon"]
-        XCTAssertTrue(reportedCommentIcon.waitForExistence(timeout: elementTimeout), "Reported post icon is missing")
+        XCTAssertTrue(reportedCommentIcon.waitForExistence(timeout: TestConstants.shortTimeout), "Reported post icon is missing")
         
         let backButton2 = app.navigationBars.firstMatch.buttons.element(boundBy: 0)
-        XCTAssertTrue(backButton2.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(backButton2.waitForExistence(timeout: TestConstants.shortTimeout))
         backButton2.tap()
         
         let homeButton2 = app.buttons["Home"]
         if homeButton2.exists {
-            XCTAssertTrue(homeButton2.waitForExistence(timeout: elementTimeout))
+            XCTAssertTrue(homeButton2.waitForExistence(timeout: TestConstants.shortTimeout))
             homeButton2.tap()
         }
         
@@ -1088,13 +1087,13 @@ final class Positive_Only_SocialUITests: XCTestCase {
         makeCommentOnPost(app: app, commentText: "Comment On a Post")
         
         let backButton = app.navigationBars.buttons.element(boundBy: 0)
-        XCTAssertTrue(backButton.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(backButton.waitForExistence(timeout: TestConstants.shortTimeout))
         backButton.tap()
         
         assertOnFeedView(app: app)
         
         let homeButton = app.buttons["Home"]
-        XCTAssertTrue(homeButton.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(homeButton.waitForExistence(timeout: TestConstants.shortTimeout))
         homeButton.tap()
         
         assertOnHomeView(app: app)
@@ -1102,7 +1101,7 @@ final class Positive_Only_SocialUITests: XCTestCase {
         makeCommentOnThread(app: app, commentText: "Comment On a Thread")
         
         let backButton2 = app.navigationBars.buttons.element(boundBy: 0)
-        XCTAssertTrue(backButton2.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(backButton2.waitForExistence(timeout: TestConstants.shortTimeout))
         backButton2.tap()
         
         assertOnHomeView(app: app)
@@ -1112,7 +1111,7 @@ final class Positive_Only_SocialUITests: XCTestCase {
         try loginUser(app: app, username: newTestUsername, password: strongPassword, rememberMe: false)
         
         let feedTab = app.buttons["Feed"]
-        XCTAssertTrue(feedTab.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(feedTab.waitForExistence(timeout: TestConstants.shortTimeout))
         feedTab.tap()
         
         assertOnFeedView(app: app)
@@ -1124,7 +1123,7 @@ final class Positive_Only_SocialUITests: XCTestCase {
         // Now, get the specific element at index 0 (the first one)
         let firstPostElement = allPostsQuery.element(boundBy: 0)
 
-        XCTAssertTrue(firstPostElement.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(firstPostElement.waitForExistence(timeout: TestConstants.shortTimeout))
         firstPostElement.tap()
 
         assertOnPostDetailView(app: app)
@@ -1132,49 +1131,49 @@ final class Positive_Only_SocialUITests: XCTestCase {
         let commentStackQuery = app.buttons.matching(identifier: "CommentStack")
         let commentStack = commentStackQuery.element(boundBy: 0)
         // 2 second press
-        XCTAssertTrue(commentStack.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(commentStack.waitForExistence(timeout: TestConstants.shortTimeout))
         commentStack.press(forDuration: 2)
         
         let reasonTextField = app.textFields["ProvideAReasonTextField"]
-        XCTAssertTrue(reasonTextField.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(reasonTextField.waitForExistence(timeout: TestConstants.shortTimeout))
         reasonTextField.tap()
         typeText(element: reasonTextField, text: "Report comment thread")
         
         let reportButton = app.buttons["SubmitReportButton"]
-        XCTAssertTrue(reportButton.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(reportButton.waitForExistence(timeout: TestConstants.shortTimeout))
         reportButton.tap()
         
         let reportedCommentIcon = app.images["ReportedCommentIcon"]
-        XCTAssertTrue(reportedCommentIcon.waitForExistence(timeout: elementTimeout), "Reported comment icon is missing")
+        XCTAssertTrue(reportedCommentIcon.waitForExistence(timeout: TestConstants.shortTimeout), "Reported comment icon is missing")
         
         
         let commentStackQuery2 = app.buttons.matching(identifier: "CommentStack")
         let commentStack2 = commentStackQuery2.element(boundBy: 1)
         // 2 second press
-        XCTAssertTrue(commentStack2.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(commentStack2.waitForExistence(timeout: TestConstants.shortTimeout))
         commentStack2.press(forDuration: 2)
         
         let reasonTextField2 = app.textFields["ProvideAReasonTextField"]
-        XCTAssertTrue(reasonTextField2.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(reasonTextField2.waitForExistence(timeout: TestConstants.shortTimeout))
         reasonTextField2.tap()
         typeText(element: reasonTextField2, text: "Report comment reply")
         
         let reportButton2 = app.buttons["SubmitReportButton"]
-        XCTAssertTrue(reportButton2.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(reportButton2.waitForExistence(timeout: TestConstants.shortTimeout))
         reportButton2.tap()
         
         let reportedCommentIcon2 = app.images.matching(identifier: "ReportedCommentIcon")
         expectation(for: NSPredicate(format: "count == 2"), evaluatedWith: reportedCommentIcon2, handler: nil)
-        waitForExpectations(timeout: elementTimeout, handler: nil)
+        waitForExpectations(timeout: TestConstants.shortTimeout, handler: nil)
         XCTAssertEqual(reportedCommentIcon2.count, 2, "Expected 2 reported comment icons but only found \(reportedCommentIcon2.count)")
         
         let backButton3 = app.navigationBars.firstMatch.buttons.element(boundBy: 0)
-        XCTAssertTrue(backButton3.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(backButton3.waitForExistence(timeout: TestConstants.shortTimeout))
         backButton3.tap()
         
         let homeButton2 = app.buttons["Home"]
         if homeButton2.exists {
-            XCTAssertTrue(homeButton2.waitForExistence(timeout: elementTimeout))
+            XCTAssertTrue(homeButton2.waitForExistence(timeout: TestConstants.shortTimeout))
             homeButton2.tap()
         }
         
@@ -1213,40 +1212,40 @@ final class Positive_Only_SocialUITests: XCTestCase {
         
         // Search for user
         let userSearchField = app.searchFields["Search for Users"]
-        XCTAssertTrue(userSearchField.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(userSearchField.waitForExistence(timeout: TestConstants.shortTimeout))
         userSearchField.tap()
         typeText(element: userSearchField, text: otherTestUsername)
         
         let userLink = app.buttons[otherTestUsername]
-        XCTAssertTrue(userLink.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(userLink.waitForExistence(timeout: TestConstants.shortTimeout))
         userLink.tap()
         
         assertOnProfileView(app: app)
         
         // Initially "Block" button should be visible
         let blockButton = app.buttons["Block"]
-        XCTAssertTrue(blockButton.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(blockButton.waitForExistence(timeout: TestConstants.shortTimeout))
         
         // Click Block
         blockButton.tap()
         
         // Verify changes to "Unblock"
         let unblockButton = app.buttons["Unblock"]
-        XCTAssertTrue(unblockButton.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(unblockButton.waitForExistence(timeout: TestConstants.shortTimeout))
         
         // Click Unblock
         unblockButton.tap()
         
         // Verify changes back to "Block"
-        XCTAssertTrue(blockButton.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(blockButton.waitForExistence(timeout: TestConstants.shortTimeout))
         
         let backButton = app.navigationBars.firstMatch.buttons.element(boundBy: 0)
-        XCTAssertTrue(backButton.waitForExistence(timeout: elementTimeout))
+        XCTAssertTrue(backButton.waitForExistence(timeout: TestConstants.shortTimeout))
         backButton.tap()
         
         let homeButton = app.buttons["Home"]
         if homeButton.exists {
-            XCTAssertTrue(homeButton.waitForExistence(timeout: elementTimeout))
+            XCTAssertTrue(homeButton.waitForExistence(timeout: TestConstants.shortTimeout))
             homeButton.tap()
         }
         

--- a/ios/Positive Only Social/Positive Only SocialUITests/TestConstants.swift
+++ b/ios/Positive Only Social/Positive Only SocialUITests/TestConstants.swift
@@ -1,0 +1,16 @@
+//
+//  TestConstants.swift
+//  Positive Only Social
+//
+
+import Foundation
+
+/// Centralized timeout constants used across all unit and UI tests.
+enum TestConstants {
+    /// 3 seconds — element existence checks and simple UI state transitions.
+    static let shortTimeout: TimeInterval = 3
+    /// 10 seconds — async reload cycles and network-dependent UI updates.
+    static let timeout: TimeInterval = 10
+    /// 30 seconds — heavyweight operations such as app launch or multi-step flows.
+    static let longTimeout: TimeInterval = 30
+}


### PR DESCRIPTION
- Change smiling.social → api.smiling.social in iOS RealAPI.swift and Android Constants.kt
- Fix backend Fields.session_management_token key from "token" to "session_management_token" so auth responses decode correctly on both clients
- Fix backend get_posts_in_feed to use author_username (consistent with other post endpoints)
- Add APIError.serverError(statusCode:serverMessage:) and capture the backend JSON error body in RealAPI.performRequest so error messages surface to the UI instead of being silently dropped
- Fix iOS RegisterBody/VerifyIdentityBody to encode date_of_birth (snake_case) instead of dateOfBirth (camelCase) which the backend never received
- Remove double-encoded APIWrapperResponse/DjangoObject indirection from all iOS view models and auth views; decode plain JSON directly matching the real backend format
- Fix Post.authorUsername CodingKey/SerializedName to "author_username" (was "authorUsername") on both iOS and Android
- Fix PostDetailViewModel CommentFields to use creation_time/updated_time matching the backend field names
- Update StatefulStubbedAPI to return plain JSON matching the real backend format so stub and production paths stay consistent; fix duplicate return statement in unfollowUser


**iOS CI Pipeline (ios-tests.yml)**
Parallel execution & build/test split

Enabled parallel test execution
Split the single job into a build job (build-for-testing) and a test matrix job (test-without-building), with the build artifact uploaded and downloaded between jobs
Test sharding

Started with 1 shard, evolved to 3 (Unit_Tests, UI_Tests_Alpha, UI_Tests_Beta), then 5 (added UI_Tests_Gamma, UI_Tests_Delta) — 12 UI tests split 3 per shard to run in parallel
xctestrun selection

Fixed a bug where bare glob expansion split space-containing filenames and was passed to xcodebuild as extra positional args
Fixed selection logic to use grep "Unit Tests" / grep -v "Unit Tests" to correctly route the unit-only vs default test plan xctestrun to each shard
Failure diagnostics

Added xcpretty to build and test steps with tee *.log | xcpretty; exit ${PIPESTATUS[0]} to preserve exit codes through pipes
Added "Show build failures" and "Show failed tests" steps that grep logs on failure
Fixed the grep pattern from "Test Case" (capital C, never matched) to grep -iE "test case .* failed" (case-insensitive)
Expanded log tail from 150 → 500 lines
Added inline xcresulttool parsing step using a Python heredoc to extract per-assertion failure messages and source locations from the xcresult bundle (since xcodebuild only writes high-level summaries to stdout)
Fixed YAML syntax error caused by python3 -c "..." with multi-line Python — replaced with cat > /tmp/parse_xcresult.py << 'PYEOF' heredoc pattern
Added stderr capture for xcresulttool to diagnose empty JSON output on Xcode 26
Reliability

Added exit ${PIPESTATUS[0]} to the resolvePackageDependencies step to preserve xcodebuild exit code through xcpretty
Added fail-fast: false to the matrix strategy
Added job-level timeouts: build → 30 min, test shards → 90 min


**iOS Test Suite (Positive_Only_SocialUITests.swift)**
Save Password dialog

Added addUIInterruptionMonitor in setUpWithError to globally catch and dismiss "Save Password" / "Not Now" system dialogs whenever they block test interactions — no longer needs to be predicted per-call
Text field reliability

Updated typeText() to triple-tap (select all) any field that already has a value before typing, preventing stale text from accumulating when a step retries
Timeout centralization

Created TestConstants.swift in both test targets (shortTimeout = 3s, timeout = 10s, longTimeout = 30s) — picked up automatically by Xcode's PBXFileSystemSynchronizedRootGroup without modifying .pbxproj
Replaced all hardcoded timeouts in both test files (elementTimeout, 5.0, 1_000_000_000 nanoseconds, etc.) with the appropriate TestConstants value
Changed all unit test init() methods from KeychainHelper() to MockKeychainHelper() for proper test isolation

**App Source (Positive Only Social/)**
**PostDetailViewModel.swift**

Fixed parseDate to handle Django's ISO8601 format (2024-01-15T10:30:45.123456+00:00) — added two-formatter fallback (with/without fractional seconds)
Refactored parseDate to nonisolated static func with locally-created ISO8601DateFormatter instances to satisfy Swift 6 actor isolation rules (formatters are non-Sendable NSObject subclasses, can't be stored in shared state)
Replaced formatter allocation with Date.ISO8601FormatStyle (a value type) to eliminate per-comment formatter churn
Fixed Set.insert unused-result warning with _ = reportedCommentIds.insert(comment.id)

**LoginView.swift / RegisterView.swift**

Fixed error handling so only .serverError(_, message) shows the backend's message to the user; all other APIError cases show a generic friendly string instead of exposing internal status codes

**ResetPasswordView.swift**

Fixed unused binding: let responseData = try await api.resetPassword(...) → _ = try await ...

**StatefulStubbedAPI.swift**

Fixed getCommentsForThread response: field names were comment_creation_time / comment_updated_time but PostDetailViewModel.CommentFields decoder expected creation_time / updated_time, causing all comment dates to fall back to Date()