### PR TITLE
ios pos fake backend and login

### DIFF
--- a/ios/Positive Only Social/Positive Only Social/api/Config.swift
+++ b/ios/Positive Only Social/Positive Only Social/api/Config.swift
@@ -24,8 +24,8 @@ func isUnitTesting() -> Bool {
 }
 
 func isTesting() -> Bool {
-    // 1. Check if ANY test is running
-    return ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil ||  /*ProcessInfo.processInfo.environment["TESTMANAGERD_SIM_SOCK"] != nil*/  ProcessInfo.processInfo.environment["XCODE_TEST_PLAN_NAME"] != nil
+    // 1. Check if ANY test is running // We removed the simulator bool so we can test images that are not fakes. 
+    return ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil ||   ProcessInfo.processInfo.environment["XCODE_TEST_PLAN_NAME"] != nil
 }
 
 func isUITesting() -> Bool {

--- a/ios/Positive Only Social/Positive Only Social/api/Config.swift
+++ b/ios/Positive Only Social/Positive Only Social/api/Config.swift
@@ -25,7 +25,7 @@ func isUnitTesting() -> Bool {
 
 func isTesting() -> Bool {
     // 1. Check if ANY test is running
-    return ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil ||  ProcessInfo.processInfo.environment["TESTMANAGERD_SIM_SOCK"] != nil || ProcessInfo.processInfo.environment["XCODE_TEST_PLAN_NAME"] != nil
+    return ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil ||  /*ProcessInfo.processInfo.environment["TESTMANAGERD_SIM_SOCK"] != nil*/  ProcessInfo.processInfo.environment["XCODE_TEST_PLAN_NAME"] != nil
 }
 
 func isUITesting() -> Bool {


### PR DESCRIPTION
WHY? 

We need to have a real URL so we can upload images to the S3 bucket. 


What, removed a flag from the bool check that will not affect our local tests and will allow us to test or send real images to the backend. We don't wanna use fakes here. 