### PR TITLE
Fix AWSManager credential resolver init and xcresulttool CI command

### DIFF
--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -222,7 +222,7 @@ jobs:
           except Exception as e:
               print("(xcresult parse error: " + str(e) + ")")
           PYEOF
-          xcrun xcresulttool get --path TestResults.xcresult --format json \
+          xcrun xcresulttool get object --legacy --path TestResults.xcresult --format json \
             > /tmp/xcresult.json 2>/tmp/xcresult_err.txt || true
           if [ -s /tmp/xcresult.json ]; then
             python3 /tmp/parse_xcresult.py < /tmp/xcresult.json
@@ -231,7 +231,7 @@ jobs:
             cat /tmp/xcresult_err.txt || true
             echo ""
             echo "--- Trying legacy invocation ---"
-            xcrun xcresulttool get --path TestResults.xcresult \
+            xcrun xcresulttool get object --legacy --path TestResults.xcresult \
               > /tmp/xcresult_legacy.txt 2>&1 || true
             head -30 /tmp/xcresult_legacy.txt || true
           fi

--- a/ios/Positive Only Social/Positive Only Social/uploader/AWSManager.swift
+++ b/ios/Positive Only Social/Positive Only Social/uploader/AWSManager.swift
@@ -49,10 +49,9 @@ final class AWSManager {
         do {
             // The resolver's internal CognitoIdentityClient also needs a region — it won't
             // pick one up from the environment on a mobile device. Supply it explicitly.
-            let cognitoConfig = try CognitoIdentityClient.Config(region: awsRegion)
             let credentialsResolver = try CognitoAWSCredentialIdentityResolver(
                 identityPoolId: identityPoolId,
-                cognitoIdentityClientConfig: cognitoConfig
+                region: awsRegion
             )
 
             let configuration = try S3Client.Config(awsCredentialIdentityResolver: credentialsResolver, region: awsRegion)

--- a/ios/Positive Only Social/Positive Only Social/uploader/AWSManager.swift
+++ b/ios/Positive Only Social/Positive Only Social/uploader/AWSManager.swift
@@ -51,7 +51,7 @@ final class AWSManager {
             // pick one up from the environment on a mobile device. Supply it explicitly.
             let credentialsResolver = try CognitoAWSCredentialIdentityResolver(
                 identityPoolId: identityPoolId,
-                region: awsRegion
+                identityPoolRegion: awsRegion
             )
 
             let configuration = try S3Client.Config(awsCredentialIdentityResolver: credentialsResolver, region: awsRegion)


### PR DESCRIPTION
## Summary

- **AWSManager.swift**: `CognitoAWSCredentialIdentityResolver` init does not accept a `cognitoIdentityClientConfig` parameter. Replaced the intermediate `CognitoIdentityClient.Config` creation with passing `awsRegion` directly as the `region` argument to the resolver.
- **ios-tests.yml**: `xcresulttool get` is deprecated in Xcode 26 and errors without the `get object --legacy` subcommand form. Updated both the primary JSON invocation and the fallback plain-text invocation accordingly.

## Test plan

- [ ] Build the iOS target — AWSManager should compile cleanly with the updated resolver init.
- [ ] Trigger CI on a PR and confirm the "Show failed tests" step no longer errors on the `xcresulttool` invocation when tests fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)