### PR TITLE
Log S3 key in image classifier and fix image compressor tests

### DIFF
--- a/backend/tests/test_image_compressor.py
+++ b/backend/tests/test_image_compressor.py
@@ -27,13 +27,15 @@ def test_lambda_handler_success(mock_s3_client, monkeypatch):
     source_bucket = 'source-bucket'
     source_key = 'input.jpg'
     dest_bucket = 'dest-bucket'
+    target_size_kb = 50
 
     monkeypatch.setenv('DEST_BUCKET', dest_bucket)
-    monkeypatch.setenv('TARGET_SIZE_KB', '500')
+    monkeypatch.setenv('TARGET_SIZE_KB', str(target_size_kb))
 
-    img = Image.new('RGB', (1000, 1000), color='red')
+    # Large image so compression loop must reduce it below target_size_kb
+    img = Image.new('RGB', (2000, 2000), color='red')
     img_byte_arr = io.BytesIO()
-    img.save(img_byte_arr, format='JPEG')
+    img.save(img_byte_arr, format='JPEG', quality=95)
     img_data = img_byte_arr.getvalue()
 
     mock_s3_client.get_object.return_value = {'Body': io.BytesIO(img_data)}
@@ -45,9 +47,14 @@ def test_lambda_handler_success(mock_s3_client, monkeypatch):
     assert body['message'] == 'Image compressed successfully'
     assert body['source'] == f"{source_bucket}/{source_key}"
     assert body['destination'] == f"{dest_bucket}/{source_key}"
+    assert body['final_size_kb'] <= target_size_kb
 
     mock_s3_client.get_object.assert_called_once_with(Bucket=source_bucket, Key=source_key)
     mock_s3_client.put_object.assert_called_once()
+    _, put_kwargs = mock_s3_client.put_object.call_args
+    assert put_kwargs['Bucket'] == dest_bucket
+    assert put_kwargs['Key'] == source_key
+    assert put_kwargs['ContentType'] == 'image/jpeg'
 
 
 def test_lambda_handler_skips_non_image(mock_s3_client, monkeypatch):
@@ -61,7 +68,7 @@ def test_lambda_handler_skips_non_image(mock_s3_client, monkeypatch):
 
 
 def test_lambda_handler_missing_records_raises():
-    with pytest.raises(Exception):
+    with pytest.raises(KeyError, match='Records'):
         lambda_handler({}, None)
 
 
@@ -83,5 +90,7 @@ def test_lambda_handler_non_rgb(mock_s3_client, monkeypatch):
 
     assert result['statusCode'] == 200
     mock_s3_client.put_object.assert_called_once()
-    _, kwargs = mock_s3_client.put_object.call_args
-    assert kwargs['ContentType'] == 'image/jpeg'
+    _, put_kwargs = mock_s3_client.put_object.call_args
+    assert put_kwargs['Bucket'] == dest_bucket
+    assert put_kwargs['Key'] == source_key
+    assert put_kwargs['ContentType'] == 'image/jpeg'

--- a/backend/tests/test_image_compressor.py
+++ b/backend/tests/test_image_compressor.py
@@ -5,96 +5,83 @@ import json
 from PIL import Image
 from tools.image_compressor import lambda_handler
 
-@pytest.fixture
-def mock_s3():
-    with patch('boto3.client') as mock_client:
-        yield mock_client()
 
-def test_lambda_handler_success(mock_s3):
-    # Setup
+def make_s3_event(bucket, key):
+    return {
+        'Records': [{
+            's3': {
+                'bucket': {'name': bucket},
+                'object': {'key': key}
+            }
+        }]
+    }
+
+
+@pytest.fixture
+def mock_s3_client():
+    with patch('boto3.client') as mock_client:
+        yield mock_client.return_value
+
+
+def test_lambda_handler_success(mock_s3_client, monkeypatch):
     source_bucket = 'source-bucket'
     source_key = 'input.jpg'
     dest_bucket = 'dest-bucket'
-    dest_key = 'output.jpg'
-    
-    event = {
-        'source_bucket': source_bucket,
-        'source_key': source_key,
-        'dest_bucket': dest_bucket,
-        'dest_key': dest_key,
-        'target_size_kb': 50
-    }
-    
-    # Create a dummy image
+
+    monkeypatch.setenv('DEST_BUCKET', dest_bucket)
+    monkeypatch.setenv('TARGET_SIZE_KB', '500')
+
     img = Image.new('RGB', (1000, 1000), color='red')
     img_byte_arr = io.BytesIO()
     img.save(img_byte_arr, format='JPEG')
     img_data = img_byte_arr.getvalue()
-    
-    # Mock S3 response
-    mock_s3.get_object.return_value = {
-        'Body': io.BytesIO(img_data)
-    }
-    
-    # Execute
-    result = lambda_handler(event, None)
-    
-    # Assert
+
+    mock_s3_client.get_object.return_value = {'Body': io.BytesIO(img_data)}
+
+    result = lambda_handler(make_s3_event(source_bucket, source_key), None)
+
     assert result['statusCode'] == 200
     body = json.loads(result['body'])
     assert body['message'] == 'Image compressed successfully'
     assert body['source'] == f"{source_bucket}/{source_key}"
-    assert body['destination'] == f"{dest_bucket}/{dest_key}"
-    
-    mock_s3.get_object.assert_called_once_with(Bucket=source_bucket, Key=source_key)
-    mock_s3.put_object.assert_called_once()
-    
-    # Check that the uploaded data is smaller than the input data
-    args, kwargs = mock_s3.put_object.call_args
-    uploaded_body = kwargs['Body']
-    uploaded_body.seek(0, io.SEEK_END)
-    assert uploaded_body.tell() / 1024 <= 50
+    assert body['destination'] == f"{dest_bucket}/{source_key}"
 
-def test_lambda_handler_missing_params():
-    event = {
-        'source_bucket': 'bucket'
-        # Missing other required params
-    }
-    
-    result = lambda_handler(event, None)
-    
-    assert result['statusCode'] == 400
-    body = json.loads(result['body'])
-    assert 'Missing required parameters' in body['error']
+    mock_s3_client.get_object.assert_called_once_with(Bucket=source_bucket, Key=source_key)
+    mock_s3_client.put_object.assert_called_once()
 
-def test_lambda_handler_non_rgb(mock_s3):
-    # Setup - RGBA image
+
+def test_lambda_handler_skips_non_image(mock_s3_client, monkeypatch):
+    monkeypatch.setenv('DEST_BUCKET', 'dest-bucket')
+
+    result = lambda_handler(make_s3_event('source-bucket', 'document.pdf'), None)
+
+    assert result['statusCode'] == 200
+    assert result['body'] == 'Skipped non-image'
+    mock_s3_client.get_object.assert_not_called()
+
+
+def test_lambda_handler_missing_records_raises():
+    with pytest.raises(Exception):
+        lambda_handler({}, None)
+
+
+def test_lambda_handler_non_rgb(mock_s3_client, monkeypatch):
     source_bucket = 'source-bucket'
     source_key = 'input.png'
     dest_bucket = 'dest-bucket'
-    dest_key = 'output.jpg'
-    
-    event = {
-        'source_bucket': source_bucket,
-        'source_key': source_key,
-        'dest_bucket': dest_bucket,
-        'dest_key': dest_key
-    }
-    
+
+    monkeypatch.setenv('DEST_BUCKET', dest_bucket)
+
     img = Image.new('RGBA', (100, 100), color=(255, 0, 0, 255))
     img_byte_arr = io.BytesIO()
     img.save(img_byte_arr, format='PNG')
     img_data = img_byte_arr.getvalue()
-    
-    mock_s3.get_object.return_value = {
-        'Body': io.BytesIO(img_data)
-    }
-    
-    # Execute
-    result = lambda_handler(event, None)
-    
-    # Assert
+
+    mock_s3_client.get_object.return_value = {'Body': io.BytesIO(img_data)}
+
+    result = lambda_handler(make_s3_event(source_bucket, source_key), None)
+
     assert result['statusCode'] == 200
-    mock_s3.put_object.assert_called_once()
-    args, kwargs = mock_s3.put_object.call_args
+    mock_s3_client.put_object.assert_called_once()
+    _, kwargs = mock_s3_client.put_object.call_args
     assert kwargs['ContentType'] == 'image/jpeg'

--- a/backend/user_system/classifiers/image_classifier.py
+++ b/backend/user_system/classifiers/image_classifier.py
@@ -66,6 +66,7 @@ def is_image_positive(image_url):
             return image_url == POSITIVE_IMAGE_URL
 
         # Download image from S3
+        logger.info(f"Fetching image from S3 with key: {key}")
         response = s3.get_object(Bucket=bucket_name, Key=key)
         image_data = response['Body'].read()
         image = Image.open(BytesIO(image_data))


### PR DESCRIPTION
## Summary

- Added an `info` log line in `image_classifier.py` that records the S3 key before each `get_object` call, making S3 fetch failures easier to trace in logs.
- Rewrote `test_image_compressor.py` to match the actual `lambda_handler` implementation.

## What changed in the tests

The existing tests used an event structure and mock setup that didn't match how `lambda_handler` actually works:

| Before | After |
|---|---|
| Direct params in event (`source_bucket`, `dest_bucket`, etc.) | S3 trigger format (`Records[0]['s3']`) |
| `DEST_BUCKET` not set — relied on event key that doesn't exist | `DEST_BUCKET` / `TARGET_SIZE_KB` set via `monkeypatch.setenv` |
| `mock_client()` (double-call, wrong object) | `mock_client.return_value` (correct target) |
| `test_lambda_handler_missing_params` expected HTTP 400 | Handler raises on missing records — replaced with `pytest.raises` |
| No test for non-image skip path | Added `test_lambda_handler_skips_non_image` |
| `destination` asserted against `output.jpg` | Asserted against `source_key` (handler uses `dest_key = source_key`) |

## Reviewer notes

No logic was changed in `image_compressor.py` itself — only the log line in `image_classifier.py` and the test file.