### PR TITLE
Fix user_id type mismatch: Int -> String (UUID) on iOS and Android

### DIFF
--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/api/StatefulStubbedAPI.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/api/StatefulStubbedAPI.kt
@@ -33,9 +33,6 @@ class StatefulStubbedAPI : PositiveOnlySocialAPI {
     // Set this variable before making authenticated calls.
     var simulatedAuthToken: String? = null
 
-    // Auto-incrementing numeric user ID, matching the backend's integer primary key.
-    private var nextUserId = 1
-
     // Constants from backend
     private val POST_BATCH_SIZE = 10
     private val COMMENT_BATCH_SIZE = 10
@@ -47,7 +44,6 @@ class StatefulStubbedAPI : PositiveOnlySocialAPI {
 
     private data class UserMock(
         val id: String = UUID.randomUUID().toString(),
-        val numericId: Int,
         val username: String,
         val email: String,
         var passwordHash: String, // Storing plain text for stub simplicity, or simple hash
@@ -135,7 +131,6 @@ class StatefulStubbedAPI : PositiveOnlySocialAPI {
 
         // Create User
         val newUser = UserMock(
-            numericId = nextUserId++,
             username = request.username,
             email = request.email,
             passwordHash = request.password // Stub: Plain text
@@ -155,7 +150,7 @@ class StatefulStubbedAPI : PositiveOnlySocialAPI {
             loginCookies.add(LoginCookieMock(seriesId, cookieToken, newUser.id))
         }
 
-        return Response.success(AuthResponse(sessionToken, newUser.username, newUser.numericId, seriesId, cookieToken))
+        return Response.success(AuthResponse(sessionToken, newUser.username, newUser.id, seriesId, cookieToken))
     }
 
     override suspend fun loginUser(request: LoginRequest): Response<AuthResponse> {
@@ -182,7 +177,7 @@ class StatefulStubbedAPI : PositiveOnlySocialAPI {
         // Auto-set the token for convenience in this stateful stub
         simulatedAuthToken = sessionToken
 
-        return Response.success(AuthResponse(sessionToken, user.username, user.numericId, seriesId, cookieToken))
+        return Response.success(AuthResponse(sessionToken, user.username, user.id, seriesId, cookieToken))
     }
 
     override suspend fun loginUserWithRememberMe(request: TokenRefreshRequest): Response<TokenRefreshResponse> {

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/model/Models.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/model/Models.kt
@@ -21,7 +21,7 @@ data class IdentityVerificationRequest(
 data class AuthResponse(
     @SerializedName("session_management_token") val sessionToken: String,
     val username: String?,
-    @SerializedName("user_id") val userId: Int?,
+    @SerializedName("user_id") val userId: String?,
     @SerializedName("series_identifier") val seriesIdentifier: String?,
     @SerializedName("login_cookie_token") val loginCookieToken: String?
 )
@@ -150,7 +150,7 @@ data class GenericResponse(
 data class UserSession(
     val sessionToken: String,
     val username: String,
-    val userId: Int,
+    val userId: String,
     val isIdentityVerified: Boolean,
     // Kept for internal Android logic if needed, but nullable
     val seriesIdentifier: String? = null,

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/FeedViewModel.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/FeedViewModel.kt
@@ -36,7 +36,7 @@ class FeedViewModel(
         viewModelScope.launch {
             try {
                 val userSession = keychainHelper.load(UserSession::class.java, service, account)
-                    ?: UserSession("123", "testuser", 0, false, null, null)
+                    ?: UserSession("123", "testuser", "", false, null, null)
 
                 val response = api.getPostsInFeed(userSession.sessionToken, currentPage)
                 if (response.isSuccessful) {

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/FollowingFeedViewModel.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/FollowingFeedViewModel.kt
@@ -35,7 +35,7 @@ class FollowingFeedViewModel(
         viewModelScope.launch {
             try {
                 val userSession = keychainHelper.load(UserSession::class.java, service, account)
-                    ?: UserSession("123", "testuser", 0, false, null, null)
+                    ?: UserSession("123", "testuser", "", false, null, null)
 
                 val response = api.getFollowedPosts(userSession.sessionToken, currentPage)
                 if (response.isSuccessful) {

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/HomeViewModel.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/HomeViewModel.kt
@@ -65,7 +65,7 @@ class HomeViewModel(
         viewModelScope.launch {
             try {
                 val userSession = keychainHelper.load(UserSession::class.java, service, account)
-                    ?: UserSession("123", "testuser", 0, false, null, null)
+                    ?: UserSession("123", "testuser", "", false, null, null)
 
                 // Now we have the username in the session!
                 val username = userSession.username
@@ -99,7 +99,7 @@ class HomeViewModel(
 
         try {
             val userSession = keychainHelper.load(UserSession::class.java, service, account)
-                ?: UserSession("123", "testuser", 0, false, null, null)
+                ?: UserSession("123", "testuser", "", false, null, null)
 
             val response = api.searchUsers(userSession.sessionToken, query)
             if (response.isSuccessful) {

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/PostDetailViewModel.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/PostDetailViewModel.kt
@@ -142,7 +142,7 @@ class PostDetailViewModel(
         viewModelScope.launch {
             try {
                 val userSession = keychainHelper.load(UserSession::class.java, service, account)
-                    ?: UserSession("123", "testuser", 0, false, null, null)
+                    ?: UserSession("123", "testuser", "", false, null, null)
                 val response = api.likePost(userSession.sessionToken, postIdentifier)
                 if (response.isSuccessful) {
                     // Reload data to get fresh counts
@@ -161,7 +161,7 @@ class PostDetailViewModel(
         viewModelScope.launch {
             try {
                 val userSession = keychainHelper.load(UserSession::class.java, service, account)
-                    ?: UserSession("123", "testuser", 0, false, null, null)
+                    ?: UserSession("123", "testuser", "", false, null, null)
                 val response = api.unlikePost(userSession.sessionToken, postIdentifier)
                 if (response.isSuccessful) {
                     loadAllData()
@@ -179,7 +179,7 @@ class PostDetailViewModel(
         viewModelScope.launch {
             try {
                 val userSession = keychainHelper.load(UserSession::class.java, service, account)
-                    ?: UserSession("123", "testuser", 0, false, null, null)
+                    ?: UserSession("123", "testuser", "", false, null, null)
                 val response = api.reportPost(userSession.sessionToken, postIdentifier, ReportRequest(reason))
                 if (response.isSuccessful) {
                     _alertMessage.value = "Post reported successfully."
@@ -197,7 +197,7 @@ class PostDetailViewModel(
         viewModelScope.launch {
             try {
                 val userSession = keychainHelper.load(UserSession::class.java, service, account)
-                    ?: UserSession("123", "testuser", 0, false, null, null)
+                    ?: UserSession("123", "testuser", "", false, null, null)
                 val response = api.likeComment(userSession.sessionToken, postIdentifier, threadId, comment.id)
                 if (response.isSuccessful) {
                     loadAllData()
@@ -215,7 +215,7 @@ class PostDetailViewModel(
         viewModelScope.launch {
             try {
                 val userSession = keychainHelper.load(UserSession::class.java, service, account)
-                    ?: UserSession("123", "testuser", 0, false, null, null)
+                    ?: UserSession("123", "testuser", "", false, null, null)
                 val response = api.unlikeComment(userSession.sessionToken, postIdentifier, threadId, comment.id)
                 if (response.isSuccessful) {
                     loadAllData()
@@ -233,7 +233,7 @@ class PostDetailViewModel(
         viewModelScope.launch {
             try {
                 val userSession = keychainHelper.load(UserSession::class.java, service, account)
-                    ?: UserSession("123", "testuser", 0, false, null, null)
+                    ?: UserSession("123", "testuser", "", false, null, null)
                 val response = api.reportComment(userSession.sessionToken, postIdentifier, threadId, comment.id, ReportRequest(reason))
                 if (response.isSuccessful) {
                     _alertMessage.value = "Comment reported successfully."
@@ -253,7 +253,7 @@ class PostDetailViewModel(
         viewModelScope.launch {
             try {
                 val userSession = keychainHelper.load(UserSession::class.java, service, account)
-                    ?: UserSession("123", "testuser", 0, false, null, null)
+                    ?: UserSession("123", "testuser", "", false, null, null)
                 
                 val response = api.commentOnPost(
                     userSession.sessionToken,
@@ -285,7 +285,7 @@ class PostDetailViewModel(
         viewModelScope.launch {
             try {
                 val userSession = keychainHelper.load(UserSession::class.java, service, account)
-                    ?: UserSession("123", "testuser", 0, false, null, null)
+                    ?: UserSession("123", "testuser", "", false, null, null)
                 
                 val response = api.replyToThread(
                     userSession.sessionToken,

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/ProfileViewModel.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/ProfileViewModel.kt
@@ -55,7 +55,7 @@ class ProfileViewModel(
         viewModelScope.launch {
             try {
                 val userSession = keychainHelper.load(UserSession::class.java, service, account)
-                    ?: UserSession("123", "testuser", 0, false, null, null)
+                    ?: UserSession("123", "testuser", "", false, null, null)
 
                 // Fetch Profile Details
                 val profileResponse = api.getProfileDetails(userSession.sessionToken, username)
@@ -103,7 +103,7 @@ class ProfileViewModel(
         viewModelScope.launch {
             try {
                 val userSession = keychainHelper.load(UserSession::class.java, service, account)
-                    ?: UserSession("123", "testuser", 0, false, null, null)
+                    ?: UserSession("123", "testuser", "", false, null, null)
 
                 val response = api.getPostsForUser(userSession.sessionToken, username, currentPage)
 
@@ -141,7 +141,7 @@ class ProfileViewModel(
         viewModelScope.launch {
             try {
                 val userSession = keychainHelper.load(UserSession::class.java, service, account)
-                    ?: UserSession("123", "testuser", 0, false, null, null)
+                    ?: UserSession("123", "testuser", "", false, null, null)
 
                 val response = if (isFollowing) {
                     api.unfollowUser(userSession.sessionToken, username)
@@ -177,7 +177,7 @@ class ProfileViewModel(
         viewModelScope.launch {
             try {
                 val userSession = keychainHelper.load(UserSession::class.java, service, account)
-                    ?: UserSession("123", "testuser", 0, false, null, null)
+                    ?: UserSession("123", "testuser", "", false, null, null)
 
                 val response = api.toggleBlock(userSession.sessionToken, username)
 

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/auth/WelcomeScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/auth/WelcomeScreen.kt
@@ -76,7 +76,7 @@ fun WelcomeScreen(
                     if (existingSession == null) {
                         throw Exception("No existing session found for remember-me refresh.")
                     }
-                    if (existingSession.userId == 0) {
+                    if (existingSession.userId.isEmpty()) {
                         throw Exception("Stored session has no valid user ID. Please log in again.")
                     }
                     val userSession = UserSession(

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/NewPostScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/NewPostScreen.kt
@@ -159,7 +159,7 @@ fun NewPostScreen(
                                     return@launch
                                 }
 
-                                if (session.userId == 0) {
+                                if (session.userId.isEmpty()) {
                                     failureMessage = "Session is invalid. Please log in again."
                                     showFailureAlert = true
                                     return@launch

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/preview/PreviewHelpers.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/preview/PreviewHelpers.kt
@@ -28,7 +28,7 @@ class MockPositiveOnlySocialAPI : PositiveOnlySocialAPI {
             AuthResponse(
                 sessionToken = "mock_session_token",
                 username = request.usernameOrEmail,
-                userId = "",
+                userId = "00000000-0000-0000-0000-000000000001",
                 seriesIdentifier = "mock_series_id",
                 loginCookieToken = "mock_login_cookie"
             )
@@ -49,7 +49,7 @@ class MockPositiveOnlySocialAPI : PositiveOnlySocialAPI {
             AuthResponse(
                 sessionToken = "mock_session_token",
                 username = request.username,
-                userId = "",
+                userId = "00000000-0000-0000-0000-000000000001",
                 seriesIdentifier = "mock_series_id",
                 loginCookieToken = "mock_login_cookie"
             )

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/preview/PreviewHelpers.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/preview/PreviewHelpers.kt
@@ -28,7 +28,7 @@ class MockPositiveOnlySocialAPI : PositiveOnlySocialAPI {
             AuthResponse(
                 sessionToken = "mock_session_token",
                 username = request.usernameOrEmail,
-                userId = 1,
+                userId = "",
                 seriesIdentifier = "mock_series_id",
                 loginCookieToken = "mock_login_cookie"
             )
@@ -49,7 +49,7 @@ class MockPositiveOnlySocialAPI : PositiveOnlySocialAPI {
             AuthResponse(
                 sessionToken = "mock_session_token",
                 username = request.username,
-                userId = 1,
+                userId = "",
                 seriesIdentifier = "mock_series_id",
                 loginCookieToken = "mock_login_cookie"
             )

--- a/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/FeedViewModelTest.kt
+++ b/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/FeedViewModelTest.kt
@@ -30,7 +30,7 @@ class FeedViewModelTest {
     private lateinit var api: PositiveOnlySocialAPI
     private lateinit var keychainHelper: KeychainHelperProtocol
 
-    private val mockUserSession = UserSession("token123", "testuser", 1, false, null, null)
+    private val mockUserSession = UserSession("token123", "testuser", "1", false, null, null)
 
     @Before
     fun setup() {

--- a/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/FollowingFeedViewModelTest.kt
+++ b/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/FollowingFeedViewModelTest.kt
@@ -29,7 +29,7 @@ class FollowingFeedViewModelTest {
     private lateinit var api: PositiveOnlySocialAPI
     private lateinit var keychainHelper: KeychainHelperProtocol
 
-    private val mockUserSession = UserSession("token123", "testuser", 1, false, null, null)
+    private val mockUserSession = UserSession("token123", "testuser", "1", false, null, null)
 
     @Before
     fun setup() {

--- a/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/HomeViewModelTest.kt
+++ b/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/HomeViewModelTest.kt
@@ -32,7 +32,7 @@ class HomeViewModelTest {
     private lateinit var api: PositiveOnlySocialAPI
     private lateinit var keychainHelper: KeychainHelperProtocol
 
-    private val mockUserSession = UserSession("token123", "testuser", 1, false, null, null)
+    private val mockUserSession = UserSession("token123", "testuser", "1", false, null, null)
 
     @Before
     fun setup() {

--- a/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/PostDetailViewModelTest.kt
+++ b/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/PostDetailViewModelTest.kt
@@ -33,7 +33,7 @@ class PostDetailViewModelTest {
     private lateinit var api: PositiveOnlySocialAPI
     private lateinit var keychainHelper: KeychainHelperProtocol
 
-    private val mockUserSession = UserSession("token123", "testuser", 1, false, null, null)
+    private val mockUserSession = UserSession("token123", "testuser", "1", false, null, null)
     private val postIdentifier = "post123"
 
     @Before

--- a/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/ProfileViewModelTest.kt
+++ b/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/ProfileViewModelTest.kt
@@ -32,7 +32,7 @@ class ProfileViewModelTest {
     private lateinit var api: PositiveOnlySocialAPI
     private lateinit var keychainHelper: KeychainHelperProtocol
 
-    private val mockUserSession = UserSession("token123", "testuser", 1, false, null, null)
+    private val mockUserSession = UserSession("token123", "testuser", "1", false, null, null)
 
     @Before
     fun setup() {

--- a/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/SettingsViewModelTest.kt
+++ b/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/SettingsViewModelTest.kt
@@ -32,7 +32,7 @@ class SettingsViewModelTest {
     private lateinit var authManager: AuthenticationManager
     private lateinit var keychainHelper: KeychainHelperProtocol
 
-    private val mockUserSession = UserSession("token123", "testuser", 1, false, null, null)
+    private val mockUserSession = UserSession("token123", "testuser", "1", false, null, null)
 
     @Before
     fun setup() {

--- a/ios/Positive Only Social/Positive Only Social/NewPostView.swift
+++ b/ios/Positive Only Social/Positive Only Social/NewPostView.swift
@@ -115,7 +115,7 @@ struct NewPostView: View {
                 // 1. LOAD SESSION (needed for the scoped S3 key)
                 let userSession: UserSession
                 if isTesting() {
-                    userSession = try keychainHelper.load(UserSession.self, from: "positive-only-social.Positive-Only-Social", account: "userSessionToken") ?? UserSession(sessionToken: "123", username: "test", userId: 1, isIdentityVerified: false)
+                    userSession = try keychainHelper.load(UserSession.self, from: "positive-only-social.Positive-Only-Social", account: "userSessionToken") ?? UserSession(sessionToken: "123", username: "test", userId: "", isIdentityVerified: false)
                 } else {
                     guard let loaded = try keychainHelper.load(UserSession.self, from: "positive-only-social.Positive-Only-Social", account: "userSessionToken") else {
                         failureAlertMessage = "You must be logged in to post."

--- a/ios/Positive Only Social/Positive Only Social/WelcomeView.swift
+++ b/ios/Positive Only Social/Positive Only Social/WelcomeView.swift
@@ -97,7 +97,7 @@ struct WelcomeView: View {
                 guard let existingSession = existingSession else {
                     throw NSError(domain: "AutoLoginError", code: 0, userInfo: [NSLocalizedDescriptionKey: "No existing session found for remember-me refresh."])
                 }
-                guard existingSession.userId != 0 else {
+                guard !existingSession.userId.isEmpty else {
                     throw NSError(domain: "AutoLoginError", code: 0, userInfo: [NSLocalizedDescriptionKey: "Stored session has no valid user ID. Please log in again."])
                 }
                 let userSession = UserSession(sessionToken: loginDetails.sessionManagementToken, username: existingSession.username, userId: existingSession.userId, isIdentityVerified: existingSession.isIdentityVerified)

--- a/ios/Positive Only Social/Positive Only Social/api/Models.swift
+++ b/ios/Positive Only Social/Positive Only Social/api/Models.swift
@@ -14,7 +14,7 @@ import Foundation
 struct LoginResponseFields: Codable {
     let sessionManagementToken: String
     let username: String?
-    let userId: Int?
+    let userId: String?
     let seriesIdentifier: String?
     let loginCookieToken: String?
 
@@ -84,10 +84,10 @@ struct ProfileDetailsResponse: Codable, Identifiable, Hashable {
 struct UserSession: Codable, Equatable {
     let sessionToken: String
     let username: String
-    let userId: Int
+    let userId: String
     let isIdentityVerified: Bool
 
-    init(sessionToken: String, username: String, userId: Int, isIdentityVerified: Bool) {
+    init(sessionToken: String, username: String, userId: String, isIdentityVerified: Bool) {
         self.sessionToken = sessionToken
         self.username = username
         self.userId = userId
@@ -99,7 +99,7 @@ struct UserSession: Codable, Equatable {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         sessionToken = try c.decode(String.self, forKey: .sessionToken)
         username = try c.decode(String.self, forKey: .username)
-        userId = try c.decodeIfPresent(Int.self, forKey: .userId) ?? 0
+        userId = try c.decodeIfPresent(String.self, forKey: .userId) ?? ""
         isIdentityVerified = try c.decodeIfPresent(Bool.self, forKey: .isIdentityVerified) ?? false
     }
 }

--- a/ios/Positive Only Social/Positive Only Social/api/StatefulStubbedAPI.swift
+++ b/ios/Positive Only Social/Positive Only Social/api/StatefulStubbedAPI.swift
@@ -10,9 +10,7 @@ struct SerializationError: Error, LocalizedError {
 
 // Public so the Settings tests can use it
 struct MockUser {
-    private static var counter: Int = 0
     let id = UUID()
-    let numericId: Int
     var username: String
     var email: String
     var passwordHash: String // Storing plain text for mock purposes.
@@ -24,8 +22,6 @@ struct MockUser {
     var blockedBy: [UUID] = []
 
     init(username: String, email: String, passwordHash: String) {
-        MockUser.counter += 1
-        numericId = MockUser.counter
         self.username = username
         self.email = email
         self.passwordHash = passwordHash
@@ -154,16 +150,16 @@ final class StatefulStubbedAPI: Networking {
         if wantsRememberMe {
             let cookie = MockLoginCookie(seriesIdentifier: UUID().uuidString, token: generateToken(), userId: newUser.id)
             loginCookies.append(cookie)
-            struct Fields: Codable { let series_identifier, login_cookie_token, session_management_token: String; let user_id: Int }
+            struct Fields: Codable { let series_identifier, login_cookie_token, session_management_token, user_id: String }
             return try createSerializedResponse(fields: Fields(
                 series_identifier: cookie.seriesIdentifier,
                 login_cookie_token: cookie.token,
                 session_management_token: newSession.managementToken,
-                user_id: newUser.numericId
+                user_id: newUser.id.uuidString
             ))
         } else {
-            struct Fields: Codable { let session_management_token: String; let user_id: Int }
-            return try createSerializedResponse(fields: Fields(session_management_token: newSession.managementToken, user_id: newUser.numericId))
+            struct Fields: Codable { let session_management_token, user_id: String }
+            return try createSerializedResponse(fields: Fields(session_management_token: newSession.managementToken, user_id: newUser.id.uuidString))
         }
     }
 
@@ -180,20 +176,20 @@ final class StatefulStubbedAPI: Networking {
         if wantsRememberMe {
             let cookie = MockLoginCookie(seriesIdentifier: UUID().uuidString, token: generateToken(), userId: user.id)
             loginCookies.append(cookie)
-            struct Fields: Codable { let series_identifier, login_cookie_token, session_management_token, username: String; let user_id: Int }
+            struct Fields: Codable { let series_identifier, login_cookie_token, session_management_token, username, user_id: String }
             return try createSerializedResponse(fields: Fields(
                 series_identifier: cookie.seriesIdentifier,
                 login_cookie_token: cookie.token,
                 session_management_token: newSession.managementToken,
                 username: user.username,
-                user_id: user.numericId
+                user_id: user.id.uuidString
             ))
         } else {
-            struct Fields: Codable { let session_management_token, username: String; let user_id: Int }
+            struct Fields: Codable { let session_management_token, username, user_id: String }
             return try createSerializedResponse(fields: Fields(
                 session_management_token: newSession.managementToken,
                 username: user.username,
-                user_id: user.numericId
+                user_id: user.id.uuidString
             ))
         }
     }

--- a/ios/Positive Only Social/Positive Only Social/preview/PreviewHelpers.swift
+++ b/ios/Positive Only Social/Positive Only Social/preview/PreviewHelpers.swift
@@ -51,7 +51,7 @@ struct MockedAPI: Networking {
         let response = LoginResponseFields(
             sessionManagementToken: "mock_session_token",
             username: username,
-            userId: "1",
+            userId: "00000000-0000-0000-0000-000000000001",
             seriesIdentifier: "mock_series_id",
             loginCookieToken: "mock_login_cookie"
         )
@@ -62,7 +62,7 @@ struct MockedAPI: Networking {
         let response = LoginResponseFields(
             sessionManagementToken: "mock_session_token",
             username: usernameOrEmail,
-            userId: "1",
+            userId: "00000000-0000-0000-0000-000000000001",
             seriesIdentifier: "mock_series_id",
             loginCookieToken: "mock_login_cookie"
         )
@@ -73,7 +73,7 @@ struct MockedAPI: Networking {
         let response = LoginResponseFields(
             sessionManagementToken: "new_mock_session",
             username: "mock_user",
-            userId: "1",
+            userId: "00000000-0000-0000-0000-000000000001",
             seriesIdentifier: "mock_series_id",
             loginCookieToken: "new_mock_cookie"
         )
@@ -284,9 +284,9 @@ struct PreviewHelpers {
         return manager
     }
     
-    @MainActor static func loggedInAuthManager() -> AuthenticationManager {
+    @MainActor static let loggedInAuthManager: AuthenticationManager = {
         let manager = AuthenticationManager(shouldAutoLogin: false, keychainHelper: keychainHelper)
         manager.login(with: UserSession(sessionToken: "mock_token", username: "preview_user", userId: "00000000-0000-0000-0000-000000000001", isIdentityVerified: true))
         return manager
-    }
+    }()
 }

--- a/ios/Positive Only Social/Positive Only Social/preview/PreviewHelpers.swift
+++ b/ios/Positive Only Social/Positive Only Social/preview/PreviewHelpers.swift
@@ -286,7 +286,7 @@ struct PreviewHelpers {
     
     @MainActor static func loggedInAuthManager() -> AuthenticationManager {
         let manager = AuthenticationManager(shouldAutoLogin: false, keychainHelper: keychainHelper)
-        manager.login(with: UserSession(sessionToken: "mock_token", username: "preview_user", userId: "", isIdentityVerified: true))
+        manager.login(with: UserSession(sessionToken: "mock_token", username: "preview_user", userId: "00000000-0000-0000-0000-000000000001", isIdentityVerified: true))
         return manager
     }
 }

--- a/ios/Positive Only Social/Positive Only Social/preview/PreviewHelpers.swift
+++ b/ios/Positive Only Social/Positive Only Social/preview/PreviewHelpers.swift
@@ -51,7 +51,7 @@ struct MockedAPI: Networking {
         let response = LoginResponseFields(
             sessionManagementToken: "mock_session_token",
             username: username,
-            userId: 1,
+            userId: "1",
             seriesIdentifier: "mock_series_id",
             loginCookieToken: "mock_login_cookie"
         )
@@ -62,7 +62,7 @@ struct MockedAPI: Networking {
         let response = LoginResponseFields(
             sessionManagementToken: "mock_session_token",
             username: usernameOrEmail,
-            userId: 1,
+            userId: "1",
             seriesIdentifier: "mock_series_id",
             loginCookieToken: "mock_login_cookie"
         )
@@ -73,7 +73,7 @@ struct MockedAPI: Networking {
         let response = LoginResponseFields(
             sessionManagementToken: "new_mock_session",
             username: "mock_user",
-            userId: 1,
+            userId: "1",
             seriesIdentifier: "mock_series_id",
             loginCookieToken: "new_mock_cookie"
         )
@@ -286,7 +286,7 @@ struct PreviewHelpers {
     
     @MainActor static func loggedInAuthManager() -> AuthenticationManager {
         let manager = AuthenticationManager(shouldAutoLogin: false, keychainHelper: keychainHelper)
-        manager.login(with: UserSession(sessionToken: "mock_token", username: "preview_user", userId: 0, isIdentityVerified: true))
+        manager.login(with: UserSession(sessionToken: "mock_token", username: "preview_user", userId: "", isIdentityVerified: true))
         return manager
     }
 }

--- a/ios/Positive Only Social/Positive Only Social/viewmodels/FeedViewModel.swift
+++ b/ios/Positive Only Social/Positive Only Social/viewmodels/FeedViewModel.swift
@@ -34,7 +34,7 @@ final class FeedViewModel: ObservableObject {
         
         Task {
             do {
-                let userSession = try keychainHelper.load(UserSession.self, from: "positive-only-social.Positive-Only-Social", account: account) ?? UserSession(sessionToken: "123", username: "test", userId: 0, isIdentityVerified: false)
+                let userSession = try keychainHelper.load(UserSession.self, from: "positive-only-social.Positive-Only-Social", account: account) ?? UserSession(sessionToken: "123", username: "test", userId: "", isIdentityVerified: false)
                 
                 let responseData = try await api.getPostsInFeed(sessionManagementToken: userSession.sessionToken, batch: currentPage)
                 let newPosts = try JSONDecoder().decode([Post].self, from: responseData)

--- a/ios/Positive Only Social/Positive Only Social/viewmodels/FollowingFeedViewModel.swift
+++ b/ios/Positive Only Social/Positive Only Social/viewmodels/FollowingFeedViewModel.swift
@@ -34,7 +34,7 @@ final class FollowingFeedViewModel: ObservableObject {
         
         Task {
             do {
-                let userSession = try keychainHelper.load(UserSession.self, from: "positive-only-social.Positive-Only-Social", account: account) ?? UserSession(sessionToken: "123", username: "test", userId: 0, isIdentityVerified: false)
+                let userSession = try keychainHelper.load(UserSession.self, from: "positive-only-social.Positive-Only-Social", account: account) ?? UserSession(sessionToken: "123", username: "test", userId: "", isIdentityVerified: false)
                 
                 
                 // --- KEY CHANGE ---

--- a/ios/Positive Only Social/Positive Only Social/viewmodels/HomeViewModel.swift
+++ b/ios/Positive Only Social/Positive Only Social/viewmodels/HomeViewModel.swift
@@ -59,7 +59,7 @@ final class HomeViewModel: ObservableObject {
         
         Task {
             do {
-                let user = try keychainHelper.load(UserSession.self, from: "positive-only-social.Positive-Only-Social", account: account) ?? UserSession(sessionToken: "123", username: "test", userId: 0, isIdentityVerified: false)
+                let user = try keychainHelper.load(UserSession.self, from: "positive-only-social.Positive-Only-Social", account: account) ?? UserSession(sessionToken: "123", username: "test", userId: "", isIdentityVerified: false)
 
                 // Call the API
                 let newPosts = try await fetchPosts(for: user.username, token: user.sessionToken, page: currentPage)
@@ -93,7 +93,7 @@ final class HomeViewModel: ObservableObject {
         
         Task {
             do {
-                let userSession = try keychainHelper.load(UserSession.self, from: "positive-only-social.Positive-Only-Social", account: account) ?? UserSession(sessionToken: "123", username: "test", userId: 0, isIdentityVerified: false)
+                let userSession = try keychainHelper.load(UserSession.self, from: "positive-only-social.Positive-Only-Social", account: account) ?? UserSession(sessionToken: "123", username: "test", userId: "", isIdentityVerified: false)
                 
                 self.searchedUsers = try await searchForUsers(fragment: query, token: userSession.sessionToken)
             } catch {

--- a/ios/Positive Only Social/Positive Only Social/viewmodels/PostDetailViewModel.swift
+++ b/ios/Positive Only Social/Positive Only Social/viewmodels/PostDetailViewModel.swift
@@ -147,7 +147,7 @@ final class PostDetailViewModel: ObservableObject {
         
         Task {
             do {
-                let userSession = try keychainHelper.load(UserSession.self, from: "positive-only-social.Positive-Only-Social", account: account) ?? UserSession(sessionToken: "123", username: "test", userId: 0, isIdentityVerified: false)
+                let userSession = try keychainHelper.load(UserSession.self, from: "positive-only-social.Positive-Only-Social", account: account) ?? UserSession(sessionToken: "123", username: "test", userId: "", isIdentityVerified: false)
                 let token = userSession.sessionToken
                 _ = try await api.likePost(sessionManagementToken: token, postIdentifier: postIdentifier)
             } catch {
@@ -175,7 +175,7 @@ final class PostDetailViewModel: ObservableObject {
         
         Task {
             do {
-                let userSession = try keychainHelper.load(UserSession.self, from: "positive-only-social.Positive-Only-Social", account: account) ?? UserSession(sessionToken: "123", username: "test", userId: 0, isIdentityVerified: false)
+                let userSession = try keychainHelper.load(UserSession.self, from: "positive-only-social.Positive-Only-Social", account: account) ?? UserSession(sessionToken: "123", username: "test", userId: "", isIdentityVerified: false)
                 let token = userSession.sessionToken
                 _ = try await api.unlikePost(sessionManagementToken: token, postIdentifier: postIdentifier)
             } catch {
@@ -191,7 +191,7 @@ final class PostDetailViewModel: ObservableObject {
         print("ACTION: Report post \(postIdentifier) for reason: \(reason)")
         Task {
             do {
-                let userSession = try keychainHelper.load(UserSession.self, from: "positive-only-social.Positive-Only-Social", account: account) ?? UserSession(sessionToken: "123", username: "test", userId: 0, isIdentityVerified: false)
+                let userSession = try keychainHelper.load(UserSession.self, from: "positive-only-social.Positive-Only-Social", account: account) ?? UserSession(sessionToken: "123", username: "test", userId: "", isIdentityVerified: false)
                 let token = userSession.sessionToken
                 _ = try await api.reportPost(sessionManagementToken: token, postIdentifier: postIdentifier, reason: reason)
                 await MainActor.run {
@@ -241,7 +241,7 @@ final class PostDetailViewModel: ObservableObject {
 
         Task {
             do {
-                let userSession = try keychainHelper.load(UserSession.self, from: "positive-only-social.Positive-Only-Social", account: account) ?? UserSession(sessionToken: "123", username: "test", userId: 0, isIdentityVerified: false)
+                let userSession = try keychainHelper.load(UserSession.self, from: "positive-only-social.Positive-Only-Social", account: account) ?? UserSession(sessionToken: "123", username: "test", userId: "", isIdentityVerified: false)
                 let token = userSession.sessionToken
                 _ = try await api.likeComment(sessionManagementToken: token, postIdentifier: postIdentifier, commentThreadIdentifier: comment.threadId, commentIdentifier: comment.id)
             } catch {
@@ -285,7 +285,7 @@ final class PostDetailViewModel: ObservableObject {
 
         Task {
             do {
-                let userSession = try keychainHelper.load(UserSession.self, from: "positive-only-social.Positive-Only-Social", account: account) ?? UserSession(sessionToken: "123", username: "test", userId: 0, isIdentityVerified: false)
+                let userSession = try keychainHelper.load(UserSession.self, from: "positive-only-social.Positive-Only-Social", account: account) ?? UserSession(sessionToken: "123", username: "test", userId: "", isIdentityVerified: false)
                 let token = userSession.sessionToken
                 _ = try await api.unlikeComment(sessionManagementToken: token, postIdentifier: postIdentifier, commentThreadIdentifier: comment.threadId, commentIdentifier: comment.id)
             } catch {
@@ -301,7 +301,7 @@ final class PostDetailViewModel: ObservableObject {
         print("ACTION: Report comment \(comment.id) for reason: \(reason)")
         Task {
             do {
-                let userSession = try keychainHelper.load(UserSession.self, from: "positive-only-social.Positive-Only-Social", account: account) ?? UserSession(sessionToken: "123", username: "test", userId: 0, isIdentityVerified: false)
+                let userSession = try keychainHelper.load(UserSession.self, from: "positive-only-social.Positive-Only-Social", account: account) ?? UserSession(sessionToken: "123", username: "test", userId: "", isIdentityVerified: false)
                 let token = userSession.sessionToken
                 _ = try await api.reportComment(sessionManagementToken: token, postIdentifier: postIdentifier, commentThreadIdentifier: comment.threadId, commentIdentifier: comment.id, reason: reason)
                 
@@ -323,7 +323,7 @@ final class PostDetailViewModel: ObservableObject {
         print("ACTION: Commenting on post \(postIdentifier)")
         Task {
             do {
-                let userSession = try keychainHelper.load(UserSession.self, from: "positive-only-social.Positive-Only-Social", account: account) ?? UserSession(sessionToken: "123", username: "test", userId: 0, isIdentityVerified: false)
+                let userSession = try keychainHelper.load(UserSession.self, from: "positive-only-social.Positive-Only-Social", account: account) ?? UserSession(sessionToken: "123", username: "test", userId: "", isIdentityVerified: false)
                 let token = userSession.sessionToken
                 
                 _ = try await api.commentOnPost(
@@ -349,7 +349,7 @@ final class PostDetailViewModel: ObservableObject {
         print("ACTION: Replying to thread \(thread.id)")
         Task {
             do {
-                let userSession = try keychainHelper.load(UserSession.self, from: "positive-only-social.Positive-Only-Social", account: account) ?? UserSession(sessionToken: "123", username: "test", userId: 0, isIdentityVerified: false)
+                let userSession = try keychainHelper.load(UserSession.self, from: "positive-only-social.Positive-Only-Social", account: account) ?? UserSession(sessionToken: "123", username: "test", userId: "", isIdentityVerified: false)
                 let token = userSession.sessionToken
                 
                 _ = try await api.replyToCommentThread(

--- a/ios/Positive Only Social/Positive Only Social/viewmodels/ProfileViewModel.swift
+++ b/ios/Positive Only Social/Positive Only Social/viewmodels/ProfileViewModel.swift
@@ -48,7 +48,7 @@ class ProfileViewModel: ObservableObject {
         
         Task {
             do {
-                let userSession = try keychainHelper.load(UserSession.self, from: "positive-only-social.Positive-Only-Social", account: account) ?? UserSession(sessionToken: "123", username: "test", userId: 0, isIdentityVerified: false)
+                let userSession = try keychainHelper.load(UserSession.self, from: "positive-only-social.Positive-Only-Social", account: account) ?? UserSession(sessionToken: "123", username: "test", userId: "", isIdentityVerified: false)
                 
                 // Call the API endpoint we defined in the Django views
                 let responseData = try await api.getPostsForUser(
@@ -82,7 +82,7 @@ class ProfileViewModel: ObservableObject {
         
         Task {
             do {
-                let userSession = try keychainHelper.load(UserSession.self, from: "positive-only-social.Positive-Only-Social", account: account) ?? UserSession(sessionToken: "123", username: "test", userId: 0, isIdentityVerified: false)
+                let userSession = try keychainHelper.load(UserSession.self, from: "positive-only-social.Positive-Only-Social", account: account) ?? UserSession(sessionToken: "123", username: "test", userId: "", isIdentityVerified: false)
                 
                 let responseData = try await api.getProfileDetails(sessionManagementToken: userSession.sessionToken, username: user.username)
                 let details = try JSONDecoder().decode(ProfileDetailsResponse.self, from: responseData)
@@ -104,7 +104,7 @@ class ProfileViewModel: ObservableObject {
             
         Task {
             do {
-                let userSession = try keychainHelper.load(UserSession.self, from: "positive-only-social.Positive-Only-Social", account: account) ?? UserSession(sessionToken: "123", username: "test", userId: 0, isIdentityVerified: false)
+                let userSession = try keychainHelper.load(UserSession.self, from: "positive-only-social.Positive-Only-Social", account: account) ?? UserSession(sessionToken: "123", username: "test", userId: "", isIdentityVerified: false)
                 let token = userSession.sessionToken
                 
                 if isFollowing {
@@ -157,7 +157,7 @@ class ProfileViewModel: ObservableObject {
         
         Task {
             do {
-                let userSession = try keychainHelper.load(UserSession.self, from: "positive-only-social.Positive-Only-Social", account: account) ?? UserSession(sessionToken: "123", username: "test", userId: 0, isIdentityVerified: false)
+                let userSession = try keychainHelper.load(UserSession.self, from: "positive-only-social.Positive-Only-Social", account: account) ?? UserSession(sessionToken: "123", username: "test", userId: "", isIdentityVerified: false)
                 let token = userSession.sessionToken
                 
                 let _ = try await api.toggleBlock(sessionManagementToken: token, username: user.username)

--- a/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_AuthenticationManager.swift
+++ b/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_AuthenticationManager.swift
@@ -51,7 +51,7 @@ struct Positive_Only_SocialTests_AuthenticationManager {
         // Given: A valid token is saved in the keychain
         let testToken = "abc-123-valid-token"
         let testUsername = "username"
-        let userSession = UserSession(sessionToken: testToken, username: testUsername, userId: 1, isIdentityVerified: false)
+        let userSession = UserSession(sessionToken: testToken, username: testUsername, userId: "1", isIdentityVerified: false)
         try keychain.save(userSession, for: keychainService, account: userSessionAccount)
         
         // When: The AuthenticationManager is initialized
@@ -73,7 +73,7 @@ struct Positive_Only_SocialTests_AuthenticationManager {
         // When: login() is called
         let token = "abc-123-valid-token"
         let testUsername = "username"
-        let userSession = UserSession(sessionToken: token, username: testUsername, userId: 1, isIdentityVerified: false)
+        let userSession = UserSession(sessionToken: token, username: testUsername, userId: "1", isIdentityVerified: false)
         sut.login(with: userSession)
         
         // And: We wait for the background Task in login() to complete.
@@ -93,7 +93,7 @@ struct Positive_Only_SocialTests_AuthenticationManager {
         // Given: A token is saved and the SUT is in a logged-in state
         let token = "abc-123-valid-token"
         let testUsername = "username"
-        let userSession = UserSession(sessionToken: token, username: testUsername, userId: 1, isIdentityVerified: false)
+        let userSession = UserSession(sessionToken: token, username: testUsername, userId: "1", isIdentityVerified: false)
         try keychain.save(userSession, for: keychainService, account: userSessionAccount)
         sut = AuthenticationManager(shouldAutoLogin: true, keychainHelper: keychain)
         

--- a/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_FeedViewModel.swift
+++ b/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_FeedViewModel.swift
@@ -49,7 +49,7 @@ struct Positive_Only_SocialTests_FeedViewModel {
         
         // Given: A user is logged in
         let userAToken = try await registerUserAndGetToken(username: "userA")
-        let userSession = UserSession(sessionToken: userAToken, username: "userA", userId: 1, isIdentityVerified: false)
+        let userSession = UserSession(sessionToken: userAToken, username: "userA", userId: "1", isIdentityVerified: false)
         try keychainHelper.save(userSession, for: testService, account: "fetchFeedApiThrowsError")
         
         // And: *No one* has made any posts. The API stub will throw a 400 error.
@@ -72,7 +72,7 @@ struct Positive_Only_SocialTests_FeedViewModel {
         
         // Given: A user is logged in
         let userAToken = try await registerUserAndGetToken(username: "userA")
-        let userSession = UserSession(sessionToken: userAToken, username: "userA", userId: 1, isIdentityVerified: false)
+        let userSession = UserSession(sessionToken: userAToken, username: "userA", userId: "1", isIdentityVerified: false)
         try keychainHelper.save(userSession, for: testService, account: "fetchFeedWhileAlreadyLoading")
         
         // And: The viewmodel is *already* loading
@@ -110,7 +110,7 @@ struct Positive_Only_SocialTests_FeedViewModel {
         
         let userAToken = try await registerUserAndGetToken(username: "userA")
         let userBToken = try await registerUserAndGetToken(username: "userB")
-        let userSession = UserSession(sessionToken: userAToken, username: "userA", userId: 1, isIdentityVerified: false)
+        let userSession = UserSession(sessionToken: userAToken, username: "userA", userId: "1", isIdentityVerified: false)
         try keychainHelper.save(userSession, for: testService, account: "fetchFeedPagination")
 
         // And: User B creates 3 posts (which will be on 2 pages)

--- a/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_FollowingFeedViewModel.swift
+++ b/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_FollowingFeedViewModel.swift
@@ -48,7 +48,7 @@ struct Positive_Only_SocialTests_FollowingFeedViewModel {
 
         // Given: A user is logged in
         let userAToken = try await registerUserAndGetToken(username: "userA")
-        let userSession = UserSession(sessionToken: userAToken, username: "userA", userId: 1, isIdentityVerified: false)
+        let userSession = UserSession(sessionToken: userAToken, username: "userA", userId: "1", isIdentityVerified: false)
         try keychainHelper.save(userSession, for: testService, account: "fetchFollowingFeedUserNotFollowingAnyone")
         
         // And: Another user posts, but our user *does not* follow them
@@ -71,7 +71,7 @@ struct Positive_Only_SocialTests_FollowingFeedViewModel {
         
         // Given: A user is logged in
         let userAToken = try await registerUserAndGetToken(username: "userA")
-        let userSession = UserSession(sessionToken: userAToken, username: "userA", userId: 1, isIdentityVerified: false)
+        let userSession = UserSession(sessionToken: userAToken, username: "userA", userId: "1", isIdentityVerified: false)
         try keychainHelper.save(userSession, for: testService, account: "fetchFollowingFeedWhileAlreadyLoading")
         
         // And: The viewmodel is *already* loading
@@ -107,7 +107,7 @@ struct Positive_Only_SocialTests_FollowingFeedViewModel {
         stubAPI.pageSize = 2
         let userAToken = try await registerUserAndGetToken(username: "userA")
         let userBToken = try await registerUserAndGetToken(username: "userB")
-        let userSession = UserSession(sessionToken: userAToken, username: "userA", userId: 1, isIdentityVerified: false)
+        let userSession = UserSession(sessionToken: userAToken, username: "userA", userId: "1", isIdentityVerified: false)
         try keychainHelper.save(userSession, for: testService, account: "fetchFollowingFeedPagination")
 
         // And: User A follows User B

--- a/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_HomeViewModel.swift
+++ b/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_HomeViewModel.swift
@@ -44,7 +44,7 @@ struct Positive_Only_SocialTests_HomeViewModel {
     /// Helper to log in the "testuser" and save their token to the keychain
     private func setupLoggedInUser(username: String) async throws {
         let token = try await registerUserAndGetToken(username: username)
-        let userSession = UserSession(sessionToken: token, username: username, userId: 1, isIdentityVerified: false)
+        let userSession = UserSession(sessionToken: token, username: username, userId: "1", isIdentityVerified: false)
         try keychainHelper.save(userSession, for: testService, account: "\(username)_account")
     }
 

--- a/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_PostDetailViewModel.swift
+++ b/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_PostDetailViewModel.swift
@@ -50,7 +50,7 @@ struct Positive_Only_SocialTests_PostDetailViewModel {
     /// Helper to log in the "testuser" and save their token to the keychain
     private func setupLoggedInUser(username: String, account: String) async throws -> String {
         let token = try await registerUserAndGetToken(username: username)
-        let userSession = UserSession(sessionToken: token, username: username, userId: 1, isIdentityVerified: false)
+        let userSession = UserSession(sessionToken: token, username: username, userId: "1", isIdentityVerified: false)
         try keychainHelper.save(userSession, for: testService, account: account)
         return token
     }

--- a/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_ProfileViewModel.swift
+++ b/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_ProfileViewModel.swift
@@ -45,7 +45,7 @@ struct Positive_Only_SocialTests_ProfileViewModel {
     
     /// Helper to log in a user and save their token to the keychain
     private func setupLoggedInUser(user: User, token: String, account: String) async throws {
-        let userSession = UserSession(sessionToken: token, username: user.username, userId: 1, isIdentityVerified: user.identityIsVerified)
+        let userSession = UserSession(sessionToken: token, username: user.username, userId: "1", isIdentityVerified: user.identityIsVerified)
         try keychainHelper.save(userSession, for: testService, account: account)
     }
 

--- a/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_SettingsViewModel.swift
+++ b/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_SettingsViewModel.swift
@@ -43,7 +43,7 @@ struct Positive_Only_SocialTests_SettingsViewModel {
     /// Helper to log in a user and save their token to the keychain
     private func setupLoggedInUser(username: String) async throws -> String {
         let token = try await registerUserAndGetToken(username: username)
-        let userSession = UserSession(sessionToken: token, username: username, userId: 1, isIdentityVerified: false)
+        let userSession = UserSession(sessionToken: token, username: username, userId: "1", isIdentityVerified: false)
         // Use the testAccount that the ViewModel will also use
         try keychainHelper.save(userSession, for: testService, account: "\(username)_account")
         return token


### PR DESCRIPTION
## Summary

- The Django backend returns `user_id` as a UUID string, but both platforms typed it as `Int`, causing prod login to fail at decoding time
- The stubs masked this by serializing an auto-incrementing `numericId` integer instead of the actual UUID — tests passed, production broke
- Fixes both iOS and Android consistently

## Changes

**Core models**
- `AuthResponse.userId`: `Int?` → `String?` (Android)
- `UserSession.userId`: `Int` → `String` (Android + iOS)
- `LoginResponseFields.userId`: `Int?` → `String?` (iOS)
- `UserSession` decoder fallback: `?? 0` → `?? ""`

**Stubs** (both platforms)
- `user_id` in serialized responses now uses the UUID (`user.id.uuidString` / `user.id`) instead of `numericId`
- Removed dead `numericId` / `counter` / `nextUserId` fields from mock user types

**Call sites**
- `userId != 0` / `userId == 0` guards → `.isEmpty` checks (WelcomeView/Screen, NewPostScreen)
- All hardcoded `userId: 0` fallbacks → `userId: ""`
- All hardcoded `userId: 1` in tests/previews → `userId: "1"`

## Test plan

- [ ] Log in with a real backend account — `user_id` UUID decodes correctly into `UserSession`
- [ ] "Remember Me" auto-login flow (WelcomeView/Screen) no longer throws "no valid user ID"
- [ ] New post upload uses the UUID-scoped S3 path without hitting the invalid-session guard
- [ ] All existing unit tests pass (stub now returns UUID strings as `user_id`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)