### PR TITLE
Return username from login endpoint and store it correctly on clients

### DIFF
--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/api/StatefulStubbedAPI.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/api/StatefulStubbedAPI.kt
@@ -149,7 +149,7 @@ class StatefulStubbedAPI : PositiveOnlySocialAPI {
             loginCookies.add(LoginCookieMock(seriesId, cookieToken, newUser.id))
         }
 
-        return Response.success(AuthResponse(sessionToken, seriesId, cookieToken))
+        return Response.success(AuthResponse(sessionToken, newUser.username, seriesId, cookieToken))
     }
 
     override suspend fun loginUser(request: LoginRequest): Response<AuthResponse> {
@@ -176,7 +176,7 @@ class StatefulStubbedAPI : PositiveOnlySocialAPI {
         // Auto-set the token for convenience in this stateful stub
         simulatedAuthToken = sessionToken
 
-        return Response.success(AuthResponse(sessionToken, seriesId, cookieToken))
+        return Response.success(AuthResponse(sessionToken, user.username, seriesId, cookieToken))
     }
 
     override suspend fun loginUserWithRememberMe(request: TokenRefreshRequest): Response<TokenRefreshResponse> {

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/model/Models.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/model/Models.kt
@@ -20,7 +20,7 @@ data class IdentityVerificationRequest(
 
 data class AuthResponse(
     @SerializedName("session_management_token") val sessionToken: String,
-    val username: String,
+    val username: String?,
     @SerializedName("series_identifier") val seriesIdentifier: String?,
     @SerializedName("login_cookie_token") val loginCookieToken: String?
 )

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/model/Models.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/model/Models.kt
@@ -20,6 +20,7 @@ data class IdentityVerificationRequest(
 
 data class AuthResponse(
     @SerializedName("session_management_token") val sessionToken: String,
+    val username: String,
     @SerializedName("series_identifier") val seriesIdentifier: String?,
     @SerializedName("login_cookie_token") val loginCookieToken: String?
 )

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/auth/LoginScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/auth/LoginScreen.kt
@@ -124,7 +124,7 @@ fun LoginScreen(
                                 if (response.isSuccessful) {
                                     val session = UserSession(
                                         sessionToken = response.body()?.sessionToken ?: "dummy_token",
-                                        username = usernameOrEmail,
+                                        username = response.body()?.username ?: usernameOrEmail,
                                         isIdentityVerified = false
                                     )
                                     authManager.login(session)

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/preview/PreviewHelpers.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/preview/PreviewHelpers.kt
@@ -27,6 +27,7 @@ class MockPositiveOnlySocialAPI : PositiveOnlySocialAPI {
         return Response.success(
             AuthResponse(
                 sessionToken = "mock_session_token",
+                username = request.usernameOrEmail,
                 seriesIdentifier = "mock_series_id",
                 loginCookieToken = "mock_login_cookie"
             )
@@ -46,6 +47,7 @@ class MockPositiveOnlySocialAPI : PositiveOnlySocialAPI {
         return Response.success(
             AuthResponse(
                 sessionToken = "mock_session_token",
+                username = request.username,
                 seriesIdentifier = "mock_series_id",
                 loginCookieToken = "mock_login_cookie"
             )

--- a/backend/user_system/tests/test_login_view.py
+++ b/backend/user_system/tests/test_login_view.py
@@ -112,10 +112,12 @@ class LoginUserTests(PositiveOnlySocialTestCase):
         self.assertIn(Fields.series_identifier, fields)
         self.assertIn(Fields.login_cookie_token, fields)
         self.assertIn(Fields.session_management_token, fields)
+        self.assertIn(Fields.username, fields)
 
         self.assertTrue(is_valid_pattern(fields[Fields.series_identifier], Patterns.uuid4))
         self.assertTrue(is_valid_pattern(fields[Fields.login_cookie_token], Patterns.alphanumeric))
         self.assertTrue(is_valid_pattern(fields[Fields.session_management_token], Patterns.alphanumeric))
+        self.assertEqual(fields[Fields.username], self.local_username)
 
     def test_user_without_remember_me_and_with_username_returns_good_response(self):
         """
@@ -128,7 +130,9 @@ class LoginUserTests(PositiveOnlySocialTestCase):
 
         fields = response.json()
         self.assertIn(Fields.session_management_token, fields)
+        self.assertIn(Fields.username, fields)
         self.assertTrue(is_valid_pattern(fields[Fields.session_management_token], Patterns.alphanumeric))
+        self.assertEqual(fields[Fields.username], self.local_username)
 
         # Should not include "remember me" fields
         self.assertNotIn(Fields.login_cookie_token, fields)
@@ -150,10 +154,12 @@ class LoginUserTests(PositiveOnlySocialTestCase):
         self.assertIn(Fields.series_identifier, fields)
         self.assertIn(Fields.login_cookie_token, fields)
         self.assertIn(Fields.session_management_token, fields)
+        self.assertIn(Fields.username, fields)
 
         self.assertTrue(is_valid_pattern(fields[Fields.series_identifier], Patterns.uuid4))
         self.assertTrue(is_valid_pattern(fields[Fields.login_cookie_token], Patterns.alphanumeric))
         self.assertTrue(is_valid_pattern(fields[Fields.session_management_token], Patterns.alphanumeric))
+        self.assertEqual(fields[Fields.username], self.local_username)
 
     def test_user_without_remember_me_and_with_email_returns_good_response(self):
         """
@@ -168,7 +174,9 @@ class LoginUserTests(PositiveOnlySocialTestCase):
 
         fields = response.json()
         self.assertIn(Fields.session_management_token, fields)
+        self.assertIn(Fields.username, fields)
         self.assertTrue(is_valid_pattern(fields[Fields.session_management_token], Patterns.alphanumeric))
+        self.assertEqual(fields[Fields.username], self.local_username)
 
         self.assertNotIn(Fields.login_cookie_token, fields)
         self.assertNotIn(Fields.series_identifier, fields)

--- a/backend/user_system/views.py
+++ b/backend/user_system/views.py
@@ -332,7 +332,8 @@ def login_user(request):
         new_session = existing.session_set.create(management_token=generate_management_token(), ip=ip)
 
         response_data = {
-            Fields.session_management_token: new_session.management_token
+            Fields.session_management_token: new_session.management_token,
+            Fields.username: existing.username
         }
         if remember_me and new_login_cookie:
             response_data[Fields.series_identifier] = new_login_cookie.series_identifier

--- a/ios/Positive Only Social/Positive Only Social/LoginView.swift
+++ b/ios/Positive Only Social/Positive Only Social/LoginView.swift
@@ -57,7 +57,7 @@ struct LoginView: View {
                 let loginDetails = try JSONDecoder().decode(LoginResponseFields.self, from: responseData)
                 
                 // MARK: - Securely Store Token in Keychain
-                authManager.login(with: UserSession(sessionToken: loginDetails.sessionManagementToken, username: usernameOrEmail, isIdentityVerified: false))
+                authManager.login(with: UserSession(sessionToken: loginDetails.sessionManagementToken, username: loginDetails.username, isIdentityVerified: false))
                 
                 print("✅ Session token securely saved to Keychain.")
                 

--- a/ios/Positive Only Social/Positive Only Social/LoginView.swift
+++ b/ios/Positive Only Social/Positive Only Social/LoginView.swift
@@ -57,7 +57,7 @@ struct LoginView: View {
                 let loginDetails = try JSONDecoder().decode(LoginResponseFields.self, from: responseData)
                 
                 // MARK: - Securely Store Token in Keychain
-                authManager.login(with: UserSession(sessionToken: loginDetails.sessionManagementToken, username: loginDetails.username, isIdentityVerified: false))
+                authManager.login(with: UserSession(sessionToken: loginDetails.sessionManagementToken, username: loginDetails.username ?? usernameOrEmail, isIdentityVerified: false))
                 
                 print("✅ Session token securely saved to Keychain.")
                 

--- a/ios/Positive Only Social/Positive Only Social/api/Models.swift
+++ b/ios/Positive Only Social/Positive Only Social/api/Models.swift
@@ -13,11 +13,13 @@ import Foundation
 /// Properties are optional since "remember me" tokens may not be present.
 struct LoginResponseFields: Codable {
     let sessionManagementToken: String
+    let username: String
     let seriesIdentifier: String?
     let loginCookieToken: String?
 
     enum CodingKeys: String, CodingKey {
         case sessionManagementToken = "session_management_token"
+        case username
         case seriesIdentifier = "series_identifier"
         case loginCookieToken = "login_cookie_token"
     }

--- a/ios/Positive Only Social/Positive Only Social/api/Models.swift
+++ b/ios/Positive Only Social/Positive Only Social/api/Models.swift
@@ -13,7 +13,7 @@ import Foundation
 /// Properties are optional since "remember me" tokens may not be present.
 struct LoginResponseFields: Codable {
     let sessionManagementToken: String
-    let username: String
+    let username: String?
     let seriesIdentifier: String?
     let loginCookieToken: String?
 

--- a/ios/Positive Only Social/Positive Only Social/api/StatefulStubbedAPI.swift
+++ b/ios/Positive Only Social/Positive Only Social/api/StatefulStubbedAPI.swift
@@ -168,15 +168,19 @@ final class StatefulStubbedAPI: Networking {
         if wantsRememberMe {
             let cookie = MockLoginCookie(seriesIdentifier: UUID().uuidString, token: generateToken(), userId: user.id)
             loginCookies.append(cookie)
-            struct Fields: Codable { let series_identifier, login_cookie_token, session_management_token: String }
+            struct Fields: Codable { let series_identifier, login_cookie_token, session_management_token, username: String }
             return try createSerializedResponse(fields: Fields(
                 series_identifier: cookie.seriesIdentifier,
                 login_cookie_token: cookie.token,
-                session_management_token: newSession.managementToken
+                session_management_token: newSession.managementToken,
+                username: user.username
             ))
         } else {
-            struct Fields: Codable { let session_management_token: String }
-            return try createSerializedResponse(fields: Fields(session_management_token: newSession.managementToken))
+            struct Fields: Codable { let session_management_token, username: String }
+            return try createSerializedResponse(fields: Fields(
+                session_management_token: newSession.managementToken,
+                username: user.username
+            ))
         }
     }
 

--- a/ios/Positive Only Social/Positive Only Social/preview/PreviewHelpers.swift
+++ b/ios/Positive Only Social/Positive Only Social/preview/PreviewHelpers.swift
@@ -50,6 +50,7 @@ struct MockedAPI: Networking {
     func register(username: String, email: String, password: String, rememberMe: String, ip: String, dateOfBirth: String) async throws -> Data {
         let response = LoginResponseFields(
             sessionManagementToken: "mock_session_token",
+            username: username,
             seriesIdentifier: "mock_series_id",
             loginCookieToken: "mock_login_cookie"
         )
@@ -59,6 +60,7 @@ struct MockedAPI: Networking {
     func loginUser(usernameOrEmail: String, password: String, rememberMe: String, ip: String) async throws -> Data {
         let response = LoginResponseFields(
             sessionManagementToken: "mock_session_token",
+            username: usernameOrEmail,
             seriesIdentifier: "mock_series_id",
             loginCookieToken: "mock_login_cookie"
         )
@@ -68,6 +70,7 @@ struct MockedAPI: Networking {
     func loginUserWithRememberMe(sessionManagementToken: String, seriesIdentifier: String, loginCookieToken: String, ip: String) async throws -> Data {
         let response = LoginResponseFields(
             sessionManagementToken: "new_mock_session",
+            username: "mock_user",
             seriesIdentifier: "mock_series_id",
             loginCookieToken: "new_mock_cookie"
         )


### PR DESCRIPTION
## Summary

- The `login_user` backend endpoint now includes `username` in its response alongside the session token
- iOS `LoginResponseFields` model and `LoginView` updated to decode and use the returned username in the session
- Android `AuthResponse` model and `LoginScreen` updated to decode and use the returned username in the session
- Backend login tests updated to assert `username` is present and equals the correct value for all four happy-path cases (username+remember_me, username only, email+remember_me, email only)

## Why

When a user logs in with their **email**, the frontends were storing the email string as the `username` in `UserSession`. This broke any feature that passes the username to the backend (e.g. `get_posts_for_user`), since the backend looks up users by username, not email.

## Test plan

- [ ] All 10 existing backend login tests pass (`user_system.tests.test_login_view`) — verified locally
- [ ] Login with username → session stores the username ✓
- [ ] Login with email → session now correctly stores the username (not the email) ✓
- [ ] Visiting a profile / loading posts after email-login works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)