### PR TITLE
Add rate limiting to all API endpoints and verify_reset lockout

### DIFF
--- a/backend/pos_backend/settings.py
+++ b/backend/pos_backend/settings.py
@@ -64,6 +64,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    'django_ratelimit.middleware.RatelimitMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -161,6 +162,28 @@ MEDIA_URL = '/media/'
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+# Rate limiting
+# Uses DatabaseCache by default (cross-process, no extra deps).
+# For high-traffic deployments set REDIS_URL to use Redis instead.
+# After deploying with DatabaseCache, run: python manage.py createcachetable
+RATELIMIT_VIEW = 'pos_backend.views.ratelimited'
+RATELIMIT_ENABLE = True
+
+if os.environ.get('REDIS_URL'):
+    CACHES = {
+        'default': {
+            'BACKEND': 'django.core.cache.backends.redis.RedisCache',
+            'LOCATION': os.environ['REDIS_URL'],
+        }
+    }
+else:
+    CACHES = {
+        'default': {
+            'BACKEND': 'django.core.cache.backends.db.DatabaseCache',
+            'LOCATION': 'rate_limit_cache',
+        }
+    }
 
 
 

--- a/backend/pos_backend/settings.py
+++ b/backend/pos_backend/settings.py
@@ -166,7 +166,7 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 # Rate limiting
 # Uses DatabaseCache by default (cross-process, no extra deps).
 # For high-traffic deployments set REDIS_URL to use Redis instead.
-# After deploying with DatabaseCache, run: python manage.py createcachetable
+# After deploying with DatabaseCache, run: python manage.py createcachetable rate_limit_cache
 RATELIMIT_VIEW = 'pos_backend.views.ratelimited'
 RATELIMIT_ENABLE = True
 

--- a/backend/pos_backend/views.py
+++ b/backend/pos_backend/views.py
@@ -4,3 +4,7 @@ from django.http import JsonResponse
 def health(request):
     """Health check endpoint that returns an ok  JSON response with status 200."""
     return JsonResponse({"status": "ok"}, status=200)
+
+
+def ratelimited(request, exception):
+    return JsonResponse({'error': 'Too many requests. Please slow down.'}, status=429)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,3 +8,5 @@ pytest
 gunicorn
 psycopg
 python-dotenv
+django-ratelimit
+redis

--- a/backend/user_system/constants.py
+++ b/backend/user_system/constants.py
@@ -101,3 +101,7 @@ COMMENT_THREAD_BATCH_SIZE = 10
 # Number of reports before hiding
 MAX_BEFORE_HIDING_POST = 10
 MAX_BEFORE_HIDING_COMMENT = 5
+
+# verify_reset lockout: lock the account after this many consecutive failures
+VERIFY_RESET_MAX_ATTEMPTS = 5
+VERIFY_RESET_LOCKOUT_MINUTES = 15

--- a/backend/user_system/migrations/0007_positiveonlysocialuser_verification_lockout.py
+++ b/backend/user_system/migrations/0007_positiveonlysocialuser_verification_lockout.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('user_system', '0006_remove_positiveonlysocialuser_reset_id'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='positiveonlysocialuser',
+            name='verification_failed_attempts',
+            field=models.IntegerField(default=0),
+        ),
+        migrations.AddField(
+            model_name='positiveonlysocialuser',
+            name='verification_lockout_until',
+            field=models.DateTimeField(blank=True, default=None, null=True),
+        ),
+    ]

--- a/backend/user_system/models.py
+++ b/backend/user_system/models.py
@@ -41,6 +41,8 @@ class PositiveOnlySocialUser(AbstractUser):
     verification_report_status = models.TextField(default=NEVER_RUN)
     identity_is_verified = models.BooleanField(default=False)
     is_adult = models.BooleanField(default=False)
+    verification_failed_attempts = models.IntegerField(default=0)
+    verification_lockout_until = models.DateTimeField(null=True, blank=True, default=None)
 
     creation_time = models.DateTimeField(auto_now_add=True, null=True, blank=True)
     updated_time = models.DateTimeField(auto_now=True, null=True, blank=True)

--- a/backend/user_system/tests/test_parent_case.py
+++ b/backend/user_system/tests/test_parent_case.py
@@ -2,7 +2,7 @@ import os
 
 from unittest.mock import patch
 
-from django.test import TestCase, Client
+from django.test import TestCase, Client, override_settings
 from django.urls import reverse
 
 # Note: test_constants are no longer used for FAIL/SUCCESS
@@ -13,6 +13,7 @@ from ..constants import Fields
 from ..models import Post, CommentThread, Comment, Session
 
 
+@override_settings(RATELIMIT_ENABLE=False)
 class PositiveOnlySocialTestCase(TestCase):
     """
     A parent test case for the PositiveOnlySocial app that uses the

--- a/backend/user_system/tests/test_reset_password_views.py
+++ b/backend/user_system/tests/test_reset_password_views.py
@@ -6,7 +6,7 @@ from django.utils import timezone
 from datetime import timedelta
 from unittest.mock import patch
 
-from ..constants import Fields
+from ..constants import Fields, VERIFY_RESET_MAX_ATTEMPTS, VERIFY_RESET_LOCKOUT_MINUTES
 from .test_constants import username, password, false, ip
 from .test_parent_case import PositiveOnlySocialTestCase
 from ..models import LoginCookie, PositiveOnlySocialUser, Session
@@ -224,6 +224,47 @@ class ResetPasswordTests(PositiveOnlySocialTestCase):
         }, content_type='application/json')
         self.assertEqual(response.status_code, 400)
         self.assertIn("Invalid reset token", response.json().get('error', ''))
+
+    def test_verify_reset_lockout_after_max_attempts(self):
+        """After VERIFY_RESET_MAX_ATTEMPTS bad tokens the Nth call returns 429."""
+        self._request_reset()
+        for _ in range(VERIFY_RESET_MAX_ATTEMPTS - 1):
+            response = self._verify_reset(FAKE_URLSAFE_TOKEN)
+            self.assertEqual(response.status_code, 400)
+            self.assertIn("Invalid or expired", response.json().get('error', ''))
+        # The Nth failure triggers the lockout
+        response = self._verify_reset(FAKE_URLSAFE_TOKEN)
+        self.assertEqual(response.status_code, 429)
+        self.assertIn("Too many failed attempts", response.json().get('error', ''))
+
+    def test_locked_out_user_stays_locked_until_expiry(self):
+        """Subsequent requests while locked out continue to return 429."""
+        self._request_reset()
+        for _ in range(VERIFY_RESET_MAX_ATTEMPTS):
+            self._verify_reset(FAKE_URLSAFE_TOKEN)
+        # Already locked — further attempts also return 429
+        response = self._verify_reset(FAKE_URLSAFE_TOKEN)
+        self.assertEqual(response.status_code, 429)
+
+    def test_request_reset_clears_active_lockout(self):
+        """Calling request_reset resets the failed-attempt counter and clears any lockout."""
+        self._request_reset()
+        # Trigger lockout
+        for _ in range(VERIFY_RESET_MAX_ATTEMPTS):
+            self._verify_reset(FAKE_URLSAFE_TOKEN)
+        # Confirm locked
+        self.assertEqual(self._verify_reset(FAKE_URLSAFE_TOKEN).status_code, 429)
+
+        # A new reset request clears the lockout
+        self._request_reset()
+        user = PositiveOnlySocialUser.objects.get(username=self.local_username)
+        self.assertEqual(user.verification_failed_attempts, 0)
+        self.assertIsNone(user.verification_lockout_until)
+
+        # Bad token now returns 400 (not locked), good token still works
+        response = self._verify_reset(FAKE_URLSAFE_TOKEN)
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Invalid or expired", response.json().get('error', ''))
 
     @patch.dict(os.environ, {"TESTING": "True"}, clear=True)
     def test_session_and_cookie_invalidated_after_reset(self):

--- a/backend/user_system/views.py
+++ b/backend/user_system/views.py
@@ -16,10 +16,13 @@ from django.http import JsonResponse
 from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST, require_GET
+from django_ratelimit.decorators import ratelimit
+from django_ratelimit.exceptions import Ratelimited
 
 from .classifiers import image_classifier, text_classifier
 from .constants import Patterns, Params, POST_BATCH_SIZE, MAX_BEFORE_HIDING_POST, MAX_BEFORE_HIDING_COMMENT, \
-    COMMENT_BATCH_SIZE, Fields, COMMENT_THREAD_BATCH_SIZE
+    COMMENT_BATCH_SIZE, Fields, COMMENT_THREAD_BATCH_SIZE, \
+    VERIFY_RESET_MAX_ATTEMPTS, VERIFY_RESET_LOCKOUT_MINUTES
 from .feed_algorithm import feed_algorithm
 from .input_validator import is_valid_pattern
 from .models import LoginCookie, Session, Post, CommentThread, PositiveOnlySocialUser, Comment, UserBlock
@@ -40,6 +43,16 @@ def log_and_return_json(view_name, data, **kwargs):
     else:
         logger.info(f"Endpoint {view_name} succeeded.")
     return JsonResponse(data, **kwargs)
+
+
+def _get_client_ip(group, request):
+    """Rate limit key: real client IP, honouring X-Forwarded-For from the ALB."""
+    x_forwarded_for = request.META.get('HTTP_X_FORWARDED_FOR', '')
+    if x_forwarded_for:
+        return x_forwarded_for.split(',')[0].strip()
+    return request.META.get('REMOTE_ADDR', '')
+
+
 def get_user_with_username_and_email(username, email):
     try:
         existing = get_user_model().objects.get(username=username, email=email)
@@ -154,6 +167,8 @@ def api_login_required(view_func):
         request.token = token
         try:
             return view_func(request, *args, **kwargs)
+        except Ratelimited:
+            raise
         except Exception as e:
             return JsonResponse({'error': str(e)}, status=401)
 
@@ -164,6 +179,7 @@ def api_login_required(view_func):
 # AUTHENTICATION VIEWS
 # =============================================================================
 
+@ratelimit(key=_get_client_ip, rate='5/h', block=True)
 @csrf_exempt
 @require_POST
 def register(request):
@@ -255,6 +271,7 @@ def register(request):
 
 @csrf_exempt
 @api_login_required
+@ratelimit(key='user', rate='5/h', block=True)
 @require_POST
 def verify_identity(request):
     logger.info("Endpoint verify_identity invoked by IP or User")
@@ -264,7 +281,7 @@ def verify_identity(request):
         return log_and_return_json("verify_identity", {'error': "Invalid JSON data"}, status=400)
 
     date_of_birth_str = data.get('date_of_birth')
-    
+
     if not date_of_birth_str:
          logger.warning(f"Identity verification failed: Missing date_of_birth for user_id: {request.user.id}")
          return log_and_return_json("verify_identity", {'error': "Missing date_of_birth"}, status=400)
@@ -273,15 +290,15 @@ def verify_identity(request):
         dob = datetime.strptime(date_of_birth_str, '%Y-%m-%d').date()
         today = date.today()
         age = today.year - dob.year - ((today.month, today.day) < (dob.month, dob.day))
-        
+
         request.user.identity_is_verified = True
         if age >= 18:
             request.user.is_adult = True
         else:
             request.user.is_adult = False
-            
+
         request.user.save()
-        
+
         logger.info(f"Identity verification successful for user_id: {request.user.id}")
         return log_and_return_json("verify_identity", {'message': 'Identity verified'})
     except ValueError:
@@ -289,6 +306,7 @@ def verify_identity(request):
         return log_and_return_json("verify_identity", {'error': "Invalid date format, expected YYYY-MM-DD"}, status=400)
 
 
+@ratelimit(key=_get_client_ip, rate='10/m', block=True)
 @csrf_exempt
 @require_POST
 def login_user(request):
@@ -353,6 +371,7 @@ def login_user(request):
         return log_and_return_json("login_user", {'error': "Invalid username or password"}, status=400)
 
 
+@ratelimit(key=_get_client_ip, rate='10/m', block=True)
 @csrf_exempt
 @require_POST
 def login_user_with_remember_me(request):
@@ -418,6 +437,7 @@ def login_user_with_remember_me(request):
 
 @csrf_exempt
 @api_login_required
+@ratelimit(key='user', rate='10/m', block=True)
 @require_POST
 def logout_user(request):
     logger.info("Endpoint logout_user invoked by IP or User")
@@ -438,6 +458,7 @@ def logout_user(request):
 
 @csrf_exempt
 @api_login_required
+@ratelimit(key='user', rate='5/h', block=True)
 @require_POST
 def delete_user(request):
     logger.info("Endpoint delete_user invoked by IP or User")
@@ -458,6 +479,7 @@ def delete_user(request):
 # PASSWORD RESET VIEWS
 # =============================================================================
 
+@ratelimit(key=_get_client_ip, rate='3/h', block=True)
 @csrf_exempt
 @require_POST
 def request_reset(request):
@@ -489,6 +511,8 @@ def request_reset(request):
         user.verification_token_expires = timezone.now() + timedelta(hours=1)
         user.reset_token = None
         user.reset_token_expires = None
+        user.verification_failed_attempts = 0
+        user.verification_lockout_until = None
         user.save()
         logger.info(f"Password reset request successful for user_id: {user.id}")
         return log_and_return_json("request_reset", {'message': 'Reset email sent'})
@@ -497,6 +521,7 @@ def request_reset(request):
         return log_and_return_json("request_reset", {'error': "No user with that username or email"}, status=400)
 
 
+@ratelimit(key=_get_client_ip, rate='10/h', block=True)
 @csrf_exempt
 @require_POST
 def verify_reset(request):
@@ -530,9 +555,24 @@ def verify_reset(request):
         logger.warning("Password reset verification failed: No user with that username or email")
         return log_and_return_json("verify_reset", {'error': "No user with that username or email"}, status=400)
 
+    # Fast-path lockout check before acquiring the row lock
+    if user.verification_lockout_until and timezone.now() < user.verification_lockout_until:
+        logger.warning(f"Password reset verification locked out for user_id: {user.id}")
+        return log_and_return_json("verify_reset", {
+            'error': "Too many failed attempts. Try again later."
+        }, status=429)
+
     try:
         with transaction.atomic():
             user = get_user_model().objects.select_for_update().get(pk=user.pk)
+
+            # Re-check lockout inside the atomic block to guard against races
+            if user.verification_lockout_until and timezone.now() < user.verification_lockout_until:
+                logger.warning(f"Password reset verification locked out for user_id: {user.id}")
+                return log_and_return_json("verify_reset", {
+                    'error': "Too many failed attempts. Try again later."
+                }, status=429)
+
             if (user.verification_token and
                     secrets.compare_digest(user.verification_token, submitted_hash) and
                     user.verification_token_expires is not None and
@@ -542,12 +582,23 @@ def verify_reset(request):
                 user.verification_token_expires = None
                 user.reset_token = hashlib.sha256(reset_token.encode()).hexdigest()
                 user.reset_token_expires = timezone.now() + timedelta(minutes=15)
+                user.verification_failed_attempts = 0
+                user.verification_lockout_until = None
                 user.save()
                 logger.info(f"Password reset verification successful for user_id: {user.id}")
                 response = log_and_return_json("verify_reset", {'message': 'Verification successful', 'reset_token': reset_token})
                 response['Cache-Control'] = 'no-store'
                 return response
             else:
+                user.verification_failed_attempts += 1
+                if user.verification_failed_attempts >= VERIFY_RESET_MAX_ATTEMPTS:
+                    user.verification_lockout_until = timezone.now() + timedelta(minutes=VERIFY_RESET_LOCKOUT_MINUTES)
+                    user.verification_failed_attempts = 0
+                    logger.warning(
+                        f"Password reset verification locked out after {VERIFY_RESET_MAX_ATTEMPTS} "
+                        f"attempts for user_id: {user.id}"
+                    )
+                user.save()
                 logger.warning(f"Password reset verification failed for user_id: {user.id}")
                 return log_and_return_json("verify_reset", {'error': "Invalid or expired verification token"}, status=400)
     except get_user_model().DoesNotExist:
@@ -555,6 +606,7 @@ def verify_reset(request):
         return log_and_return_json("verify_reset", {'error': "No user with that username or email"}, status=400)
 
 
+@ratelimit(key=_get_client_ip, rate='10/h', block=True)
 @csrf_exempt
 @require_POST
 def reset_password(request):
@@ -618,6 +670,7 @@ def reset_password(request):
 
 @csrf_exempt
 @api_login_required
+@ratelimit(key='user', rate='10/h', block=True)
 @require_POST
 def make_post(request):
     logger.info("Endpoint make_post invoked by IP or User")
@@ -665,6 +718,7 @@ def make_post(request):
 
 @csrf_exempt
 @api_login_required
+@ratelimit(key='user', rate='30/h', block=True)
 @require_POST  # Or @require_DELETE if you prefer
 def delete_post(request, post_identifier):
     logger.info("Endpoint delete_post invoked by IP or User")
@@ -684,6 +738,7 @@ def delete_post(request, post_identifier):
 
 @csrf_exempt
 @api_login_required
+@ratelimit(key='user', rate='20/h', block=True)
 @require_POST
 def report_post(request, post_identifier):
     logger.info("Endpoint report_post invoked by IP or User")
@@ -729,6 +784,7 @@ def report_post(request, post_identifier):
 
 @csrf_exempt
 @api_login_required
+@ratelimit(key='user', rate='60/m', block=True)
 @require_POST
 def like_post(request, post_identifier):
     logger.info("Endpoint like_post invoked by IP or User")
@@ -758,6 +814,7 @@ def like_post(request, post_identifier):
 
 @csrf_exempt
 @api_login_required
+@ratelimit(key='user', rate='60/m', block=True)
 @require_POST  # Or @require_DELETE
 def unlike_post(request, post_identifier):
     logger.info("Endpoint unlike_post invoked by IP or User")
@@ -789,6 +846,7 @@ def unlike_post(request, post_identifier):
 # =============================================================================
 
 @api_login_required
+@ratelimit(key='user', rate='60/m', block=True)
 @require_GET
 def get_posts_in_feed(request, batch):
     logger.info("Endpoint get_posts_in_feed invoked by IP or User")
@@ -797,7 +855,7 @@ def get_posts_in_feed(request, batch):
         return log_and_return_json("get_posts_in_feed", {'error': "Invalid batch parameter"}, status=400)
 
     relevant_posts = feed_algorithm_class.get_posts_weighted(request.user, Post)
-    
+
     # Filter out posts from users the current user has blocked or who have blocked the current user
     blocked_users = request.user.blocked.all()
     blocking_users = request.user.blocked_by.all()
@@ -820,6 +878,7 @@ def get_posts_in_feed(request, batch):
 
 
 @api_login_required
+@ratelimit(key='user', rate='60/m', block=True)
 @require_GET
 def get_posts_for_followed_users(request, batch):
     logger.info("Endpoint get_posts_for_followed_users invoked by IP or User")
@@ -828,7 +887,7 @@ def get_posts_for_followed_users(request, batch):
         return log_and_return_json("get_posts_for_followed_users", {'error': "Invalid batch parameter"}, status=400)
 
     followed_users = request.user.following.all()
-    
+
     # Filter out users who are blocked or blocking
     blocked_users = request.user.blocked.all()
     blocking_users = request.user.blocked_by.all()
@@ -854,6 +913,7 @@ def get_posts_for_followed_users(request, batch):
 
 
 @api_login_required
+@ratelimit(key='user', rate='60/m', block=True)
 @require_GET
 def get_posts_for_user(request, username, batch):
     logger.info("Endpoint get_posts_for_user invoked by IP or User")
@@ -891,6 +951,7 @@ def get_posts_for_user(request, username, batch):
         return log_and_return_json("get_posts_for_user", [], safe=False)
 
 
+@ratelimit(key=_get_client_ip, rate='60/m', block=True)
 @require_GET  # Publicly viewable, no @api_login_required
 def get_post_details(request, post_identifier):
     logger.info("Endpoint get_post_details invoked by IP or User")
@@ -919,6 +980,7 @@ def get_post_details(request, post_identifier):
 
 @csrf_exempt
 @api_login_required
+@ratelimit(key='user', rate='20/h', block=True)
 @require_POST
 def comment_on_post(request, post_identifier):
     logger.info("Endpoint comment_on_post invoked by IP or User")
@@ -956,6 +1018,7 @@ def comment_on_post(request, post_identifier):
 
 @csrf_exempt
 @api_login_required
+@ratelimit(key='user', rate='20/h', block=True)
 @require_POST
 def reply_to_comment_thread(request, post_identifier, comment_thread_identifier):
     logger.info("Endpoint reply_to_comment_thread invoked by IP or User")
@@ -995,6 +1058,7 @@ def reply_to_comment_thread(request, post_identifier, comment_thread_identifier)
 
 @csrf_exempt
 @api_login_required
+@ratelimit(key='user', rate='60/m', block=True)
 @require_POST
 def like_comment(request, post_identifier, comment_thread_identifier, comment_identifier):
     logger.info("Endpoint like_comment invoked by IP or User")
@@ -1034,6 +1098,7 @@ def like_comment(request, post_identifier, comment_thread_identifier, comment_id
 
 @csrf_exempt
 @api_login_required
+@ratelimit(key='user', rate='60/m', block=True)
 @require_POST  # Or @require_DELETE
 def unlike_comment(request, post_identifier, comment_thread_identifier, comment_identifier):
     logger.info("Endpoint unlike_comment invoked by IP or User")
@@ -1073,6 +1138,7 @@ def unlike_comment(request, post_identifier, comment_thread_identifier, comment_
 
 @csrf_exempt
 @api_login_required
+@ratelimit(key='user', rate='30/h', block=True)
 @require_POST  # Or @require_DELETE
 def delete_comment(request, post_identifier, comment_thread_identifier, comment_identifier):
     logger.info("Endpoint delete_comment invoked by IP or User")
@@ -1108,6 +1174,7 @@ def delete_comment(request, post_identifier, comment_thread_identifier, comment_
 
 @csrf_exempt
 @api_login_required
+@ratelimit(key='user', rate='20/h', block=True)
 @require_POST
 def report_comment(request, post_identifier, comment_thread_identifier, comment_identifier):
     logger.info("Endpoint report_comment invoked by IP or User")
@@ -1160,6 +1227,7 @@ def report_comment(request, post_identifier, comment_thread_identifier, comment_
 
 
 @api_login_required  # Original had @login_required
+@ratelimit(key='user', rate='60/m', block=True)
 @require_GET
 def get_comments_for_post(request, post_identifier, batch):
     logger.info("Endpoint get_comments_for_post invoked by IP or User")
@@ -1186,6 +1254,7 @@ def get_comments_for_post(request, post_identifier, batch):
 
 
 @api_login_required  # Original had @login_required
+@ratelimit(key='user', rate='60/m', block=True)
 @require_GET
 def get_comments_for_thread(request, comment_thread_identifier, batch):
     logger.info("Endpoint get_comments_for_thread invoked by IP or User")
@@ -1225,6 +1294,7 @@ def get_comments_for_thread(request, comment_thread_identifier, batch):
 # =============================================================================
 
 @api_login_required
+@ratelimit(key='user', rate='30/m', block=True)
 @require_GET
 def get_users_matching_fragment(request, username_fragment):
     logger.info("Endpoint get_users_matching_fragment invoked by IP or User")
@@ -1237,7 +1307,7 @@ def get_users_matching_fragment(request, username_fragment):
     users = PositiveOnlySocialUser.objects.filter(
         username__istartswith=username_fragment
     ).exclude(pk=request.user.pk)
-    
+
     # User B cannot search for User A if User A blocked User B.
     # request.user is B (searcher). We must exclude any user A who has blocked B.
     # We must also exclude users that B has blocked? Spec says: "If user A blocks user B then user A can search for user B"
@@ -1259,6 +1329,7 @@ def get_users_matching_fragment(request, username_fragment):
 
 @csrf_exempt
 @api_login_required
+@ratelimit(key='user', rate='30/m', block=True)
 @require_POST
 def follow_user(request, username_to_follow):
     logger.info("Endpoint follow_user invoked by IP or User")
@@ -1283,6 +1354,7 @@ def follow_user(request, username_to_follow):
 
 @csrf_exempt
 @api_login_required
+@ratelimit(key='user', rate='30/m', block=True)
 @require_POST  # Or @require_DELETE
 def unfollow_user(request, username_to_unfollow):
     logger.info("Endpoint unfollow_user invoked by IP or User")
@@ -1304,6 +1376,7 @@ def unfollow_user(request, username_to_unfollow):
 
 @csrf_exempt
 @api_login_required
+@ratelimit(key='user', rate='30/m', block=True)
 @require_POST
 def toggle_block(request, username_to_toggle_block):
     logger.info("Endpoint toggle_block invoked by IP or User")
@@ -1330,12 +1403,13 @@ def toggle_block(request, username_to_toggle_block):
             request.user.following.remove(user_to_toggle_obj)
         if user_to_toggle_obj.following.filter(pk=request.user.pk).exists():
             user_to_toggle_obj.following.remove(request.user)
-            
+
         logger.info(f"User blocked successful: target_user_id: {user_to_toggle_obj.id} by user_id: {request.user.id}")
         return log_and_return_json("toggle_block", {'message': 'User blocked'})
 
 
 @api_login_required
+@ratelimit(key='user', rate='30/m', block=True)
 @require_GET
 def get_profile_details(request, username):
     logger.info("Endpoint get_profile_details invoked by IP or User")
@@ -1359,16 +1433,16 @@ def get_profile_details(request, username):
 
     is_following = request.user.following.filter(pk=profile_user.pk).exists()
     is_blocked = request.user.blocked.filter(pk=profile_user.pk).exists()
-    
-    # If I am blocked by them, should I see details? 
+
+    # If I am blocked by them, should I see details?
     # Spec: "user B cannot search for user A".
     # Typically profiles are also hidden or return 404.
     # But `get_posts_for_user` will return empty.
     # Let's hide stats if blocked by them.
     is_blocked_by = request.user.blocked_by.filter(pk=profile_user.pk).exists()
-    
+
     if is_blocked_by:
-        # Return limited info or error? 
+        # Return limited info or error?
         # Usually it looks like the user doesn't exist or empty profile.
         # Let's return empty stats.
         post_count = 0

--- a/backend/user_system/views.py
+++ b/backend/user_system/views.py
@@ -1,4 +1,5 @@
 import hashlib
+import ipaddress
 import json
 import logging
 import secrets
@@ -46,10 +47,20 @@ def log_and_return_json(view_name, data, **kwargs):
 
 
 def _get_client_ip(group, request):
-    """Rate limit key: real client IP, honouring X-Forwarded-For from the ALB."""
+    """Rate limit key: real client IP from AWS ALB.
+
+    AWS ALB appends the actual client IP to the *end* of any existing
+    X-Forwarded-For header, so reading the last entry is tamper-resistant
+    (a client can forge earlier entries but not the one the ALB adds).
+    """
     x_forwarded_for = request.META.get('HTTP_X_FORWARDED_FOR', '')
     if x_forwarded_for:
-        return x_forwarded_for.split(',')[0].strip()
+        candidate = x_forwarded_for.split(',')[-1].strip()
+        try:
+            ipaddress.ip_address(candidate)
+            return candidate
+        except ValueError:
+            pass
     return request.META.get('REMOTE_ADDR', '')
 
 
@@ -594,10 +605,14 @@ def verify_reset(request):
                 if user.verification_failed_attempts >= VERIFY_RESET_MAX_ATTEMPTS:
                     user.verification_lockout_until = timezone.now() + timedelta(minutes=VERIFY_RESET_LOCKOUT_MINUTES)
                     user.verification_failed_attempts = 0
+                    user.save()
                     logger.warning(
                         f"Password reset verification locked out after {VERIFY_RESET_MAX_ATTEMPTS} "
                         f"attempts for user_id: {user.id}"
                     )
+                    return log_and_return_json("verify_reset", {
+                        'error': "Too many failed attempts. Try again later."
+                    }, status=429)
                 user.save()
                 logger.warning(f"Password reset verification failed for user_id: {user.id}")
                 return log_and_return_json("verify_reset", {'error': "Invalid or expired verification token"}, status=400)


### PR DESCRIPTION
Fixes #120.

## Summary

- **`django-ratelimit` + Redis/DatabaseCache**: rate limit state is stored in the cache (DatabaseCache by default, Redis if `REDIS_URL` is set — cross-process safe in both cases)
- **JSON 429 responses**: `RatelimitMiddleware` + custom `ratelimited` view returns `{"error": "Too many requests. Please slow down."}` instead of HTML
- **`api_login_required` patched**: re-raises `Ratelimited` so the middleware handles it rather than the catch-all 401 swallowing it

### Rate limits applied

| Tier | Key | Endpoints | Limit |
|------|-----|-----------|-------|
| 1 — unauthenticated | IP (X-Forwarded-For) | `register` | 5/hour |
| 1 | IP | `login_user`, `login_user_with_remember_me` | 10/min |
| 1 | IP | `request_reset` | 3/hour |
| 1 | IP | `verify_reset` | 10/hour |
| 1 | IP | `reset_password` | 10/hour |
| 1 | IP | `get_post_details` (public) | 60/min |
| 2 — authenticated | user PK | `make_post` | 10/hour |
| 2 | user PK | `report_post`, `report_comment` | 20/hour |
| 2 | user PK | `like/unlike_post`, `like/unlike_comment` | 60/min |
| 2 | user PK | `get_users_matching_fragment` | 30/min |
| 2 | user PK | all feed/post/comment GETs | 60/min |
| 3 — authenticated (light) | user PK | `follow/unfollow/toggle_block` | 30/min |
| 3 | user PK | `comment_on_post`, `reply_to_comment_thread` | 20/hour |
| 3 | user PK | `delete_post`, `delete_comment` | 30/hour |
| 3 | user PK | `get_profile_details` | 30/min |
| 3 | user PK | `verify_identity`, `delete_user` | 5/hour |
| 3 | user PK | `logout_user` | 10/min |

### `verify_reset` lockout (DB-level, per user)

Adds `verification_failed_attempts` + `verification_lockout_until` to the user model (migration 0007). After 5 consecutive failed verification attempts the account is locked for 15 minutes. The counter is reset when `request_reset` is called (new flow) or when verification succeeds. The lockout check is inside a `select_for_update()` atomic block to prevent races.

## Deployment notes

- Run `python manage.py createcachetable` **once** after deploying (creates the `rate_limit_cache` table used by DatabaseCache)
- For multi-worker production, set `REDIS_URL` to a Redis instance so limits are shared across gunicorn workers

## Test plan

- [x] All 198 existing tests pass (`@override_settings(RATELIMIT_ENABLE=False)` on the base test class suppresses rate limiting during tests)
- [ ] Manually hit `verify_reset` 5× with a wrong token and confirm 429 with lockout message on the 5th
- [ ] Confirm `request_reset` resets the counter (new attempt succeeds after calling it again)
- [ ] Confirm `login_user` returns 429 after 10 rapid requests from the same IP

🤖 Generated with [Claude Code](https://claude.com/claude-code)