### PR TITLE
Use generic login failure message

### DIFF
--- a/backend/user_system/tests/test_login_view.py
+++ b/backend/user_system/tests/test_login_view.py
@@ -56,11 +56,24 @@ class LoginUserTests(PositiveOnlySocialTestCase):
         Tests that a correctly formatted but incorrect password fails.
         """
         data = self.valid_data.copy()
-        data['password'] = "CorrectFormatButWrongPassword123!"
+        data['password'] = "CorrectFormatButWrongPassword123$"
 
         response = self.client.post(self.url, data=data, content_type='application/json')
 
         self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json().get('error'), "Invalid username or password")
+
+    def test_unknown_username_or_email_returns_generic_bad_response(self):
+        """
+        Tests that an unknown account does not reveal whether the username/email exists.
+        """
+        data = self.valid_data.copy()
+        data['username_or_email'] = "UnknownUser123"
+
+        response = self.client.post(self.url, data=data, content_type='application/json')
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json().get('error'), "Invalid username or password")
 
     def test_invalid_remember_me_returns_bad_response(self):
         """

--- a/backend/user_system/tests/test_reset_password_views.py
+++ b/backend/user_system/tests/test_reset_password_views.py
@@ -147,7 +147,7 @@ class ResetPasswordTests(PositiveOnlySocialTestCase):
         }
         response = self.client.post(login_url, data=old_login_data, content_type='application/json')
         self.assertEqual(response.status_code, 400)
-        self.assertIn("Password was not correct", response.json().get('error', ''))
+        self.assertEqual(response.json().get('error'), "Invalid username or password")
 
         # b) Try to log in with the NEW password (should succeed)
         new_login_data = {

--- a/backend/user_system/views.py
+++ b/backend/user_system/views.py
@@ -320,7 +320,7 @@ def login_user(request):
     if existing is not None:
         if not check_password(password, existing.password):
             logger.warning(f"Login failed: Password was not correct for user_id: {existing.id}")
-            return log_and_return_json("login_user", {'error': "Password was not correct"}, status=400)
+            return log_and_return_json("login_user", {'error': "Invalid username or password"}, status=400)
 
         login(request, existing)  # Logs into Django's session auth
 
@@ -342,7 +342,7 @@ def login_user(request):
         return log_and_return_json("login_user", response_data)
     else:
         logger.warning("Login failed: No user exists with that information")
-        return log_and_return_json("login_user", {'error': "No user exists with that information"}, status=400)
+        return log_and_return_json("login_user", {'error': "Invalid username or password"}, status=400)
 
 
 @csrf_exempt


### PR DESCRIPTION
## Summary
- return the same generic error for unknown username/email and wrong password
- keep the detailed reason in server logs only
- add login coverage for incorrect-password and unknown-account responses
- update the password-reset regression expectation after old-password login fails

Fixes #97.

## Verification
- `python3 -m pip install --user -r requirements.txt`
- `python3 manage.py test user_system.tests.test_login_view user_system.tests.test_reset_password_views`
- `git diff --check`