### PR TITLE
Fix AWS region not configured error in S3 client initialization

### DIFF
--- a/ios/Positive Only Social/Positive Only Social/uploader/AWSManager.swift
+++ b/ios/Positive Only Social/Positive Only Social/uploader/AWSManager.swift
@@ -47,8 +47,14 @@ final class AWSManager {
 
     private init() {
         do {
-            let credentialsResolver = try CognitoAWSCredentialIdentityResolver(identityPoolId: identityPoolId)
-            
+            // The resolver's internal CognitoIdentityClient also needs a region — it won't
+            // pick one up from the environment on a mobile device. Supply it explicitly.
+            let cognitoConfig = try CognitoIdentityClient.Config(region: awsRegion)
+            let credentialsResolver = try CognitoAWSCredentialIdentityResolver(
+                identityPoolId: identityPoolId,
+                cognitoIdentityClientConfig: cognitoConfig
+            )
+
             let configuration = try S3Client.Config(awsCredentialIdentityResolver: credentialsResolver, region: awsRegion)
             
             // Initialize the S3 client


### PR DESCRIPTION
## Summary

- `CognitoAWSCredentialIdentityResolver` internally creates a `CognitoIdentityClient` that resolves its region from the environment (env vars, `~/.aws/config`, instance metadata)
- None of those sources exist on an iOS device, causing the resolver to throw "AWS region not configured" before the `S3Client` is ever constructed
- Fix: pass an explicit `CognitoIdentityClient.Config(region: awsRegion)` to the resolver so the internal client has the region at construction time

## Test plan

- [ ] Build and run on a real device (not simulator) where no AWS environment variables are set
- [ ] Confirm the `✅ AWSManager: S3Client initialized successfully.` log appears on launch
- [ ] Attempt an image upload and confirm it succeeds end-to-end
- [ ] Confirm no "AWS region not configured" error appears in logs or Firebase Crashlytics

🤖 Generated with [Claude Code](https://claude.com/claude-code)