### PR TITLE
Fix reset_password using wrong Session/LoginCookie field names

### DIFF
--- a/backend/user_system/views.py
+++ b/backend/user_system/views.py
@@ -598,8 +598,6 @@ def reset_password(request):
             user.set_password(password)
             user.reset_token = None
             user.reset_token_expires = None
-            Session.objects.filter(user=user).delete()
-            LoginCookie.objects.filter(user=user).delete()
             user.save()
             Session.objects.filter(management_user=user).delete()
             LoginCookie.objects.filter(cookie_user=user).delete()


### PR DESCRIPTION
## Summary
- Removed two erroneous `Session.objects.filter(user=user)` and `LoginCookie.objects.filter(user=user)` calls in `reset_password` that used a nonexistent `user` field
- The correct calls using `management_user` and `cookie_user` were already present immediately after, so no session/cookie invalidation logic is lost

## Test plan
- [ ] `test_password_reset_flow_succeeds_and_changes_password` passes
- [ ] `test_reset_token_is_single_use` passes
- [ ] `test_session_and_cookie_invalidated_after_reset` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)