### PR TITLE
Expand content moderation rules with new categories and nuanced allowances

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Overview
 
-Social media site that only allows "positive" text and image posts. The guidelines are as follows.
+Social media site that only allows positive or neutral text and image posts. The guidelines are as follows.
 
 1. No swear words
 2. No nudity

--- a/README.md
+++ b/README.md
@@ -9,9 +9,13 @@ Social media site that only allows "positive" text and image posts. The guidelin
 
 1. No swear words
 2. No nudity
-3. No gore
-4. No hate speech
-5. No harassment
-6. No bullying
+3. No sexually suggestive content
+4. No gore
+5. No hate speech
+6. No harassment
+7. No bullying
+8. No misinformation
+
+Neutral content is allowed. Content that starts sad but ends on a happy or hopeful note is also allowed.
 
 These will be updated as time goes on.

--- a/backend/user_system/classifiers/classifier_constants.py
+++ b/backend/user_system/classifiers/classifier_constants.py
@@ -3,3 +3,36 @@ NEGATIVE_IMAGE_URL = 'https://test-bucket.s3.amazonaws.com/negative_image_url.pn
 POSITIVE_TEXT = 'positive'
 NEGATIVE_TEXT = 'negative'
 GEMINI_MODEL = 'gemini-2.5-flash'
+
+_CONTENT_RULES = (
+    "1. No swear words\n"
+    "2. No nudity\n"
+    "3. No sexually suggestive content\n"
+    "4. No gore\n"
+    "5. No hate speech\n"
+    "6. No harassment\n"
+    "7. No bullying\n"
+    "8. No misinformation\n"
+)
+
+_CONTENT_ALLOWANCES = (
+    "Neutral content is acceptable. "
+    "Content that begins sad but ends on a happy or hopeful note is also acceptable.\n"
+)
+
+TEXT_CLASSIFIER_PROMPT = (
+    "Is the following text positive, neutral, or otherwise acceptable? "
+    "Text is acceptable if it follows these rules:\n"
+    + _CONTENT_RULES
+    + _CONTENT_ALLOWANCES
+    + 'Answer with only "True" or "False".\n\n'
+    "Text: \"{text}\""
+)
+
+IMAGE_CLASSIFIER_PROMPT = (
+    "Is this image positive, neutral, or otherwise acceptable? "
+    "An image is acceptable if it follows these rules:\n"
+    + _CONTENT_RULES
+    + _CONTENT_ALLOWANCES
+    + 'Answer with only "True" or "False".'
+)

--- a/backend/user_system/classifiers/image_classifier.py
+++ b/backend/user_system/classifiers/image_classifier.py
@@ -5,7 +5,7 @@ from google import genai
 from PIL import Image
 from io import BytesIO
 from urllib.parse import urlparse
-from .classifier_constants import POSITIVE_IMAGE_URL, GEMINI_MODEL
+from .classifier_constants import POSITIVE_IMAGE_URL, GEMINI_MODEL, IMAGE_CLASSIFIER_PROMPT
 from ..utils import convert_to_bool
 
 logger = logging.getLogger(__name__)
@@ -71,20 +71,7 @@ def is_image_positive(image_url):
         image_data = response['Body'].read()
         image = Image.open(BytesIO(image_data))
 
-        prompt = (
-            "Is this image positive, neutral, or otherwise acceptable? "
-            "An image is acceptable if it follows these rules:\n"
-            "1. No swear words\n"
-            "2. No nudity\n"
-            "3. No sexually suggestive content\n"
-            "4. No gore\n"
-            "5. No hate speech\n"
-            "6. No harassment\n"
-            "7. No bullying\n"
-            "8. No misinformation\n"
-            "Neutral content is acceptable. Content that begins sad but ends on a happy or hopeful note is also acceptable.\n"
-            'Answer with only "True" or "False".'
-        )
+        prompt = IMAGE_CLASSIFIER_PROMPT
         
         response = client.models.generate_content(
             model=GEMINI_MODEL,

--- a/backend/user_system/classifiers/image_classifier.py
+++ b/backend/user_system/classifiers/image_classifier.py
@@ -72,14 +72,17 @@ def is_image_positive(image_url):
         image = Image.open(BytesIO(image_data))
 
         prompt = (
-            "Is this image positive, happy or otherwise makes the user feel good? "
-            "To be considered positive, it must follow these rules:\n"
+            "Is this image positive, neutral, or otherwise acceptable? "
+            "An image is acceptable if it follows these rules:\n"
             "1. No swear words\n"
             "2. No nudity\n"
-            "3. No gore\n"
-            "4. No hate speech\n"
-            "5. No harassment\n"
-            "6. No bullying\n"
+            "3. No sexually suggestive content\n"
+            "4. No gore\n"
+            "5. No hate speech\n"
+            "6. No harassment\n"
+            "7. No bullying\n"
+            "8. No misinformation\n"
+            "Neutral content is acceptable. Content that begins sad but ends on a happy or hopeful note is also acceptable.\n"
             'Answer with only "True" or "False".'
         )
         

--- a/backend/user_system/classifiers/text_classifier.py
+++ b/backend/user_system/classifiers/text_classifier.py
@@ -29,14 +29,17 @@ def is_text_positive(text):
         client = genai.Client(api_key=api_key)
         
         prompt = (
-            "Is the following text positive, happy or otherwise makes the user feel good? "
-            "To be considered positive, it must follow these rules:\n"
+            "Is the following text positive, neutral, or otherwise acceptable? "
+            "Text is acceptable if it follows these rules:\n"
             "1. No swear words\n"
             "2. No nudity\n"
-            "3. No gore\n"
-            "4. No hate speech\n"
-            "5. No harassment\n"
-            "6. No bullying\n"
+            "3. No sexually suggestive content\n"
+            "4. No gore\n"
+            "5. No hate speech\n"
+            "6. No harassment\n"
+            "7. No bullying\n"
+            "8. No misinformation\n"
+            "Neutral content is acceptable. Text that begins sad but ends on a happy or hopeful note is also acceptable.\n"
             'Answer with only "True" or "False".\n\n'
             f'Text: "{text}"'
         )

--- a/backend/user_system/classifiers/text_classifier.py
+++ b/backend/user_system/classifiers/text_classifier.py
@@ -1,7 +1,7 @@
 import os
 import logging
 from google import genai
-from .classifier_constants import POSITIVE_TEXT, GEMINI_MODEL
+from .classifier_constants import POSITIVE_TEXT, GEMINI_MODEL, TEXT_CLASSIFIER_PROMPT
 from ..utils import convert_to_bool
 
 logger = logging.getLogger(__name__)
@@ -28,21 +28,7 @@ def is_text_positive(text):
     try:
         client = genai.Client(api_key=api_key)
         
-        prompt = (
-            "Is the following text positive, neutral, or otherwise acceptable? "
-            "Text is acceptable if it follows these rules:\n"
-            "1. No swear words\n"
-            "2. No nudity\n"
-            "3. No sexually suggestive content\n"
-            "4. No gore\n"
-            "5. No hate speech\n"
-            "6. No harassment\n"
-            "7. No bullying\n"
-            "8. No misinformation\n"
-            "Neutral content is acceptable. Text that begins sad but ends on a happy or hopeful note is also acceptable.\n"
-            'Answer with only "True" or "False".\n\n'
-            f'Text: "{text}"'
-        )
+        prompt = TEXT_CLASSIFIER_PROMPT.format(text=text)
         
         response = client.models.generate_content(
             model=GEMINI_MODEL,

--- a/backend/user_system/tests/test_classifiers.py
+++ b/backend/user_system/tests/test_classifiers.py
@@ -4,7 +4,7 @@ from io import BytesIO
 from PIL import Image
 from ..classifiers.text_classifier import is_text_positive
 from ..classifiers.image_classifier import is_image_positive
-from ..classifiers.classifier_constants import POSITIVE_TEXT, POSITIVE_IMAGE_URL
+from ..classifiers.classifier_constants import POSITIVE_TEXT, POSITIVE_IMAGE_URL, TEXT_CLASSIFIER_PROMPT, IMAGE_CLASSIFIER_PROMPT
 from .test_parent_case import PositiveOnlySocialTestCase
 
 class TestClassifiers(PositiveOnlySocialTestCase):
@@ -119,3 +119,21 @@ class TestClassifiers(PositiveOnlySocialTestCase):
         # Test fallback
         self.assertTrue(is_image_positive(POSITIVE_IMAGE_URL))
         self.assertFalse(is_image_positive("random_image.png"))
+
+    def test_text_classifier_prompt_content(self):
+        for phrase in [
+            "neutral",
+            "sexually suggestive content",
+            "misinformation",
+            "begins sad but ends on a happy or hopeful note",
+        ]:
+            self.assertIn(phrase, TEXT_CLASSIFIER_PROMPT, msg=f"Missing in TEXT_CLASSIFIER_PROMPT: {phrase!r}")
+
+    def test_image_classifier_prompt_content(self):
+        for phrase in [
+            "neutral",
+            "sexually suggestive content",
+            "misinformation",
+            "begins sad but ends on a happy or hopeful note",
+        ]:
+            self.assertIn(phrase, IMAGE_CLASSIFIER_PROMPT, msg=f"Missing in IMAGE_CLASSIFIER_PROMPT: {phrase!r}")


### PR DESCRIPTION
## Summary

- Added **sexually suggestive content** and **misinformation** to the list of prohibited content categories
- Clarified that **neutral content** is allowed (not just strictly positive content)
- Clarified that content **starting sad but ending happy/hopeful** is also allowed
- Updated [README.md](README.md), [image_classifier.py](backend/user_system/classifiers/image_classifier.py), and [text_classifier.py](backend/user_system/classifiers/text_classifier.py) consistently

## Reviewer notes

The classifier prompts were also reframed from "is this positive?" to "is this acceptable?" to better match the broader, more nuanced criteria. This should reduce false negatives on neutral or bittersweet-but-hopeful content while tightening the net around misinformation and sexually suggestive material.

## Test plan

- [ ] Verify existing classifier tests still pass (neutral and positive content should return `True`, negative content should return `False`)
- [ ] Manually test that neutral text/images are now accepted
- [ ] Manually test that misinformation and sexually suggestive content are rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)