### PR TITLE
Add multi-API voting to text and image classifiers

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,7 @@
+anthropic
 boto3
 google-genai
+openai
 Pillow
 django
 pytest

--- a/backend/user_system/classifiers/classifier_constants.py
+++ b/backend/user_system/classifiers/classifier_constants.py
@@ -3,6 +3,8 @@ NEGATIVE_IMAGE_URL = 'https://test-bucket.s3.amazonaws.com/negative_image_url.pn
 POSITIVE_TEXT = 'positive'
 NEGATIVE_TEXT = 'negative'
 GEMINI_MODEL = 'gemini-2.5-flash'
+CLAUDE_MODEL = 'claude-haiku-4-5-20251001'
+OPENAI_MODEL = 'gpt-4o-mini'
 
 _CONTENT_RULES = (
     "1. No swear words\n"

--- a/backend/user_system/classifiers/classifier_utils.py
+++ b/backend/user_system/classifiers/classifier_utils.py
@@ -1,0 +1,134 @@
+import os
+import random
+import logging
+import base64
+from io import BytesIO
+from google import genai
+import anthropic
+import openai as openai_lib
+from .classifier_constants import GEMINI_MODEL, CLAUDE_MODEL, OPENAI_MODEL
+
+logger = logging.getLogger(__name__)
+
+API_GEMINI = 'gemini'
+API_CLAUDE = 'claude'
+API_OPENAI = 'openai'
+
+
+def get_available_apis():
+    available = []
+    if os.environ.get('GEMINI_API_KEY'):
+        available.append(API_GEMINI)
+    if os.environ.get('ANTHROPIC_API_KEY'):
+        available.append(API_CLAUDE)
+    if os.environ.get('OPENAI_API_KEY'):
+        available.append(API_OPENAI)
+    return available
+
+
+def classify_with_voting(available_apis, call_fn):
+    """
+    Picks 2 random APIs and uses majority vote; a 3rd breaks ties if available.
+    Falls back to False with 0 APIs, or uses the sole API with 1.
+    """
+    if not available_apis:
+        return False
+
+    if len(available_apis) == 1:
+        return call_fn(available_apis[0])
+
+    chosen = random.sample(available_apis, 2)
+    remaining = [a for a in available_apis if a not in chosen]
+
+    result_a = call_fn(chosen[0])
+    result_b = call_fn(chosen[1])
+
+    if result_a == result_b:
+        return result_a
+
+    if remaining:
+        return call_fn(remaining[0])
+
+    logger.warning("Two APIs disagreed with no tiebreaker available. Defaulting to False.")
+    return False
+
+
+def call_text_gemini(text, prompt_template):
+    api_key = os.environ.get('GEMINI_API_KEY')
+    client = genai.Client(api_key=api_key)
+    prompt = prompt_template.format(text=text)
+    response = client.models.generate_content(model=GEMINI_MODEL, contents=prompt)
+    return response.text.strip().lower() == 'true'
+
+
+def call_text_claude(text, prompt_template):
+    api_key = os.environ.get('ANTHROPIC_API_KEY')
+    client = anthropic.Anthropic(api_key=api_key)
+    prompt = prompt_template.format(text=text)
+    response = client.messages.create(
+        model=CLAUDE_MODEL,
+        max_tokens=10,
+        messages=[{"role": "user", "content": prompt}]
+    )
+    return response.content[0].text.strip().lower() == 'true'
+
+
+def call_text_openai(text, prompt_template):
+    api_key = os.environ.get('OPENAI_API_KEY')
+    client = openai_lib.OpenAI(api_key=api_key)
+    prompt = prompt_template.format(text=text)
+    response = client.chat.completions.create(
+        model=OPENAI_MODEL,
+        max_tokens=10,
+        messages=[{"role": "user", "content": prompt}]
+    )
+    return response.choices[0].message.content.strip().lower() == 'true'
+
+
+def _image_to_base64_png(image):
+    buffer = BytesIO()
+    image.save(buffer, format='PNG')
+    return base64.standard_b64encode(buffer.getvalue()).decode('utf-8')
+
+
+def call_image_gemini(image, prompt):
+    api_key = os.environ.get('GEMINI_API_KEY')
+    client = genai.Client(api_key=api_key)
+    response = client.models.generate_content(model=GEMINI_MODEL, contents=[prompt, image])
+    return response.text.strip().lower() == 'true'
+
+
+def call_image_claude(image, prompt):
+    api_key = os.environ.get('ANTHROPIC_API_KEY')
+    client = anthropic.Anthropic(api_key=api_key)
+    image_data = _image_to_base64_png(image)
+    response = client.messages.create(
+        model=CLAUDE_MODEL,
+        max_tokens=10,
+        messages=[{
+            "role": "user",
+            "content": [
+                {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": image_data}},
+                {"type": "text", "text": prompt}
+            ]
+        }]
+    )
+    return response.content[0].text.strip().lower() == 'true'
+
+
+def call_image_openai(image, prompt):
+    api_key = os.environ.get('OPENAI_API_KEY')
+    client = openai_lib.OpenAI(api_key=api_key)
+    image_data = _image_to_base64_png(image)
+    response = client.chat.completions.create(
+        model=OPENAI_MODEL,
+        max_tokens=10,
+        messages=[{
+            "role": "user",
+            "content": [
+                {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{image_data}"}},
+                {"type": "text", "text": prompt}
+            ]
+        }]
+    )
+    return response.choices[0].message.content.strip().lower() == 'true'

--- a/backend/user_system/classifiers/image_classifier.py
+++ b/backend/user_system/classifiers/image_classifier.py
@@ -1,40 +1,41 @@
 import os
 import boto3
 import logging
-from google import genai
 from PIL import Image
 from io import BytesIO
 from urllib.parse import urlparse
-from .classifier_constants import POSITIVE_IMAGE_URL, GEMINI_MODEL, IMAGE_CLASSIFIER_PROMPT
+from .classifier_constants import POSITIVE_IMAGE_URL, IMAGE_CLASSIFIER_PROMPT
+from .classifier_utils import (
+    get_available_apis, classify_with_voting,
+    call_image_gemini, call_image_claude, call_image_openai,
+    API_GEMINI, API_CLAUDE, API_OPENAI,
+)
 from ..utils import convert_to_bool
 
 logger = logging.getLogger(__name__)
 
 
 def is_image_positive(image_url):
-    """
-    Determines if the image at the given URL (or S3 key) is positive using Gemini.
-    """
-    api_key = os.environ.get("GEMINI_API_KEY")
-    aws_access_key = os.environ.get("AWS_ACCESS_KEY_ID")
-    aws_secret_key = os.environ.get("AWS_SECRET_ACCESS_KEY")
     testing = os.environ.get("TESTING", False)
-
     testing = testing if isinstance(testing, bool) else convert_to_bool(testing)
 
     if testing:
         return image_url == POSITIVE_IMAGE_URL
 
-    # Fallback if keys are missing
-    if not api_key or not aws_access_key or not aws_secret_key:
-        logger.error("Missing API keys (GEMINI or AWS). Using fallback.")
+    available_apis = get_available_apis()
+
+    if not available_apis:
+        logger.error("No AI API keys available.")
+        return False
+
+    aws_access_key = os.environ.get("AWS_ACCESS_KEY_ID")
+    aws_secret_key = os.environ.get("AWS_SECRET_ACCESS_KEY")
+
+    if not aws_access_key or not aws_secret_key:
+        logger.error("Missing AWS credentials.")
         return False
 
     try:
-        # Initialize Gemini
-        client = genai.Client(api_key=api_key)
-
-        # Initialize S3
         s3 = boto3.client(
             's3',
             aws_access_key_id=aws_access_key,
@@ -42,47 +43,43 @@ def is_image_positive(image_url):
             region_name=os.environ.get("AWS_REGION", "us-east-1")
         )
 
-        # Determine Bucket and Key
         bucket_name = os.environ.get("AWS_STORAGE_BUCKET_NAME")
         key = image_url
 
-        # Attempt to parse if it's a full URL
         parsed = urlparse(image_url)
         if parsed.scheme == 's3':
             bucket_name = parsed.netloc
             key = parsed.path.lstrip('/')
         elif parsed.scheme in ['http', 'https'] and 's3' in parsed.netloc:
-            # Very basic parsing for standard s3 urls: https://bucket.s3.region.amazonaws.com/key
-            # or https://s3.region.amazonaws.com/bucket/key
             if not bucket_name:
-                 # Try to extract from subdomain
-                 parts = parsed.netloc.split('.')
-                 if parts[0] != 's3':
-                     bucket_name = parts[0]
-                     key = parsed.path.lstrip('/')
-        
+                parts = parsed.netloc.split('.')
+                if parts[0] != 's3':
+                    bucket_name = parts[0]
+                    key = parsed.path.lstrip('/')
+
         if not bucket_name:
             logger.error("Could not determine S3 bucket name.")
-            return image_url == POSITIVE_IMAGE_URL
+            return False
 
-        # Download image from S3
-        logger.info(f"Fetching image from S3 with key: {key}")
+        logger.info("Fetching image from S3 with key: %s", key)
         response = s3.get_object(Bucket=bucket_name, Key=key)
         image_data = response['Body'].read()
         image = Image.open(BytesIO(image_data))
 
-        prompt = IMAGE_CLASSIFIER_PROMPT
-        
-        response = client.models.generate_content(
-            model=GEMINI_MODEL,
-            contents=[prompt, image]
-        )
-        
-        answer = response.text.strip().lower()
-        is_positive = (answer == "true")
-        logger.info(f"Gemini image classification returned: {is_positive}")
-        return is_positive
+        def call_api(api_name):
+            try:
+                if api_name == API_GEMINI:
+                    return call_image_gemini(image, IMAGE_CLASSIFIER_PROMPT)
+                if api_name == API_CLAUDE:
+                    return call_image_claude(image, IMAGE_CLASSIFIER_PROMPT)
+                if api_name == API_OPENAI:
+                    return call_image_openai(image, IMAGE_CLASSIFIER_PROMPT)
+            except Exception:
+                logger.exception("Error calling %s API for image classification", api_name)
+                return False
 
-    except Exception as e:
-        logger.exception("Error in image classifier calling Gemini API")
+        return classify_with_voting(available_apis, call_api)
+
+    except Exception:
+        logger.exception("Error in image classifier")
         return False

--- a/backend/user_system/classifiers/text_classifier.py
+++ b/backend/user_system/classifiers/text_classifier.py
@@ -1,45 +1,35 @@
 import os
 import logging
-from google import genai
-from .classifier_constants import POSITIVE_TEXT, GEMINI_MODEL, TEXT_CLASSIFIER_PROMPT
+from .classifier_constants import TEXT_CLASSIFIER_PROMPT
+from .classifier_utils import (
+    get_available_apis, classify_with_voting,
+    call_text_gemini, call_text_claude, call_text_openai,
+    API_GEMINI, API_CLAUDE, API_OPENAI,
+)
 from ..utils import convert_to_bool
 
 logger = logging.getLogger(__name__)
 
 
 def is_text_positive(text):
-    """
-    Determines if the given text is positive using Gemini.
-    """
-
     testing = os.environ.get("TESTING", False)
     testing = testing if isinstance(testing, bool) else convert_to_bool(testing)
 
     if testing:
         return "negative" not in text.lower()
 
-    api_key = os.environ.get("GEMINI_API_KEY")
-    if not api_key:
-        logger.error("GEMINI_API_KEY not found in environment variables.")
-        # Fallback to simple check for testing purposes if API key is missing
-        # In production, this should probably raise an error or handle gracefully
-        return False
+    available_apis = get_available_apis()
 
-    try:
-        client = genai.Client(api_key=api_key)
-        
-        prompt = TEXT_CLASSIFIER_PROMPT.format(text=text)
-        
-        response = client.models.generate_content(
-            model=GEMINI_MODEL,
-            contents=prompt
-        )
-        
-        # Clean up response and check for "True"
-        answer = response.text.strip().lower()
-        is_positive = (answer == "true")
-        logger.info(f"Gemini text classification returned: {is_positive}")
-        return is_positive
-    except Exception as e:
-        logger.exception("Error calling Gemini API for text classification")
-        return False
+    def call_api(api_name):
+        try:
+            if api_name == API_GEMINI:
+                return call_text_gemini(text, TEXT_CLASSIFIER_PROMPT)
+            if api_name == API_CLAUDE:
+                return call_text_claude(text, TEXT_CLASSIFIER_PROMPT)
+            if api_name == API_OPENAI:
+                return call_text_openai(text, TEXT_CLASSIFIER_PROMPT)
+        except Exception:
+            logger.exception("Error calling %s API for text classification", api_name)
+            return False
+
+    return classify_with_voting(available_apis, call_api)

--- a/backend/user_system/tests/test_classifiers.py
+++ b/backend/user_system/tests/test_classifiers.py
@@ -5,120 +5,252 @@ from PIL import Image
 from ..classifiers.text_classifier import is_text_positive
 from ..classifiers.image_classifier import is_image_positive
 from ..classifiers.classifier_constants import POSITIVE_TEXT, POSITIVE_IMAGE_URL, TEXT_CLASSIFIER_PROMPT, IMAGE_CLASSIFIER_PROMPT
+from ..classifiers.classifier_utils import API_GEMINI, API_CLAUDE, API_OPENAI
 from .test_parent_case import PositiveOnlySocialTestCase
+
+_ALL_AI_KEYS = {
+    "GEMINI_API_KEY": "fake_gemini",
+    "ANTHROPIC_API_KEY": "fake_claude",
+    "OPENAI_API_KEY": "fake_openai",
+}
+_AWS_KEYS = {
+    "AWS_ACCESS_KEY_ID": "fake_aws_key",
+    "AWS_SECRET_ACCESS_KEY": "fake_aws_secret",
+    "AWS_STORAGE_BUCKET_NAME": "fake_bucket",
+}
+
+
+def _make_fake_image_bytes():
+    img = Image.new('RGB', (10, 10), color='red')
+    buf = BytesIO()
+    img.save(buf, format='PNG')
+    return buf.getvalue()
+
 
 class TestClassifiers(PositiveOnlySocialTestCase):
 
-    @patch.dict(os.environ, {"GEMINI_API_KEY": "fake_key"})
-    @patch("user_system.classifiers.text_classifier.genai")
-    def test_text_classifier_positive(self, mock_genai):
-        # Setup mock
-        mock_client = MagicMock()
-        mock_response = MagicMock()
-        mock_response.text = "true"
-        mock_client.models.generate_content.return_value = mock_response
-        mock_genai.Client.return_value = mock_client
-
-        # Test
-        result = is_text_positive("I am happy")
-        self.assertTrue(result)
-        mock_client.models.generate_content.assert_called()
-
-    @patch.dict(os.environ, {"GEMINI_API_KEY": "fake_key"})
-    @patch("user_system.classifiers.text_classifier.genai")
-    def test_text_classifier_negative(self, mock_genai):
-        # Setup mock
-        mock_client = MagicMock()
-        mock_response = MagicMock()
-        mock_response.text = "false"
-        mock_client.models.generate_content.return_value = mock_response
-        mock_genai.Client.return_value = mock_client
-
-        # Test
-        result = is_text_positive("I am sad")
-        self.assertFalse(result)
+    # ------------------------------------------------------------------ #
+    # Text classifier – testing mode                                       #
+    # ------------------------------------------------------------------ #
 
     @patch.dict(os.environ, {"TESTING": "True"}, clear=True)
-    def test_text_classifier_no_api_key(self):
-        # Test fallback
+    def test_text_classifier_testing_mode(self):
         self.assertTrue(is_text_positive(POSITIVE_TEXT))
         self.assertFalse(is_text_positive("negative random text"))
 
-    @patch.dict(os.environ, {
-        "GEMINI_API_KEY": "fake_key",
-        "AWS_ACCESS_KEY_ID": "fake_aws_key",
-        "AWS_SECRET_ACCESS_KEY": "fake_aws_secret",
-        "AWS_STORAGE_BUCKET_NAME": "fake_bucket"
-    })
-    @patch("user_system.classifiers.image_classifier.boto3")
-    @patch("user_system.classifiers.image_classifier.genai")
-    def test_image_classifier_positive(self, mock_genai, mock_boto3):
-        # Setup Gemini mock
-        mock_client = MagicMock()
-        mock_response = MagicMock()
-        mock_response.text = "true"
-        mock_client.models.generate_content.return_value = mock_response
-        mock_genai.Client.return_value = mock_client
+    # ------------------------------------------------------------------ #
+    # Text classifier – no API keys                                        #
+    # ------------------------------------------------------------------ #
 
-        # Setup S3 mock
-        mock_s3 = MagicMock()
-        mock_boto3.client.return_value = mock_s3
+    @patch.dict(os.environ, {}, clear=True)
+    def test_text_classifier_no_api_keys(self):
+        self.assertFalse(is_text_positive("some text"))
 
-        # Create a fake image
-        img = Image.new('RGB', (10, 10), color = 'red')
-        img_byte_arr = BytesIO()
-        img.save(img_byte_arr, format='PNG')
-        img_byte_arr.seek(0)
+    # ------------------------------------------------------------------ #
+    # Text classifier – single API                                         #
+    # ------------------------------------------------------------------ #
 
-        mock_s3_body = MagicMock()
-        mock_s3_body.read.return_value = img_byte_arr.getvalue()
-        mock_s3.get_object.return_value = {'Body': mock_s3_body}
+    @patch.dict(os.environ, {"GEMINI_API_KEY": "fake_key"}, clear=True)
+    @patch("user_system.classifiers.text_classifier.call_text_gemini", return_value=True)
+    def test_text_classifier_single_gemini_positive(self, mock_gemini):
+        self.assertTrue(is_text_positive("I am happy"))
+        mock_gemini.assert_called_once_with("I am happy", TEXT_CLASSIFIER_PROMPT)
 
-        # Test
-        result = is_image_positive("some_image.png")
-        self.assertTrue(result)
-        mock_s3.get_object.assert_called_with(Bucket="fake_bucket", Key="some_image.png")
-        mock_client.models.generate_content.assert_called()
+    @patch.dict(os.environ, {"GEMINI_API_KEY": "fake_key"}, clear=True)
+    @patch("user_system.classifiers.text_classifier.call_text_gemini", return_value=False)
+    def test_text_classifier_single_gemini_negative(self, mock_gemini):
+        self.assertFalse(is_text_positive("I am sad"))
 
-    @patch.dict(os.environ, {
-        "GEMINI_API_KEY": "fake_key",
-        "AWS_ACCESS_KEY_ID": "fake_aws_key",
-        "AWS_SECRET_ACCESS_KEY": "fake_aws_secret",
-        "AWS_STORAGE_BUCKET_NAME": "fake_bucket"
-    })
-    @patch("user_system.classifiers.image_classifier.boto3")
-    @patch("user_system.classifiers.image_classifier.genai")
-    def test_image_classifier_negative(self, mock_genai, mock_boto3):
-        # Setup Gemini mock
-        mock_client = MagicMock()
-        mock_response = MagicMock()
-        mock_response.text = "false"
-        mock_client.models.generate_content.return_value = mock_response
-        mock_genai.Client.return_value = mock_client
+    @patch.dict(os.environ, {"ANTHROPIC_API_KEY": "fake_key"}, clear=True)
+    @patch("user_system.classifiers.text_classifier.call_text_claude", return_value=True)
+    def test_text_classifier_single_claude_positive(self, mock_claude):
+        self.assertTrue(is_text_positive("Great day"))
+        mock_claude.assert_called_once_with("Great day", TEXT_CLASSIFIER_PROMPT)
 
-        # Setup S3 mock
-        mock_s3 = MagicMock()
-        mock_boto3.client.return_value = mock_s3
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "fake_key"}, clear=True)
+    @patch("user_system.classifiers.text_classifier.call_text_openai", return_value=True)
+    def test_text_classifier_single_openai_positive(self, mock_openai):
+        self.assertTrue(is_text_positive("Wonderful"))
+        mock_openai.assert_called_once_with("Wonderful", TEXT_CLASSIFIER_PROMPT)
 
-        # Create a fake image
-        img = Image.new('RGB', (10, 10), color='red')
-        img_byte_arr = BytesIO()
-        img.save(img_byte_arr, format='PNG')
-        img_byte_arr.seek(0)
+    # ------------------------------------------------------------------ #
+    # Text classifier – voting: two APIs agree                             #
+    # ------------------------------------------------------------------ #
 
-        mock_s3_body = MagicMock()
-        mock_s3_body.read.return_value = img_byte_arr.getvalue()
-        mock_s3.get_object.return_value = {'Body': mock_s3_body}
+    @patch.dict(os.environ, _ALL_AI_KEYS, clear=True)
+    @patch("user_system.classifiers.classifier_utils.random")
+    @patch("user_system.classifiers.text_classifier.call_text_openai", return_value=True)
+    @patch("user_system.classifiers.text_classifier.call_text_claude", return_value=True)
+    @patch("user_system.classifiers.text_classifier.call_text_gemini", return_value=True)
+    def test_text_voting_two_agree_true(self, mock_gemini, mock_claude, mock_openai, mock_random):
+        mock_random.sample.return_value = [API_GEMINI, API_CLAUDE]
+        self.assertTrue(is_text_positive("nice text"))
+        mock_openai.assert_not_called()
 
-        # Test
-        result = is_image_positive("some_image.png")
-        self.assertFalse(result)
+    @patch.dict(os.environ, _ALL_AI_KEYS, clear=True)
+    @patch("user_system.classifiers.classifier_utils.random")
+    @patch("user_system.classifiers.text_classifier.call_text_openai", return_value=False)
+    @patch("user_system.classifiers.text_classifier.call_text_claude", return_value=False)
+    @patch("user_system.classifiers.text_classifier.call_text_gemini", return_value=False)
+    def test_text_voting_two_agree_false(self, mock_gemini, mock_claude, mock_openai, mock_random):
+        mock_random.sample.return_value = [API_GEMINI, API_CLAUDE]
+        self.assertFalse(is_text_positive("bad text"))
+        mock_openai.assert_not_called()
+
+    # ------------------------------------------------------------------ #
+    # Text classifier – voting: disagree with tiebreaker                   #
+    # ------------------------------------------------------------------ #
+
+    @patch.dict(os.environ, _ALL_AI_KEYS, clear=True)
+    @patch("user_system.classifiers.classifier_utils.random")
+    @patch("user_system.classifiers.text_classifier.call_text_openai", return_value=True)
+    @patch("user_system.classifiers.text_classifier.call_text_claude", return_value=False)
+    @patch("user_system.classifiers.text_classifier.call_text_gemini", return_value=True)
+    def test_text_voting_disagree_tiebreaker_true(self, mock_gemini, mock_claude, mock_openai, mock_random):
+        mock_random.sample.return_value = [API_GEMINI, API_CLAUDE]
+        self.assertTrue(is_text_positive("some text"))
+        mock_openai.assert_called_once()
+
+    @patch.dict(os.environ, _ALL_AI_KEYS, clear=True)
+    @patch("user_system.classifiers.classifier_utils.random")
+    @patch("user_system.classifiers.text_classifier.call_text_openai", return_value=False)
+    @patch("user_system.classifiers.text_classifier.call_text_claude", return_value=False)
+    @patch("user_system.classifiers.text_classifier.call_text_gemini", return_value=True)
+    def test_text_voting_disagree_tiebreaker_false(self, mock_gemini, mock_claude, mock_openai, mock_random):
+        mock_random.sample.return_value = [API_GEMINI, API_CLAUDE]
+        self.assertFalse(is_text_positive("some text"))
+        mock_openai.assert_called_once()
+
+    # ------------------------------------------------------------------ #
+    # Text classifier – voting: two APIs, no tiebreaker, disagree          #
+    # ------------------------------------------------------------------ #
+
+    @patch.dict(os.environ, {"GEMINI_API_KEY": "gk", "ANTHROPIC_API_KEY": "ak"}, clear=True)
+    @patch("user_system.classifiers.classifier_utils.random")
+    @patch("user_system.classifiers.text_classifier.call_text_claude", return_value=False)
+    @patch("user_system.classifiers.text_classifier.call_text_gemini", return_value=True)
+    def test_text_voting_two_apis_disagree_no_tiebreaker(self, mock_gemini, mock_claude, mock_random):
+        mock_random.sample.return_value = [API_GEMINI, API_CLAUDE]
+        self.assertFalse(is_text_positive("some text"))
+
+    # ------------------------------------------------------------------ #
+    # Image classifier – testing mode                                      #
+    # ------------------------------------------------------------------ #
 
     @patch.dict(os.environ, {"TESTING": "True"}, clear=True)
-    def test_image_classifier_no_api_key(self):
-        # Test fallback
+    def test_image_classifier_testing_mode(self):
         self.assertTrue(is_image_positive(POSITIVE_IMAGE_URL))
         self.assertFalse(is_image_positive("random_image.png"))
+
+    # ------------------------------------------------------------------ #
+    # Image classifier – no API keys                                       #
+    # ------------------------------------------------------------------ #
+
+    @patch.dict(os.environ, _AWS_KEYS, clear=True)
+    def test_image_classifier_no_api_keys(self):
+        self.assertFalse(is_image_positive("some_image.png"))
+
+    # ------------------------------------------------------------------ #
+    # Image classifier – single API                                        #
+    # ------------------------------------------------------------------ #
+
+    @patch.dict(os.environ, {"GEMINI_API_KEY": "fake_key", **_AWS_KEYS}, clear=True)
+    @patch("user_system.classifiers.image_classifier.boto3")
+    @patch("user_system.classifiers.image_classifier.call_image_gemini", return_value=True)
+    def test_image_classifier_single_gemini_positive(self, mock_gemini, mock_boto3):
+        mock_s3 = MagicMock()
+        mock_boto3.client.return_value = mock_s3
+        mock_body = MagicMock()
+        mock_body.read.return_value = _make_fake_image_bytes()
+        mock_s3.get_object.return_value = {'Body': mock_body}
+
+        self.assertTrue(is_image_positive("some_image.png"))
+        mock_s3.get_object.assert_called_with(Bucket="fake_bucket", Key="some_image.png")
+        mock_gemini.assert_called_once()
+
+    @patch.dict(os.environ, {"GEMINI_API_KEY": "fake_key", **_AWS_KEYS}, clear=True)
+    @patch("user_system.classifiers.image_classifier.boto3")
+    @patch("user_system.classifiers.image_classifier.call_image_gemini", return_value=False)
+    def test_image_classifier_single_gemini_negative(self, mock_gemini, mock_boto3):
+        mock_s3 = MagicMock()
+        mock_boto3.client.return_value = mock_s3
+        mock_body = MagicMock()
+        mock_body.read.return_value = _make_fake_image_bytes()
+        mock_s3.get_object.return_value = {'Body': mock_body}
+
+        self.assertFalse(is_image_positive("some_image.png"))
+
+    @patch.dict(os.environ, {"ANTHROPIC_API_KEY": "fake_key", **_AWS_KEYS}, clear=True)
+    @patch("user_system.classifiers.image_classifier.boto3")
+    @patch("user_system.classifiers.image_classifier.call_image_claude", return_value=True)
+    def test_image_classifier_single_claude_positive(self, mock_claude, mock_boto3):
+        mock_s3 = MagicMock()
+        mock_boto3.client.return_value = mock_s3
+        mock_body = MagicMock()
+        mock_body.read.return_value = _make_fake_image_bytes()
+        mock_s3.get_object.return_value = {'Body': mock_body}
+
+        self.assertTrue(is_image_positive("some_image.png"))
+        mock_claude.assert_called_once()
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "fake_key", **_AWS_KEYS}, clear=True)
+    @patch("user_system.classifiers.image_classifier.boto3")
+    @patch("user_system.classifiers.image_classifier.call_image_openai", return_value=True)
+    def test_image_classifier_single_openai_positive(self, mock_openai, mock_boto3):
+        mock_s3 = MagicMock()
+        mock_boto3.client.return_value = mock_s3
+        mock_body = MagicMock()
+        mock_body.read.return_value = _make_fake_image_bytes()
+        mock_s3.get_object.return_value = {'Body': mock_body}
+
+        self.assertTrue(is_image_positive("some_image.png"))
+        mock_openai.assert_called_once()
+
+    # ------------------------------------------------------------------ #
+    # Image classifier – voting: two agree                                 #
+    # ------------------------------------------------------------------ #
+
+    @patch.dict(os.environ, {**_ALL_AI_KEYS, **_AWS_KEYS}, clear=True)
+    @patch("user_system.classifiers.classifier_utils.random")
+    @patch("user_system.classifiers.image_classifier.boto3")
+    @patch("user_system.classifiers.image_classifier.call_image_openai", return_value=True)
+    @patch("user_system.classifiers.image_classifier.call_image_claude", return_value=True)
+    @patch("user_system.classifiers.image_classifier.call_image_gemini", return_value=True)
+    def test_image_voting_two_agree_true(self, mock_gemini, mock_claude, mock_openai, mock_boto3, mock_random):
+        mock_random.sample.return_value = [API_GEMINI, API_CLAUDE]
+        mock_s3 = MagicMock()
+        mock_boto3.client.return_value = mock_s3
+        mock_body = MagicMock()
+        mock_body.read.return_value = _make_fake_image_bytes()
+        mock_s3.get_object.return_value = {'Body': mock_body}
+
+        self.assertTrue(is_image_positive("img.png"))
+        mock_openai.assert_not_called()
+
+    # ------------------------------------------------------------------ #
+    # Image classifier – voting: disagree with tiebreaker                  #
+    # ------------------------------------------------------------------ #
+
+    @patch.dict(os.environ, {**_ALL_AI_KEYS, **_AWS_KEYS}, clear=True)
+    @patch("user_system.classifiers.classifier_utils.random")
+    @patch("user_system.classifiers.image_classifier.boto3")
+    @patch("user_system.classifiers.image_classifier.call_image_openai", return_value=False)
+    @patch("user_system.classifiers.image_classifier.call_image_claude", return_value=False)
+    @patch("user_system.classifiers.image_classifier.call_image_gemini", return_value=True)
+    def test_image_voting_disagree_tiebreaker_false(self, mock_gemini, mock_claude, mock_openai, mock_boto3, mock_random):
+        mock_random.sample.return_value = [API_GEMINI, API_CLAUDE]
+        mock_s3 = MagicMock()
+        mock_boto3.client.return_value = mock_s3
+        mock_body = MagicMock()
+        mock_body.read.return_value = _make_fake_image_bytes()
+        mock_s3.get_object.return_value = {'Body': mock_body}
+
+        self.assertFalse(is_image_positive("img.png"))
+        mock_openai.assert_called_once()
+
+    # ------------------------------------------------------------------ #
+    # Prompt content                                                       #
+    # ------------------------------------------------------------------ #
 
     def test_text_classifier_prompt_content(self):
         for phrase in [


### PR DESCRIPTION
## Summary

- **New `classifier_utils.py`**: houses `get_available_apis()`, `classify_with_voting()`, and per-API call functions for text (`call_text_gemini/claude/openai`) and image (`call_image_gemini/claude/openai`)
- **Voting logic**: at runtime, all available APIs (detected by checking `GEMINI_API_KEY`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`) are collected, 2 are chosen at random and queried; if they agree that result is used, if not a 3rd breaks the tie; falls back to `False` with no keys or a split 2-way vote with no tiebreaker
- **Classifiers simplified**: `text_classifier.py` and `image_classifier.py` now delegate to the voting utility rather than calling Gemini directly
- **Constants**: added `CLAUDE_MODEL = 'claude-haiku-4-5-20251001'` and `OPENAI_MODEL = 'gpt-4o-mini'`
- **Tests expanded**: single-API path for each provider, two-agree scenario (tiebreaker not called), disagree-with-tiebreaker, disagree-with-no-tiebreaker (returns `False`), and no-key fallback — for both text and image classifiers
- **Dependencies**: added `anthropic` and `openai` to `requirements.txt`

## Test plan

- [ ] `test_text_classifier_testing_mode` — testing-mode bypass still works
- [ ] `test_text_classifier_no_api_keys` — returns `False` with no keys
- [ ] `test_text_classifier_single_{gemini,claude,openai}_positive` — correct API called when only one key set
- [ ] `test_text_voting_two_agree_{true,false}` — tiebreaker not invoked when two agree
- [ ] `test_text_voting_disagree_tiebreaker_{true,false}` — third API used to break tie
- [ ] `test_text_voting_two_apis_disagree_no_tiebreaker` — defaults to `False`
- [ ] Equivalent image classifier tests pass
- [ ] `test_{text,image}_classifier_prompt_content` — prompt content unchanged

🤖 Generated with [Claude Code](https://claude.ai/claude-code)