### PR TITLE
Fix decoding crash for old UserSession Keychain entries

### DIFF
--- a/ios/Positive Only Social/Positive Only Social/api/Models.swift
+++ b/ios/Positive Only Social/Positive Only Social/api/Models.swift
@@ -100,7 +100,7 @@ struct UserSession: Codable, Equatable {
         sessionToken = try c.decode(String.self, forKey: .sessionToken)
         username = try c.decode(String.self, forKey: .username)
         userId = try c.decodeIfPresent(Int.self, forKey: .userId) ?? 0
-        isIdentityVerified = try c.decode(Bool.self, forKey: .isIdentityVerified)
+        isIdentityVerified = try c.decodeIfPresent(Bool.self, forKey: .isIdentityVerified) ?? false
     }
 }
 


### PR DESCRIPTION
## Summary
- `UserSession.init(from decoder:)` used `c.decode` (required) for `isIdentityVerified`, causing a `DecodingError.keyNotFound` crash when loading Keychain-persisted sessions saved before this field was added
- Changed to `c.decodeIfPresent(...) ?? false` to match the same graceful pattern already used for `userId`

Closes #136

## Test plan
- [ ] Log in with a fresh account — `isIdentityVerified` is set correctly from the server response
- [ ] Simulate an old Keychain entry (missing `isIdentityVerified`) — app loads without crashing, defaults to `false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)