### PR TITLE
Fix missing auth token on getCommentsForPost and getCommentsForThread (iOS)

### DIFF
--- a/ios/Positive Only Social/Positive Only Social/api/Networking.swift
+++ b/ios/Positive Only Social/Positive Only Social/api/Networking.swift
@@ -100,10 +100,10 @@ protocol Networking {
     func reportComment(sessionManagementToken: String, postIdentifier: String, commentThreadIdentifier: String, commentIdentifier: String, reason: String) async throws -> Data
 
     /// Gets a batch of comments for a post.
-    func getCommentsForPost(postIdentifier: String, batch: Int) async throws -> Data
+    func getCommentsForPost(sessionManagementToken: String, postIdentifier: String, batch: Int) async throws -> Data
 
     /// Gets a batch of comments for a specific comment thread (i.e., replies to a comment).
-    func getCommentsForThread(commentThreadIdentifier: String, batch: Int) async throws -> Data
+    func getCommentsForThread(sessionManagementToken: String, commentThreadIdentifier: String, batch: Int) async throws -> Data
 
     /// Replies to a comment thread.
     func replyToCommentThread(sessionManagementToken: String, postIdentifier: String, commentThreadIdentifier: String, commentText: String) async throws -> Data

--- a/ios/Positive Only Social/Positive Only Social/api/RealAPI.swift
+++ b/ios/Positive Only Social/Positive Only Social/api/RealAPI.swift
@@ -497,20 +497,20 @@ final class RealAPI: Networking {
     }
     
     /// Gets a batch of comments for a post.
-    func getCommentsForPost(postIdentifier: String, batch: Int) async throws -> Data {
-        // This is a GET request, no body, with no auth. ID/Batch are in path.
+    func getCommentsForPost(sessionManagementToken: String, postIdentifier: String, batch: Int) async throws -> Data {
         return try await performRequest(
             pathSegments: ["posts", postIdentifier, "comments", String(batch)],
             method: .get,
+            authToken: sessionManagementToken
         )
     }
-    
+
     /// Gets a batch of comments for a specific comment thread.
-    func getCommentsForThread(commentThreadIdentifier: String, batch: Int) async throws -> Data {
-        // This is a GET request, no body, with no auth. ID/Batch are in path.
+    func getCommentsForThread(sessionManagementToken: String, commentThreadIdentifier: String, batch: Int) async throws -> Data {
         return try await performRequest(
             pathSegments: ["threads", commentThreadIdentifier, "comments", String(batch)],
             method: .get,
+            authToken: sessionManagementToken
         )
     }
     

--- a/ios/Positive Only Social/Positive Only Social/api/StatefulStubbedAPI.swift
+++ b/ios/Positive Only Social/Positive Only Social/api/StatefulStubbedAPI.swift
@@ -599,7 +599,7 @@ final class StatefulStubbedAPI: Networking {
         return try createEmptySuccessResponse()
     }
 
-    func getCommentsForPost(postIdentifier: String, batch: Int) async throws -> Data {
+    func getCommentsForPost(sessionManagementToken: String, postIdentifier: String, batch: Int) async throws -> Data {
         await simulateNetwork()
         let relevantThreads = commentThreads.filter { $0.postId == postIdentifier }
         
@@ -613,7 +613,7 @@ final class StatefulStubbedAPI: Networking {
         return try createSerializedListResponse(fieldsList: fieldObjects)
     }
 
-    func getCommentsForThread(commentThreadIdentifier: String, batch: Int) async throws -> Data {
+    func getCommentsForThread(sessionManagementToken: String, commentThreadIdentifier: String, batch: Int) async throws -> Data {
         await simulateNetwork()
         let relevantComments = comments.filter { $0.threadId == commentThreadIdentifier && !$0.isHidden }.sorted { $0.createdDate < $1.createdDate }
         

--- a/ios/Positive Only Social/Positive Only Social/preview/PreviewHelpers.swift
+++ b/ios/Positive Only Social/Positive Only Social/preview/PreviewHelpers.swift
@@ -202,7 +202,7 @@ struct MockedAPI: Networking {
         return try encodeGenericSuccess()
     }
 
-    func getCommentsForPost(postIdentifier: String, batch: Int) async throws -> Data {
+    func getCommentsForPost(sessionManagementToken: String, postIdentifier: String, batch: Int) async throws -> Data {
         // Matches PostDetailViewModel.ThreadIDFields
         struct ThreadIDResponse: Codable {
             let comment_thread_identifier: String
@@ -215,7 +215,7 @@ struct MockedAPI: Networking {
         return try encode(threads)
     }
 
-    func getCommentsForThread(commentThreadIdentifier: String, batch: Int) async throws -> Data {
+    func getCommentsForThread(sessionManagementToken: String, commentThreadIdentifier: String, batch: Int) async throws -> Data {
         // Matches PostDetailViewModel.CommentFields
         struct CommentResponse: Codable {
             let comment_identifier: String

--- a/ios/Positive Only Social/Positive Only Social/viewmodels/PostDetailViewModel.swift
+++ b/ios/Positive Only Social/Positive Only Social/viewmodels/PostDetailViewModel.swift
@@ -64,10 +64,18 @@ final class PostDetailViewModel: ObservableObject {
         
         Task {
             do {
+                guard let userSession = try keychainHelper.load(UserSession.self, from: keychainService, account: account) else {
+                    NSLog("%@", "No active session — cannot load post details")
+                    self.alertMessage = "Session not found."
+                    self.isLoading = false
+                    return
+                }
+                let token = userSession.sessionToken
+
                 // 1. Fetch the main post details
                 let postData = try await api.getPostDetails(postIdentifier: postIdentifier)
                 let postFields = try self.decodeSingle(from: postData, type: PostDetailsFields.self)
-                
+
                 self.postDetail = PostDisplayData(
                     id: postFields.post_identifier,
                     imageURL: postFields.image_url,
@@ -75,19 +83,19 @@ final class PostDetailViewModel: ObservableObject {
                     likeCount: postFields.post_likes,
                     authorUsername: postFields.author_username
                 )
-                
+
                 // 2. Fetch the list of comment thread IDs for this post
-                let threadListData = try await api.getCommentsForPost(postIdentifier: postIdentifier, batch: 0)
+                let threadListData = try await api.getCommentsForPost(sessionManagementToken: token, postIdentifier: postIdentifier, batch: 0)
                 let threadIDFields = try self.decodeList(from: threadListData, type: ThreadIDFields.self)
                 let threadIdentifiers = threadIDFields.map { $0.comment_thread_identifier }
-                
+
                 // 3. Fetch all comments for *each* thread in parallel
                 var loadedThreads: [CommentThreadViewData] = []
-                
+
                 try await withThrowingTaskGroup(of: [CommentViewData].self) { group in
                     for threadId in threadIdentifiers {
                         group.addTask {
-                            let commentsData = try await self.api.getCommentsForThread(commentThreadIdentifier: threadId, batch: 0)
+                            let commentsData = try await self.api.getCommentsForThread(sessionManagementToken: token, commentThreadIdentifier: threadId, batch: 0)
                             
                             // *** FIXED: Removed 'await' here, as decodeList is not async ***
                             let commentFields = try await self.decodeList(from: commentsData, type: CommentFields.self)


### PR DESCRIPTION
## What changed

`get_comments_for_post` and `get_comments_for_thread` on the backend are both decorated with `@api_login_required`, requiring a `Bearer` token in the `Authorization` header. The iOS client was calling both endpoints without any auth header, which caused the `Authorization header missing or malformed` (401) error surfaced in `PostDetailView`.

## Changes

- **`Networking.swift`** — added `sessionManagementToken` parameter to `getCommentsForPost` and `getCommentsForThread` protocol methods
- **`RealAPI.swift`** — pass the token as `authToken` in both calls
- **`PostDetailViewModel.swift`** — `loadAllData()` now loads the session from keychain once at the top and threads the token through all three comment-fetching calls (`getCommentsForPost`, `getCommentsForThread`); also handles the missing-session case with a user-facing `alertMessage`
- **`StatefulStubbedAPI.swift`** / **`PreviewHelpers.swift`** — updated signatures to match the new protocol

## Audit

All other iOS endpoints were cross-checked against the backend's `@api_login_required` decorators. These two were the only mismatches. `getPostDetails` correctly remains unauthenticated (it's the only backend endpoint without `@api_login_required`).

## Testing

Verify that opening a post in `PostDetailView` now loads comments without showing an "Authorization header missing or malformed" alert.