### PR TITLE
Restrict /admin/ with IP allowlist middleware and tighten UserAdmin

### DIFF
--- a/backend/pos_backend/middleware.py
+++ b/backend/pos_backend/middleware.py
@@ -8,8 +8,18 @@ def _get_allowlist():
     return {ip.strip() for ip in raw.split(",") if ip.strip()}
 
 
+def _get_trusted_proxies():
+    raw = os.environ.get("TRUSTED_PROXY_IPS", "")
+    return {ip.strip() for ip in raw.split(",") if ip.strip()}
+
+
 def _client_ip(request):
-    return request.META.get("REMOTE_ADDR", "")
+    remote_addr = request.META.get("REMOTE_ADDR", "")
+    if remote_addr in _get_trusted_proxies():
+        # Request arrived through a known proxy (e.g. nginx on the same host).
+        # Trust the X-Real-IP header it set; fall back to REMOTE_ADDR if absent.
+        return request.META.get("HTTP_X_REAL_IP") or remote_addr
+    return remote_addr
 
 
 class AdminIPAllowlistMiddleware:

--- a/backend/pos_backend/middleware.py
+++ b/backend/pos_backend/middleware.py
@@ -9,13 +9,7 @@ def _get_allowlist():
 
 
 def _client_ip(request):
-    # Prefer X-Real-IP set by the reverse proxy (nginx: proxy_set_header X-Real-IP $remote_addr).
-    # Fall back to REMOTE_ADDR. X-Forwarded-For is not used because the leftmost
-    # value is client-controlled and can be spoofed to bypass the allowlist.
-    return (
-        request.META.get("HTTP_X_REAL_IP")
-        or request.META.get("REMOTE_ADDR", "")
-    )
+    return request.META.get("REMOTE_ADDR", "")
 
 
 class AdminIPAllowlistMiddleware:
@@ -23,9 +17,7 @@ class AdminIPAllowlistMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
-        # Match both "/admin" and "/admin/..." — the untrailed path would otherwise
-        # receive a redirect response before this guard takes effect.
-        if request.path.startswith("/admin"):
+        if request.path == "/admin" or request.path.startswith("/admin/"):
             allowlist = _get_allowlist()
             if not allowlist or _client_ip(request) not in allowlist:
                 raise Http404

--- a/backend/pos_backend/middleware.py
+++ b/backend/pos_backend/middleware.py
@@ -9,10 +9,13 @@ def _get_allowlist():
 
 
 def _client_ip(request):
-    forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR")
-    if forwarded_for:
-        return forwarded_for.split(",")[0].strip()
-    return request.META.get("REMOTE_ADDR", "")
+    # Prefer X-Real-IP set by the reverse proxy (nginx: proxy_set_header X-Real-IP $remote_addr).
+    # Fall back to REMOTE_ADDR. X-Forwarded-For is not used because the leftmost
+    # value is client-controlled and can be spoofed to bypass the allowlist.
+    return (
+        request.META.get("HTTP_X_REAL_IP")
+        or request.META.get("REMOTE_ADDR", "")
+    )
 
 
 class AdminIPAllowlistMiddleware:
@@ -20,8 +23,10 @@ class AdminIPAllowlistMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
-        if request.path.startswith("/admin/"):
+        # Match both "/admin" and "/admin/..." — the untrailed path would otherwise
+        # receive a redirect response before this guard takes effect.
+        if request.path.startswith("/admin"):
             allowlist = _get_allowlist()
-            if allowlist and _client_ip(request) not in allowlist:
+            if not allowlist or _client_ip(request) not in allowlist:
                 raise Http404
         return self.get_response(request)

--- a/backend/pos_backend/middleware.py
+++ b/backend/pos_backend/middleware.py
@@ -1,0 +1,27 @@
+import os
+
+from django.http import Http404
+
+
+def _get_allowlist():
+    raw = os.environ.get("ADMIN_IP_ALLOWLIST", "")
+    return {ip.strip() for ip in raw.split(",") if ip.strip()}
+
+
+def _client_ip(request):
+    forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR")
+    if forwarded_for:
+        return forwarded_for.split(",")[0].strip()
+    return request.META.get("REMOTE_ADDR", "")
+
+
+class AdminIPAllowlistMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if request.path.startswith("/admin/"):
+            allowlist = _get_allowlist()
+            if allowlist and _client_ip(request) not in allowlist:
+                raise Http404
+        return self.get_response(request)

--- a/backend/pos_backend/settings.py
+++ b/backend/pos_backend/settings.py
@@ -63,8 +63,8 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
-    'pos_backend.middleware.AdminIPAllowlistMiddleware',
     'django.middleware.security.SecurityMiddleware',
+    'pos_backend.middleware.AdminIPAllowlistMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',

--- a/backend/pos_backend/settings.py
+++ b/backend/pos_backend/settings.py
@@ -64,6 +64,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    'pos_backend.middleware.AdminIPAllowlistMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',

--- a/backend/pos_backend/settings.py
+++ b/backend/pos_backend/settings.py
@@ -63,8 +63,8 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
-    'django.middleware.security.SecurityMiddleware',
     'pos_backend.middleware.AdminIPAllowlistMiddleware',
+    'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = pos_backend.settings

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,6 +5,7 @@ openai
 Pillow
 django
 pytest
+pytest-django
 gunicorn
 psycopg
 python-dotenv

--- a/backend/tests/test_admin_middleware.py
+++ b/backend/tests/test_admin_middleware.py
@@ -2,7 +2,6 @@ import pytest
 from unittest.mock import MagicMock, patch
 
 from django.http import Http404
-from django.test import RequestFactory
 
 from pos_backend.middleware import AdminIPAllowlistMiddleware
 
@@ -13,12 +12,14 @@ def make_middleware(get_response=None):
     return AdminIPAllowlistMiddleware(get_response)
 
 
-def make_request(path, remote_addr="1.2.3.4", x_real_ip=None):
-    factory = RequestFactory()
-    request = factory.get(path)
-    request.META["REMOTE_ADDR"] = remote_addr
+def make_request(path, remote_addr="1.2.3.4", x_real_ip=None, xff=None):
+    request = MagicMock()
+    request.path = path
+    request.META = {"REMOTE_ADDR": remote_addr}
     if x_real_ip is not None:
         request.META["HTTP_X_REAL_IP"] = x_real_ip
+    if xff is not None:
+        request.META["HTTP_X_FORWARDED_FOR"] = xff
     return request
 
 
@@ -87,8 +88,7 @@ def test_path_with_admin_prefix_not_matched():
     middleware = make_middleware()
     request = make_request("/admintools/", remote_addr="9.9.9.9")
     with patch.dict("os.environ", {"ADMIN_IP_ALLOWLIST": "10.0.0.1"}):
-        # /admintools/ starts with /admin so it IS caught — this test
-        # documents the current conservative behaviour.
+        # /admintools/ starts with /admin so it IS caught — documents conservative behaviour.
         with pytest.raises(Http404):
             middleware(request)
 
@@ -107,8 +107,7 @@ def test_x_real_ip_takes_precedence_over_remote_addr():
 def test_x_forwarded_for_is_not_trusted():
     """X-Forwarded-For must not grant access — it's client-controlled."""
     middleware = make_middleware()
-    request = make_request("/admin/", remote_addr="9.9.9.9")
-    request.META["HTTP_X_FORWARDED_FOR"] = "10.0.0.1"
+    request = make_request("/admin/", remote_addr="9.9.9.9", xff="10.0.0.1")
     with patch.dict("os.environ", {"ADMIN_IP_ALLOWLIST": "10.0.0.1"}):
         with pytest.raises(Http404):
             middleware(request)

--- a/backend/tests/test_admin_middleware.py
+++ b/backend/tests/test_admin_middleware.py
@@ -33,7 +33,7 @@ def test_empty_allowlist_blocks_admin():
             middleware(request)
 
 
-def test_unset_allowlist_blocks_admin():
+def test_empty_string_allowlist_blocks_admin():
     middleware = make_middleware()
     request = make_request("/admin/")
     with patch.dict("os.environ", {"ADMIN_IP_ALLOWLIST": ""}, clear=False):
@@ -83,25 +83,24 @@ def test_non_admin_path_not_affected():
     assert response.status_code == 200
 
 
-def test_path_with_admin_prefix_not_matched():
-    """Paths like /admintools/ should not be gated — only /admin paths."""
+def test_path_with_admin_prefix_not_blocked():
+    """Paths like /admintools/ share the prefix but should not be gated."""
     middleware = make_middleware()
     request = make_request("/admintools/", remote_addr="9.9.9.9")
     with patch.dict("os.environ", {"ADMIN_IP_ALLOWLIST": "10.0.0.1"}):
-        # /admintools/ starts with /admin so it IS caught — documents conservative behaviour.
-        with pytest.raises(Http404):
-            middleware(request)
+        response = middleware(request)
+    assert response.status_code == 200
 
 
 # --- IP source precedence ---
 
-def test_x_real_ip_takes_precedence_over_remote_addr():
+def test_x_real_ip_is_not_trusted():
+    """X-Real-IP is client-controllable if no proxy is present; only REMOTE_ADDR is used."""
     middleware = make_middleware()
-    # REMOTE_ADDR is unlisted, X-Real-IP is listed
     request = make_request("/admin/", remote_addr="9.9.9.9", x_real_ip="10.0.0.1")
     with patch.dict("os.environ", {"ADMIN_IP_ALLOWLIST": "10.0.0.1"}):
-        response = middleware(request)
-    assert response.status_code == 200
+        with pytest.raises(Http404):
+            middleware(request)
 
 
 def test_x_forwarded_for_is_not_trusted():

--- a/backend/tests/test_admin_middleware.py
+++ b/backend/tests/test_admin_middleware.py
@@ -12,14 +12,14 @@ def make_middleware(get_response=None):
     return AdminIPAllowlistMiddleware(get_response)
 
 
-def make_request(path, remote_addr="1.2.3.4", x_real_ip=None, xff=None):
+def make_request(path, remote_addr="1.2.3.4", x_real_ip=None, spoofed_xff=None):
     request = MagicMock()
     request.path = path
     request.META = {"REMOTE_ADDR": remote_addr}
     if x_real_ip is not None:
         request.META["HTTP_X_REAL_IP"] = x_real_ip
-    if xff is not None:
-        request.META["HTTP_X_FORWARDED_FOR"] = xff
+    if spoofed_xff is not None:
+        request.META["HTTP_X_FORWARDED_FOR"] = spoofed_xff
     return request
 
 
@@ -106,7 +106,7 @@ def test_x_real_ip_is_not_trusted():
 def test_x_forwarded_for_is_not_trusted():
     """X-Forwarded-For must not grant access — it's client-controlled."""
     middleware = make_middleware()
-    request = make_request("/admin/", remote_addr="9.9.9.9", xff="10.0.0.1")
+    request = make_request("/admin/", remote_addr="9.9.9.9", spoofed_xff="10.0.0.1")
     with patch.dict("os.environ", {"ADMIN_IP_ALLOWLIST": "10.0.0.1"}):
         with pytest.raises(Http404):
             middleware(request)

--- a/backend/tests/test_admin_middleware.py
+++ b/backend/tests/test_admin_middleware.py
@@ -92,13 +92,13 @@ def test_path_with_admin_prefix_not_blocked():
     assert response.status_code == 200
 
 
-# --- IP source precedence ---
+# --- IP source: direct (no trusted proxy) ---
 
-def test_x_real_ip_is_not_trusted():
-    """X-Real-IP is client-controllable if no proxy is present; only REMOTE_ADDR is used."""
+def test_x_real_ip_ignored_without_trusted_proxy():
+    """X-Real-IP is not used when REMOTE_ADDR is not a trusted proxy."""
     middleware = make_middleware()
     request = make_request("/admin/", remote_addr="9.9.9.9", x_real_ip="10.0.0.1")
-    with patch.dict("os.environ", {"ADMIN_IP_ALLOWLIST": "10.0.0.1"}):
+    with patch.dict("os.environ", {"ADMIN_IP_ALLOWLIST": "10.0.0.1"}, clear=False):
         with pytest.raises(Http404):
             middleware(request)
 
@@ -107,6 +107,48 @@ def test_x_forwarded_for_is_not_trusted():
     """X-Forwarded-For must not grant access — it's client-controlled."""
     middleware = make_middleware()
     request = make_request("/admin/", remote_addr="9.9.9.9", spoofed_xff="10.0.0.1")
-    with patch.dict("os.environ", {"ADMIN_IP_ALLOWLIST": "10.0.0.1"}):
+    with patch.dict("os.environ", {"ADMIN_IP_ALLOWLIST": "10.0.0.1"}, clear=False):
+        with pytest.raises(Http404):
+            middleware(request)
+
+
+# --- IP source: behind trusted proxy (nginx → Gunicorn) ---
+
+def test_x_real_ip_used_when_remote_addr_is_trusted_proxy():
+    """When REMOTE_ADDR is a trusted proxy, X-Real-IP carries the real client IP."""
+    middleware = make_middleware()
+    request = make_request("/admin/", remote_addr="127.0.0.1", x_real_ip="10.0.0.1")
+    env = {"ADMIN_IP_ALLOWLIST": "10.0.0.1", "TRUSTED_PROXY_IPS": "127.0.0.1"}
+    with patch.dict("os.environ", env, clear=False):
+        response = middleware(request)
+    assert response.status_code == 200
+
+
+def test_unlisted_real_ip_blocked_via_trusted_proxy():
+    """Client not in allowlist is blocked even when coming through a trusted proxy."""
+    middleware = make_middleware()
+    request = make_request("/admin/", remote_addr="127.0.0.1", x_real_ip="9.9.9.9")
+    env = {"ADMIN_IP_ALLOWLIST": "10.0.0.1", "TRUSTED_PROXY_IPS": "127.0.0.1"}
+    with patch.dict("os.environ", env, clear=False):
+        with pytest.raises(Http404):
+            middleware(request)
+
+
+def test_trusted_proxy_without_x_real_ip_falls_back_to_remote_addr():
+    """If the trusted proxy didn't set X-Real-IP, fall back to REMOTE_ADDR."""
+    middleware = make_middleware()
+    request = make_request("/admin/", remote_addr="127.0.0.1")
+    env = {"ADMIN_IP_ALLOWLIST": "127.0.0.1", "TRUSTED_PROXY_IPS": "127.0.0.1"}
+    with patch.dict("os.environ", env, clear=False):
+        response = middleware(request)
+    assert response.status_code == 200
+
+
+def test_empty_trusted_proxy_ips_means_no_proxies_trusted():
+    """TRUSTED_PROXY_IPS unset/empty means X-Real-IP is never used."""
+    middleware = make_middleware()
+    request = make_request("/admin/", remote_addr="9.9.9.9", x_real_ip="10.0.0.1")
+    env = {"ADMIN_IP_ALLOWLIST": "10.0.0.1", "TRUSTED_PROXY_IPS": ""}
+    with patch.dict("os.environ", env, clear=False):
         with pytest.raises(Http404):
             middleware(request)

--- a/backend/tests/test_admin_middleware.py
+++ b/backend/tests/test_admin_middleware.py
@@ -1,0 +1,114 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from django.http import Http404
+from django.test import RequestFactory
+
+from pos_backend.middleware import AdminIPAllowlistMiddleware
+
+
+def make_middleware(get_response=None):
+    if get_response is None:
+        get_response = MagicMock(return_value=MagicMock(status_code=200))
+    return AdminIPAllowlistMiddleware(get_response)
+
+
+def make_request(path, remote_addr="1.2.3.4", x_real_ip=None):
+    factory = RequestFactory()
+    request = factory.get(path)
+    request.META["REMOTE_ADDR"] = remote_addr
+    if x_real_ip is not None:
+        request.META["HTTP_X_REAL_IP"] = x_real_ip
+    return request
+
+
+# --- allowlist parsing ---
+
+def test_empty_allowlist_blocks_admin():
+    middleware = make_middleware()
+    request = make_request("/admin/", remote_addr="1.2.3.4")
+    with patch.dict("os.environ", {}, clear=True):
+        with pytest.raises(Http404):
+            middleware(request)
+
+
+def test_unset_allowlist_blocks_admin():
+    middleware = make_middleware()
+    request = make_request("/admin/")
+    with patch.dict("os.environ", {"ADMIN_IP_ALLOWLIST": ""}, clear=False):
+        with pytest.raises(Http404):
+            middleware(request)
+
+
+def test_listed_ip_allowed():
+    middleware = make_middleware()
+    request = make_request("/admin/", remote_addr="10.0.0.1")
+    with patch.dict("os.environ", {"ADMIN_IP_ALLOWLIST": "10.0.0.1"}):
+        response = middleware(request)
+    assert response.status_code == 200
+
+
+def test_unlisted_ip_blocked():
+    middleware = make_middleware()
+    request = make_request("/admin/", remote_addr="9.9.9.9")
+    with patch.dict("os.environ", {"ADMIN_IP_ALLOWLIST": "10.0.0.1"}):
+        with pytest.raises(Http404):
+            middleware(request)
+
+
+def test_multiple_ips_in_allowlist():
+    middleware = make_middleware()
+    request = make_request("/admin/", remote_addr="10.0.0.2")
+    with patch.dict("os.environ", {"ADMIN_IP_ALLOWLIST": "10.0.0.1, 10.0.0.2, 10.0.0.3"}):
+        response = middleware(request)
+    assert response.status_code == 200
+
+
+# --- path matching ---
+
+def test_admin_without_trailing_slash_blocked():
+    middleware = make_middleware()
+    request = make_request("/admin", remote_addr="9.9.9.9")
+    with patch.dict("os.environ", {"ADMIN_IP_ALLOWLIST": "10.0.0.1"}):
+        with pytest.raises(Http404):
+            middleware(request)
+
+
+def test_non_admin_path_not_affected():
+    middleware = make_middleware()
+    request = make_request("/user_index/login/", remote_addr="9.9.9.9")
+    with patch.dict("os.environ", {"ADMIN_IP_ALLOWLIST": "10.0.0.1"}):
+        response = middleware(request)
+    assert response.status_code == 200
+
+
+def test_path_with_admin_prefix_not_matched():
+    """Paths like /admintools/ should not be gated — only /admin paths."""
+    middleware = make_middleware()
+    request = make_request("/admintools/", remote_addr="9.9.9.9")
+    with patch.dict("os.environ", {"ADMIN_IP_ALLOWLIST": "10.0.0.1"}):
+        # /admintools/ starts with /admin so it IS caught — this test
+        # documents the current conservative behaviour.
+        with pytest.raises(Http404):
+            middleware(request)
+
+
+# --- IP source precedence ---
+
+def test_x_real_ip_takes_precedence_over_remote_addr():
+    middleware = make_middleware()
+    # REMOTE_ADDR is unlisted, X-Real-IP is listed
+    request = make_request("/admin/", remote_addr="9.9.9.9", x_real_ip="10.0.0.1")
+    with patch.dict("os.environ", {"ADMIN_IP_ALLOWLIST": "10.0.0.1"}):
+        response = middleware(request)
+    assert response.status_code == 200
+
+
+def test_x_forwarded_for_is_not_trusted():
+    """X-Forwarded-For must not grant access — it's client-controlled."""
+    middleware = make_middleware()
+    request = make_request("/admin/", remote_addr="9.9.9.9")
+    request.META["HTTP_X_FORWARDED_FOR"] = "10.0.0.1"
+    with patch.dict("os.environ", {"ADMIN_IP_ALLOWLIST": "10.0.0.1"}):
+        with pytest.raises(Http404):
+            middleware(request)

--- a/backend/user_system/admin.py
+++ b/backend/user_system/admin.py
@@ -1,6 +1,40 @@
 from django.contrib import admin
-
 from django.contrib.auth.admin import UserAdmin
+
 from .models import PositiveOnlySocialUser
 
-admin.site.register(PositiveOnlySocialUser, UserAdmin)
+_SUPERUSER_ONLY_FIELDS = frozenset(("is_staff", "is_superuser", "groups", "user_permissions"))
+_ALWAYS_READONLY_FIELDS = ("verification_token", "verification_token_expires",
+                           "reset_token", "reset_token_expires")
+
+
+class PositiveOnlySocialUserAdmin(UserAdmin):
+    fieldsets = UserAdmin.fieldsets + (
+        ("Profile", {"fields": (
+            "identity_is_verified", "is_adult",
+            "report_id", "verification_report_status",
+            "verification_token", "verification_token_expires",
+            "reset_token", "reset_token_expires",
+        )}),
+    )
+
+    def get_readonly_fields(self, request, obj=None):
+        readonly = set(super().get_readonly_fields(request, obj))
+        readonly.update(_ALWAYS_READONLY_FIELDS)
+        if not request.user.is_superuser:
+            readonly.update(_SUPERUSER_ONLY_FIELDS)
+        return tuple(readonly)
+
+    def get_fieldsets(self, request, obj=None):
+        fieldsets = super().get_fieldsets(request, obj)
+        if request.user.is_superuser:
+            return fieldsets
+        return [
+            (name, {**opts, "fields": tuple(
+                f for f in opts["fields"] if f not in _SUPERUSER_ONLY_FIELDS
+            )})
+            for name, opts in fieldsets
+        ]
+
+
+admin.site.register(PositiveOnlySocialUser, PositiveOnlySocialUserAdmin)


### PR DESCRIPTION
## Summary
- Adds `AdminIPAllowlistMiddleware` in `pos_backend/middleware.py` that reads `ADMIN_IP_ALLOWLIST` (comma-separated IPs) from env and returns 404 for any unlisted client hitting `/admin/`. Unset/empty var blocks all admin traffic — safe by default.
- Replaces the bare `UserAdmin` registration in `user_system/admin.py` with `PositiveOnlySocialUserAdmin` that hides `is_staff`, `is_superuser`, `groups`, and `user_permissions` from non-superusers, makes security tokens always read-only, and surfaces custom profile fields.

Closes #123

## Test plan
- [ ] Set `ADMIN_IP_ALLOWLIST` to your machine's IP and confirm `/admin/` loads
- [ ] Remove/unset `ADMIN_IP_ALLOWLIST` and confirm `/admin/` returns 404
- [ ] Add a second IP to the allowlist and confirm both IPs can reach admin
- [ ] Log in as a staff (non-superuser) user and confirm `is_staff`/`is_superuser` fields are absent from the user change form
- [ ] Log in as a superuser and confirm those fields are still present and editable
- [ ] Confirm `verification_token` and `reset_token` are read-only for all admin users

🤖 Generated with [Claude Code](https://claude.com/claude-code)