### PR TITLE
Add fine-grained logging and fix S3 URL key extraction in classifiers

### DIFF
--- a/backend/user_system/classifiers/image_classifier.py
+++ b/backend/user_system/classifiers/image_classifier.py
@@ -14,14 +14,15 @@ logger = logging.getLogger(__name__)
 
 
 def is_image_positive(image_url):
-    logger.debug("is_image_positive called with URL: %s", image_url)
+    _p = urlparse(image_url)
+    logger.debug("is_image_positive called with URL: %s", _p._replace(query='', fragment='').geturl())
     testing = os.environ.get("TESTING", False)
     testing = testing if isinstance(testing, bool) else convert_to_bool(testing)
 
     if testing:
         parsed_url = urlparse(image_url)
         result = parsed_url.path.endswith(POSITIVE_IMAGE_FILENAME)
-        logger.debug("Testing mode — path=%s endswith %s → %s", parsed_url.path, POSITIVE_IMAGE_FILENAME, result)
+        logger.debug("Testing mode - path=%s endswith %s -> %s", parsed_url.path, POSITIVE_IMAGE_FILENAME, result)
         return result
 
     logger.debug("Checking available AI APIs for image classification")
@@ -62,7 +63,18 @@ def is_image_positive(image_url):
             logger.debug("s3:// URL — bucket=%s key=%s", bucket_name, key)
         elif parsed.scheme in ['http', 'https'] and 's3' in parsed.netloc:
             parts = parsed.netloc.split('.')
-            if parts[0] != 's3':
+            if parts[0] == 's3' or parts[0].startswith('s3-'):
+                # Path-style: s3[.region].amazonaws.com/bucket/key
+                # or dashed-region: s3-region.amazonaws.com/bucket/key
+                path_parts = parsed.path.lstrip('/').split('/', 1)
+                if not bucket_name and len(path_parts) >= 2:
+                    bucket_name = path_parts[0]
+                    key = path_parts[1]
+                    logger.debug("Derived bucket/key from path-style URL — bucket=%s key=%s", bucket_name, key)
+                elif len(path_parts) >= 2:
+                    key = path_parts[1]
+                    logger.debug("Using env-var bucket; extracted key from path-style URL: %s", key)
+            else:
                 # Virtual-hosted-style: bucket.s3[.region].amazonaws.com/key
                 if not bucket_name:
                     bucket_name = parts[0]
@@ -72,16 +84,6 @@ def is_image_positive(image_url):
                 # Always extract key from path for virtual-hosted-style URLs
                 key = parsed.path.lstrip('/')
                 logger.debug("Extracted key from path: %s", key)
-            else:
-                # Path-style: s3[.region].amazonaws.com/bucket/key
-                path_parts = parsed.path.lstrip('/').split('/', 1)
-                if not bucket_name and len(path_parts) >= 2:
-                    bucket_name = path_parts[0]
-                    key = path_parts[1]
-                    logger.debug("Derived bucket/key from path-style URL — bucket=%s key=%s", bucket_name, key)
-                elif len(path_parts) >= 2:
-                    key = path_parts[1]
-                    logger.debug("Using env-var bucket; extracted key from path-style URL: %s", key)
         else:
             logger.warning("Unrecognized URL scheme or non-S3 host — scheme=%s netloc=%s; will use key=%s as-is", parsed.scheme, parsed.netloc, key)
 

--- a/backend/user_system/classifiers/image_classifier.py
+++ b/backend/user_system/classifiers/image_classifier.py
@@ -14,14 +14,19 @@ logger = logging.getLogger(__name__)
 
 
 def is_image_positive(image_url):
+    logger.debug("is_image_positive called with URL: %s", image_url)
     testing = os.environ.get("TESTING", False)
     testing = testing if isinstance(testing, bool) else convert_to_bool(testing)
 
     if testing:
         parsed_url = urlparse(image_url)
-        return parsed_url.path.endswith(POSITIVE_IMAGE_FILENAME)
+        result = parsed_url.path.endswith(POSITIVE_IMAGE_FILENAME)
+        logger.debug("Testing mode — path=%s endswith %s → %s", parsed_url.path, POSITIVE_IMAGE_FILENAME, result)
+        return result
 
+    logger.debug("Checking available AI APIs for image classification")
     available_apis = get_available_apis()
+    logger.info("Available APIs for image classification: %s", available_apis)
 
     if not available_apis:
         logger.error("No AI API keys available.")
@@ -31,39 +36,67 @@ def is_image_positive(image_url):
     aws_secret_key = os.environ.get("AWS_SECRET_ACCESS_KEY")
 
     if not aws_access_key or not aws_secret_key:
-        logger.error("Missing AWS credentials.")
+        logger.error("Missing AWS credentials — AWS_ACCESS_KEY_ID present=%s, AWS_SECRET_ACCESS_KEY present=%s",
+                     bool(aws_access_key), bool(aws_secret_key))
         return False
 
     try:
+        region = os.environ.get("AWS_REGION", "us-east-1")
+        logger.debug("Creating S3 client in region: %s", region)
         s3 = boto3.client(
             's3',
             aws_access_key_id=aws_access_key,
             aws_secret_access_key=aws_secret_key,
-            region_name=os.environ.get("AWS_REGION", "us-east-1")
+            region_name=region
         )
 
         bucket_name = os.environ.get("AWS_STORAGE_BUCKET_NAME")
         key = image_url
 
         parsed = urlparse(image_url)
+        logger.debug("Parsing image URL — scheme=%s netloc=%s path=%s", parsed.scheme, parsed.netloc, parsed.path)
+
         if parsed.scheme == 's3':
             bucket_name = parsed.netloc
             key = parsed.path.lstrip('/')
+            logger.debug("s3:// URL — bucket=%s key=%s", bucket_name, key)
         elif parsed.scheme in ['http', 'https'] and 's3' in parsed.netloc:
-            if not bucket_name:
-                parts = parsed.netloc.split('.')
-                if parts[0] != 's3':
+            parts = parsed.netloc.split('.')
+            if parts[0] != 's3':
+                # Virtual-hosted-style: bucket.s3[.region].amazonaws.com/key
+                if not bucket_name:
                     bucket_name = parts[0]
-                    key = parsed.path.lstrip('/')
+                    logger.debug("Derived bucket from virtual-hosted URL host: %s", bucket_name)
+                else:
+                    logger.debug("Using env-var bucket name: %s", bucket_name)
+                # Always extract key from path for virtual-hosted-style URLs
+                key = parsed.path.lstrip('/')
+                logger.debug("Extracted key from path: %s", key)
+            else:
+                # Path-style: s3[.region].amazonaws.com/bucket/key
+                path_parts = parsed.path.lstrip('/').split('/', 1)
+                if not bucket_name and len(path_parts) >= 2:
+                    bucket_name = path_parts[0]
+                    key = path_parts[1]
+                    logger.debug("Derived bucket/key from path-style URL — bucket=%s key=%s", bucket_name, key)
+                elif len(path_parts) >= 2:
+                    key = path_parts[1]
+                    logger.debug("Using env-var bucket; extracted key from path-style URL: %s", key)
+        else:
+            logger.warning("Unrecognized URL scheme or non-S3 host — scheme=%s netloc=%s; will use key=%s as-is", parsed.scheme, parsed.netloc, key)
 
         if not bucket_name:
-            logger.error("Could not determine S3 bucket name.")
+            logger.error("Could not determine S3 bucket name from URL=%s and AWS_STORAGE_BUCKET_NAME is unset", image_url)
             return False
 
-        logger.info("Fetching image from S3 with key: %s", key)
+        logger.info("Fetching image from S3 — bucket=%s key=%s", bucket_name, key)
         response = s3.get_object(Bucket=bucket_name, Key=key)
+        content_length = response.get('ContentLength', 'unknown')
+        content_type = response.get('ContentType', 'unknown')
+        logger.debug("S3 object fetched — ContentLength=%s ContentType=%s", content_length, content_type)
         image_data = response['Body'].read()
         image = Image.open(BytesIO(image_data))
+        logger.debug("PIL image opened — size=%s mode=%s", image.size, image.mode)
 
         def call_api(api_name):
             try:
@@ -71,13 +104,19 @@ def is_image_positive(image_url):
                 if not api_func:
                     logger.error("Unsupported API name: %s", api_name)
                     return False
-                return api_func(image, IMAGE_CLASSIFIER_PROMPT)
+                logger.debug("Calling %s API for image classification", api_name)
+                result = api_func(image, IMAGE_CLASSIFIER_PROMPT)
+                logger.debug("%s API returned: %s", api_name, result)
+                return result
             except Exception:
                 logger.exception("Error calling %s API for image classification", api_name)
                 return False
 
-        return classify_with_voting(available_apis, call_api)
+        logger.info("Starting image classification vote with APIs: %s", available_apis)
+        result = classify_with_voting(available_apis, call_api)
+        logger.info("Image classification result for key=%s: %s", key, result)
+        return result
 
     except Exception:
-        logger.exception("Error in image classifier")
+        logger.exception("Error in image classifier for URL: %s", image_url)
         return False

--- a/backend/user_system/classifiers/text_classifier.py
+++ b/backend/user_system/classifiers/text_classifier.py
@@ -10,13 +10,22 @@ logger = logging.getLogger(__name__)
 
 
 def is_text_positive(text):
+    logger.debug("is_text_positive called — text length=%d preview=%r", len(text), text[:80])
     testing = os.environ.get("TESTING", False)
     testing = testing if isinstance(testing, bool) else convert_to_bool(testing)
 
     if testing:
-        return "negative" not in text.lower()
+        result = "negative" not in text.lower()
+        logger.debug("Testing mode — result=%s", result)
+        return result
 
+    logger.debug("Checking available AI APIs for text classification")
     available_apis = get_available_apis()
+    logger.info("Available APIs for text classification: %s", available_apis)
+
+    if not available_apis:
+        logger.error("No AI API keys available.")
+        return False
 
     def call_api(api_name):
         try:
@@ -24,9 +33,15 @@ def is_text_positive(text):
             if not api_func:
                 logger.error("Unsupported API name: %s", api_name)
                 return False
-            return api_func(text, TEXT_CLASSIFIER_PROMPT)
+            logger.debug("Calling %s API for text classification", api_name)
+            result = api_func(text, TEXT_CLASSIFIER_PROMPT)
+            logger.debug("%s API returned: %s", api_name, result)
+            return result
         except Exception:
             logger.exception("Error calling %s API for text classification", api_name)
             return False
 
-    return classify_with_voting(available_apis, call_api)
+    logger.info("Starting text classification vote with APIs: %s", available_apis)
+    result = classify_with_voting(available_apis, call_api)
+    logger.info("Text classification result: %s", result)
+    return result

--- a/backend/user_system/classifiers/text_classifier.py
+++ b/backend/user_system/classifiers/text_classifier.py
@@ -10,7 +10,8 @@ logger = logging.getLogger(__name__)
 
 
 def is_text_positive(text):
-    logger.debug("is_text_positive called — text length=%d preview=%r", len(text), text[:80])
+    text = str(text)
+    logger.debug("is_text_positive called — text length=%d", len(text))
     testing = os.environ.get("TESTING", False)
     testing = testing if isinstance(testing, bool) else convert_to_bool(testing)
 

--- a/backend/user_system/tests/test_classifiers.py
+++ b/backend/user_system/tests/test_classifiers.py
@@ -18,6 +18,10 @@ _AWS_KEYS = {
     "AWS_SECRET_ACCESS_KEY": "fake_aws_secret",
     "AWS_STORAGE_BUCKET_NAME": "fake_bucket",
 }
+_AWS_KEYS_NO_BUCKET = {
+    "AWS_ACCESS_KEY_ID": "fake_aws_key",
+    "AWS_SECRET_ACCESS_KEY": "fake_aws_secret",
+}
 
 _TEXT_DISPATCH = "user_system.classifiers.classifier_utils.TEXT_API_DISPATCH"
 _IMAGE_DISPATCH = "user_system.classifiers.classifier_utils.IMAGE_API_DISPATCH"
@@ -263,6 +267,58 @@ class TestClassifiers(PositiveOnlySocialTestCase):
         with patch.dict(_IMAGE_DISPATCH, {API_GEMINI: mock_gemini, API_CLAUDE: mock_claude, API_OPENAI: mock_openai}):
             self.assertFalse(is_image_positive("img.png"))
         mock_openai.assert_called_once()
+
+    # ------------------------------------------------------------------ #
+    # Image classifier – S3 URL parsing                                    #
+    # ------------------------------------------------------------------ #
+
+    def _make_mock_s3(self, mock_boto3):
+        mock_s3 = MagicMock()
+        mock_boto3.client.return_value = mock_s3
+        mock_body = MagicMock()
+        mock_body.read.return_value = _make_fake_image_bytes()
+        mock_s3.get_object.return_value = {'Body': mock_body}
+        return mock_s3
+
+    @patch.dict(os.environ, {"GEMINI_API_KEY": "fake_key", **_AWS_KEYS}, clear=True)
+    @patch("user_system.classifiers.image_classifier.boto3")
+    def test_url_parsing_virtual_hosted_with_bucket_env_var(self, mock_boto3):
+        """When AWS_STORAGE_BUCKET_NAME is set, virtual-hosted URL key is still extracted from path."""
+        mock_s3 = self._make_mock_s3(mock_boto3)
+        url = "https://goodvibesonly-images.s3.us-east-2.amazonaws.com/folder/image.jpg"
+        with patch.dict(_IMAGE_DISPATCH, {API_GEMINI: MagicMock(return_value=True)}):
+            is_image_positive(url)
+        mock_s3.get_object.assert_called_with(Bucket="fake_bucket", Key="folder/image.jpg")
+
+    @patch.dict(os.environ, {"GEMINI_API_KEY": "fake_key", **_AWS_KEYS_NO_BUCKET}, clear=True)
+    @patch("user_system.classifiers.image_classifier.boto3")
+    def test_url_parsing_virtual_hosted_without_bucket_env_var(self, mock_boto3):
+        """When AWS_STORAGE_BUCKET_NAME is unset, bucket is derived from virtual-hosted URL hostname."""
+        mock_s3 = self._make_mock_s3(mock_boto3)
+        url = "https://goodvibesonly-images.s3.us-east-2.amazonaws.com/folder/image.jpg"
+        with patch.dict(_IMAGE_DISPATCH, {API_GEMINI: MagicMock(return_value=True)}):
+            is_image_positive(url)
+        mock_s3.get_object.assert_called_with(Bucket="goodvibesonly-images", Key="folder/image.jpg")
+
+    @patch.dict(os.environ, {"GEMINI_API_KEY": "fake_key", **_AWS_KEYS_NO_BUCKET}, clear=True)
+    @patch("user_system.classifiers.image_classifier.boto3")
+    def test_url_parsing_path_style(self, mock_boto3):
+        """Path-style URL (s3.amazonaws.com/bucket/key) correctly splits bucket and key."""
+        mock_s3 = self._make_mock_s3(mock_boto3)
+        url = "https://s3.amazonaws.com/mybucket/path/to/image.jpg"
+        with patch.dict(_IMAGE_DISPATCH, {API_GEMINI: MagicMock(return_value=True)}):
+            is_image_positive(url)
+        mock_s3.get_object.assert_called_with(Bucket="mybucket", Key="path/to/image.jpg")
+
+    @patch.dict(os.environ, {"GEMINI_API_KEY": "fake_key", **_AWS_KEYS_NO_BUCKET}, clear=True)
+    @patch("user_system.classifiers.image_classifier.boto3")
+    def test_url_parsing_path_style_dashed_region(self, mock_boto3):
+        """Dashed-region path-style URL (s3-region.amazonaws.com/bucket/key) is not misread as virtual-hosted."""
+        mock_s3 = self._make_mock_s3(mock_boto3)
+        url = "https://s3-us-west-2.amazonaws.com/mybucket/path/to/image.jpg"
+        with patch.dict(_IMAGE_DISPATCH, {API_GEMINI: MagicMock(return_value=True)}):
+            is_image_positive(url)
+        mock_s3.get_object.assert_called_with(Bucket="mybucket", Key="path/to/image.jpg")
 
     # ------------------------------------------------------------------ #
     # Prompt content                                                       #


### PR DESCRIPTION
## Summary

- **Bug fix:** Virtual-hosted-style S3 URLs (e.g. `bucket.s3.region.amazonaws.com/key`) were only having their key extracted when `AWS_STORAGE_BUCKET_NAME` was unset. If the env var was set, `key` stayed as the full URL string, causing `get_object` to fail with `NoSuchKey`. The key is now always extracted from the URL path for virtual-hosted URLs regardless of env var state.
- **Bug fix:** Added `if not available_apis` guard to `text_classifier.py` — it was missing, so an empty list would fall through to `classify_with_voting` silently.
- **Observability:** Added `DEBUG`/`INFO` logging throughout both classifiers covering function entry, URL parsing branch taken, resolved bucket + key, S3 response metadata, PIL image info, per-API calls and their return values, and final classification result.

## Test plan

- [ ] Confirm `is_image_positive` works correctly with a virtual-hosted S3 URL when `AWS_STORAGE_BUCKET_NAME` is set in env
- [ ] Confirm `is_image_positive` works correctly with a virtual-hosted S3 URL when `AWS_STORAGE_BUCKET_NAME` is unset (bucket derived from hostname)
- [ ] Confirm `is_image_positive` works with `s3://` scheme URLs
- [ ] Set log level to `DEBUG` and verify expected log lines appear for both classifiers
- [ ] Confirm `is_text_positive` returns `False` (not an exception) when no API keys are configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)