### PR TITLE
Heart icons reflect real per-user like state; run text classifier before image classifier

### DIFF
--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/api/PositiveOnlySocialAPI.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/api/PositiveOnlySocialAPI.kt
@@ -162,6 +162,7 @@ interface PositiveOnlySocialAPI {
 
     @GET("posts/{post_id}/comments/{batch}/")
     suspend fun getCommentsForPost(
+        @Header("Authorization") token: String,
         @Path("post_id") postId: String,
         @Path("batch") batch: Int
     ): Response<List<CommentThreadDto>>

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/api/PositiveOnlySocialAPI.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/api/PositiveOnlySocialAPI.kt
@@ -69,6 +69,7 @@ interface PositiveOnlySocialAPI {
 
     @GET("posts/{post_id}/details/")
     suspend fun getPostDetails(
+        @Header("Authorization") token: String,
         @Path("post_id") postId: String
     ): Response<Post>
 
@@ -167,6 +168,7 @@ interface PositiveOnlySocialAPI {
 
     @GET("threads/{thread_id}/comments/{batch}/")
     suspend fun getCommentsForThread(
+        @Header("Authorization") token: String,
         @Path("thread_id") threadId: String,
         @Path("batch") batch: Int
     ): Response<List<CommentDto>>

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/api/StatefulStubbedAPI.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/api/StatefulStubbedAPI.kt
@@ -426,7 +426,8 @@ class StatefulStubbedAPI : PositiveOnlySocialAPI {
         return Response.success(dtos)
     }
 
-    override suspend fun getPostDetails(postId: String): Response<Post> {
+    override suspend fun getPostDetails(token: String, postId: String): Response<Post> {
+        val user = getAuthorizedUser(token) ?: return errorGeneric(401, "Unauthorized")
         val post = posts.find { it.postIdentifier == postId }
             ?: return errorGeneric(404, "No post with that identifier")
         val author = users.find { it.id == post.authorId }!!
@@ -436,7 +437,8 @@ class StatefulStubbedAPI : PositiveOnlySocialAPI {
             post.imageUrl,
             post.caption,
             authorUsername = author.username,
-            post.likes.count()
+            likeCount = post.likes.count(),
+            isLiked = post.likes.contains(user.id)
         ))
     }
 
@@ -522,7 +524,8 @@ class StatefulStubbedAPI : PositiveOnlySocialAPI {
         return Response.success(batched.map { CommentThreadDto(it.threadIdentifier) })
     }
 
-    override suspend fun getCommentsForThread(threadId: String, batch: Int): Response<List<CommentDto>> {
+    override suspend fun getCommentsForThread(token: String, threadId: String, batch: Int): Response<List<CommentDto>> {
+        val user = getAuthorizedUser(token) ?: return errorGeneric(401, "Unauthorized")
         val thread = commentThreads.find { it.threadIdentifier == threadId }
             ?: return errorGeneric(404, "Thread not found")
 
@@ -537,7 +540,8 @@ class StatefulStubbedAPI : PositiveOnlySocialAPI {
                 author.username,
                 c.creationTime.toString(),
                 c.creationTime.toString(),
-                c.likes.size
+                c.likes.size,
+                isLiked = c.likes.contains(user.id)
             )
         }
         return Response.success(dtos)

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/api/StatefulStubbedAPI.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/api/StatefulStubbedAPI.kt
@@ -518,7 +518,8 @@ class StatefulStubbedAPI : PositiveOnlySocialAPI {
         return Response.success(GenericResponse("Comment reported", null))
     }
 
-    override suspend fun getCommentsForPost(postId: String, batch: Int): Response<List<CommentThreadDto>> {
+    override suspend fun getCommentsForPost(token: String, postId: String, batch: Int): Response<List<CommentThreadDto>> {
+        getAuthorizedUser(token) ?: return errorGeneric(401, "Unauthorized")
         val threads = commentThreads.filter { it.postId == postId }
         val batched = getBatch(threads, batch, COMMENT_BATCH_SIZE)
         return Response.success(batched.map { CommentThreadDto(it.threadIdentifier) })

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/model/Models.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/model/Models.kt
@@ -90,7 +90,9 @@ data class Post(
     @SerializedName("image_url") val imageUrl: String,
     val caption: String,
     @SerializedName("author_username") val authorUsername: String,
-    val likeCount: Int? = 0,
+    // Only the post-details endpoint returns the like count (as "post_likes");
+    // feed endpoints omit it, so it defaults to 0.
+    @SerializedName("post_likes") val likeCount: Int? = 0,
     // Whether the current user has liked this post. Only the post-details endpoint
     // populates this; feed endpoints omit it, so it defaults to false.
     @SerializedName("is_liked") val isLiked: Boolean = false

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/model/Models.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/model/Models.kt
@@ -90,7 +90,10 @@ data class Post(
     @SerializedName("image_url") val imageUrl: String,
     val caption: String,
     @SerializedName("author_username") val authorUsername: String,
-    val likeCount: Int? = 0
+    val likeCount: Int? = 0,
+    // Whether the current user has liked this post. Only the post-details endpoint
+    // populates this; feed endpoints omit it, so it defaults to false.
+    @SerializedName("is_liked") val isLiked: Boolean = false
 )
 
 // --- Comment DTOs ---
@@ -114,7 +117,8 @@ data class CommentDto(
     @SerializedName("author_username") val authorUsername: String,
     @SerializedName("creation_time") val creationTime: String,
     @SerializedName("updated_time") val updatedTime: String,
-    @SerializedName("comment_likes") val likeCount: Int
+    @SerializedName("comment_likes") val likeCount: Int,
+    @SerializedName("is_liked") val isLiked: Boolean = false
 )
 
 // --- User/Profile DTOs ---
@@ -173,6 +177,7 @@ data class CommentViewData(
     val authorUsername: String,
     val body: String,
     val likeCount: Int,
+    val isLiked: Boolean, // Whether the current user has liked this comment
     val createdDate: Date // Using Date for now, might need conversion from String
 )
 

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/PostDetailViewModel.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/PostDetailViewModel.kt
@@ -105,7 +105,7 @@ class PostDetailViewModel(
                 }
 
                 // 2. Fetch the list of comment thread IDs for this post
-                val threadListResponse = api.getCommentsForPost(postIdentifier, 0)
+                val threadListResponse = api.getCommentsForPost(token, postIdentifier, 0)
                 val threadDtos = threadListResponse.body() ?: emptyList()
                 val threadIdentifiers = threadDtos.map { it.threadIdentifier }
 

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/PostDetailViewModel.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/PostDetailViewModel.kt
@@ -86,8 +86,18 @@ class PostDetailViewModel(
 
         viewModelScope.launch {
             try {
+                // These authenticated GETs need the session token so the backend can
+                // report whether the current user has liked the post / each comment.
+                val userSession = keychainHelper.load(UserSession::class.java, service, account)
+                if (userSession == null) {
+                    Log.e(TAG, "No active session found — cannot load post details")
+                    _alertMessage.value = "Not logged in."
+                    return@launch
+                }
+                val token = userSession.sessionToken
+
                 // 1. Fetch the main post details
-                val postResponse = api.getPostDetails(postIdentifier)
+                val postResponse = api.getPostDetails(token, postIdentifier)
                 if (postResponse.isSuccessful) {
                     _postDetail.value = postResponse.body()
                 } else {
@@ -103,11 +113,11 @@ class PostDetailViewModel(
                 val loadedThreads = coroutineScope {
                     threadIdentifiers.map { threadId ->
                         async {
-                            val commentsResponse = api.getCommentsForThread(threadId, 0)
+                            val commentsResponse = api.getCommentsForThread(token, threadId, 0)
                             val comments = commentsResponse.body() ?: emptyList()
                             // Sort comments by date (oldest first)
                             val sortedComments = comments.sortedBy { it.creationTime }
-                            
+
                             // Convert to CommentViewData
                             val commentViewDataList = sortedComments.map { c ->
                                 CommentViewData(
@@ -116,10 +126,11 @@ class PostDetailViewModel(
                                     authorUsername = c.authorUsername,
                                     body = c.body,
                                     likeCount = c.likeCount,
+                                    isLiked = c.isLiked,
                                     createdDate = Date() // TODO: Parse c.creationTime string to Date
                                 )
                             }
-                            
+
                             CommentThreadViewData(threadId, commentViewDataList)
                         }
                     }.awaitAll()

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/PostDetailScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/PostDetailScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material.icons.filled.Flag
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -133,7 +134,7 @@ fun PostDetailScreen(
                         
                         Column(modifier = Modifier.padding(16.dp)) {
                             Row(verticalAlignment = Alignment.CenterVertically) {
-                                Icon(Icons.Default.Favorite, contentDescription = "Like", tint = Color.Red)
+                                Icon(if (isPostLiked) Icons.Default.Favorite else Icons.Default.FavoriteBorder, contentDescription = "Like", tint = Color.Red)
                                 Spacer(modifier = Modifier.width(4.dp))
                                 Text("${post.likeCount} likes", fontWeight = FontWeight.Bold)
                                 Spacer(modifier = Modifier.weight(1f))
@@ -267,6 +268,13 @@ fun CommentRow(
                 // TODO Date placeholder - needs formatting logic
                 Text("Just now", fontSize = 12.sp, color = Color.Gray)
                 Spacer(modifier = Modifier.width(8.dp))
+                Icon(
+                    if (isLiked) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
+                    contentDescription = "Like",
+                    tint = Color.Red,
+                    modifier = Modifier.size(12.dp)
+                )
+                Spacer(modifier = Modifier.width(4.dp))
                 Text("${comment.likeCount} likes", fontSize = 12.sp, color = Color.Gray)
                 Spacer(modifier = Modifier.width(8.dp))
                 if (isReported) {

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/PostDetailScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/PostDetailScreen.kt
@@ -53,7 +53,6 @@ fun PostDetailScreen(
         val alertMessage by viewModel.alertMessage.collectAsState()
         
         // Local state for interactions
-        var isPostLiked by remember { mutableStateOf(false) }
         var isPostReported by remember { mutableStateOf(false) }
         
         // Sheets
@@ -121,8 +120,8 @@ fun PostDetailScreen(
                                 .aspectRatio(1f)
                                 .combinedClickable(
                                     onDoubleClick = {
-                                        isPostLiked = !isPostLiked
-                                        if (isPostLiked) viewModel.likePost() else viewModel.unlikePost()
+                                        // Drive the action from the server-backed like state
+                                        if (post.isLiked) viewModel.unlikePost() else viewModel.likePost()
                                     },
                                     onLongClick = {
                                        viewModel.setShowReportSheetForPost(true)
@@ -134,7 +133,7 @@ fun PostDetailScreen(
                         
                         Column(modifier = Modifier.padding(16.dp)) {
                             Row(verticalAlignment = Alignment.CenterVertically) {
-                                Icon(if (isPostLiked) Icons.Default.Favorite else Icons.Default.FavoriteBorder, contentDescription = if (isPostLiked) "Liked" else "Like", tint = Color.Red)
+                                Icon(if (post.isLiked) Icons.Default.Favorite else Icons.Default.FavoriteBorder, contentDescription = if (post.isLiked) "Liked" else "Like", tint = Color.Red)
                                 Spacer(modifier = Modifier.width(4.dp))
                                 Text("${post.likeCount} likes", fontWeight = FontWeight.Bold)
                                 Spacer(modifier = Modifier.weight(1f))
@@ -229,17 +228,16 @@ fun CommentRow(
     onUnlike: () -> Unit,
     onReport: () -> Unit
 ) {
-    var isLiked by remember { mutableStateOf(false) }
     var isReported by remember { mutableStateOf(false) }
-    
+
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .padding(vertical = 4.dp)
             .combinedClickable(
                 onDoubleClick = {
-                    isLiked = !isLiked
-                    if (isLiked) onLike() else onUnlike()
+                    // Drive the action from the server-backed like state
+                    if (comment.isLiked) onUnlike() else onLike()
                 },
                 onLongClick = {
                     isReported = true
@@ -269,8 +267,8 @@ fun CommentRow(
                 Text("Just now", fontSize = 12.sp, color = Color.Gray)
                 Spacer(modifier = Modifier.width(8.dp))
                 Icon(
-                    if (isLiked) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
-                    contentDescription = if (isLiked) "Liked" else "Like",
+                    if (comment.isLiked) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
+                    contentDescription = if (comment.isLiked) "Liked" else "Like",
                     tint = Color.Red,
                     modifier = Modifier.size(12.dp)
                 )

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/PostDetailScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/PostDetailScreen.kt
@@ -134,7 +134,7 @@ fun PostDetailScreen(
                         
                         Column(modifier = Modifier.padding(16.dp)) {
                             Row(verticalAlignment = Alignment.CenterVertically) {
-                                Icon(if (isPostLiked) Icons.Default.Favorite else Icons.Default.FavoriteBorder, contentDescription = "Like", tint = Color.Red)
+                                Icon(if (isPostLiked) Icons.Default.Favorite else Icons.Default.FavoriteBorder, contentDescription = if (isPostLiked) "Liked" else "Like", tint = Color.Red)
                                 Spacer(modifier = Modifier.width(4.dp))
                                 Text("${post.likeCount} likes", fontWeight = FontWeight.Bold)
                                 Spacer(modifier = Modifier.weight(1f))
@@ -270,7 +270,7 @@ fun CommentRow(
                 Spacer(modifier = Modifier.width(8.dp))
                 Icon(
                     if (isLiked) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
-                    contentDescription = "Like",
+                    contentDescription = if (isLiked) "Liked" else "Like",
                     tint = Color.Red,
                     modifier = Modifier.size(12.dp)
                 )

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/preview/PreviewHelpers.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/preview/PreviewHelpers.kt
@@ -316,6 +316,7 @@ class MockPositiveOnlySocialAPI : PositiveOnlySocialAPI {
     }
 
     override suspend fun getCommentsForPost(
+        token: String,
         postId: String,
         batch: Int
     ): Response<List<CommentThreadDto>> {

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/preview/PreviewHelpers.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/preview/PreviewHelpers.kt
@@ -167,14 +167,15 @@ class MockPositiveOnlySocialAPI : PositiveOnlySocialAPI {
         )
     }
 
-    override suspend fun getPostDetails(postId: String): Response<Post> {
+    override suspend fun getPostDetails(token: String, postId: String): Response<Post> {
         return Response.success(
             Post(
                 postIdentifier = postId,
                 imageUrl = "https://example.com/detail.jpg",
                 caption = "Detailed view of the post",
                 authorUsername = "mock_author",
-                likeCount = 100
+                likeCount = 100,
+                isLiked = false
             )
         )
     }
@@ -327,6 +328,7 @@ class MockPositiveOnlySocialAPI : PositiveOnlySocialAPI {
     }
 
     override suspend fun getCommentsForThread(
+        token: String,
         threadId: String,
         batch: Int
     ): Response<List<CommentDto>> {
@@ -338,7 +340,8 @@ class MockPositiveOnlySocialAPI : PositiveOnlySocialAPI {
                     authorUsername = "fan_1",
                     creationTime = "2023-01-01T12:00:00Z",
                     updatedTime = "2023-01-01T12:00:00Z",
-                    likeCount = 5
+                    likeCount = 5,
+                    isLiked = false
                 ),
                 CommentDto(
                     commentIdentifier = "c2",
@@ -346,7 +349,8 @@ class MockPositiveOnlySocialAPI : PositiveOnlySocialAPI {
                     authorUsername = "fan_2",
                     creationTime = "2023-01-01T12:05:00Z",
                     updatedTime = "2023-01-01T12:05:00Z",
-                    likeCount = 2
+                    likeCount = 2,
+                    isLiked = true
                 )
             )
         )

--- a/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/data/model/PostDeserializationTest.kt
+++ b/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/data/model/PostDeserializationTest.kt
@@ -1,0 +1,56 @@
+package com.example.positiveonlysocial.data.model
+
+import com.google.gson.Gson
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Locks in the JSON mapping for the [Post] DTO. The post-details endpoint returns
+ * the like count under "post_likes" (not "likeCount"), so without the
+ * @SerializedName the like count silently deserialized to its default and the
+ * detail screen always showed 0.
+ */
+class PostDeserializationTest {
+
+    private val gson = Gson()
+
+    @Test
+    fun `post details json maps post_likes to likeCount and is_liked to isLiked`() {
+        val json = """
+            {
+              "post_identifier": "p1",
+              "image_url": "https://example.com/a.jpg",
+              "caption": "hi",
+              "post_likes": 7,
+              "is_liked": true,
+              "author_username": "alice"
+            }
+        """.trimIndent()
+
+        val post = gson.fromJson(json, Post::class.java)
+
+        assertEquals("p1", post.postIdentifier)
+        assertEquals("alice", post.authorUsername)
+        assertEquals(7, post.likeCount)
+        assertTrue(post.isLiked)
+    }
+
+    @Test
+    fun `feed json without like fields leaves isLiked false`() {
+        // Feed endpoints omit post_likes / is_liked entirely.
+        val json = """
+            {
+              "post_identifier": "p2",
+              "image_url": "https://example.com/b.jpg",
+              "caption": "yo",
+              "author_username": "bob"
+            }
+        """.trimIndent()
+
+        val post = gson.fromJson(json, Post::class.java)
+
+        assertEquals("p2", post.postIdentifier)
+        assertEquals(false, post.isLiked)
+    }
+}

--- a/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/PostDetailViewModelTest.kt
+++ b/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/PostDetailViewModelTest.kt
@@ -56,7 +56,7 @@ class PostDetailViewModelTest {
                     )
                 )
             )
-            whenever(api.getCommentsForPost(postIdentifier, 0)).thenReturn(
+            whenever(api.getCommentsForPost("token123", postIdentifier, 0)).thenReturn(
                 Response.success(
                     emptyList()
                 )

--- a/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/PostDetailViewModelTest.kt
+++ b/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/PostDetailViewModelTest.kt
@@ -45,7 +45,7 @@ class PostDetailViewModelTest {
 
         runBlocking {
             // Mock API calls for loadAllData which is called in init
-            whenever(api.getPostDetails(postIdentifier)).thenReturn(
+            whenever(api.getPostDetails("token123", postIdentifier)).thenReturn(
                 Response.success(
                     Post(
                         postIdentifier,
@@ -82,7 +82,7 @@ class PostDetailViewModelTest {
 
         verify(api).likePost("token123", postIdentifier)
         // Verify loadAllData is called again (getPostDetails called twice: once in init, once after like)
-        verify(api, org.mockito.kotlin.times(2)).getPostDetails(postIdentifier)
+        verify(api, org.mockito.kotlin.times(2)).getPostDetails("token123", postIdentifier)
     }
 
     @Test
@@ -93,6 +93,6 @@ class PostDetailViewModelTest {
         viewModel.commentOnPost("Nice post!")
 
         assertEquals("", viewModel.newCommentText.value)
-        verify(api, org.mockito.kotlin.times(2)).getPostDetails(postIdentifier)
+        verify(api, org.mockito.kotlin.times(2)).getPostDetails("token123", postIdentifier)
     }
 }

--- a/backend/user_system/constants.py
+++ b/backend/user_system/constants.py
@@ -69,6 +69,7 @@ class Fields:
     following_count = "following_count"
     follower_count = "follower_count"
     is_following = "is_following"
+    is_liked = "is_liked"
     author_username = "author_username"
     email = "email"
     password = "password"

--- a/backend/user_system/tests/test_get_comments_for_thread_view.py
+++ b/backend/user_system/tests/test_get_comments_for_thread_view.py
@@ -1,6 +1,7 @@
 from django.urls import reverse
 
 from .test_parent_case import PositiveOnlySocialTestCase
+from ..constants import Fields
 
 invalid_comment_thread_identifier = '?'
 invalid_batch = -1
@@ -96,6 +97,54 @@ class GetCommentsForThreadTests(PositiveOnlySocialTestCase):
         responses = response.json()
         # Assumes COMMENT_BATCH_SIZE is 30
         self.assertEqual(len(responses), 30)
+
+    def test_comments_include_is_liked_defaulting_false(self):
+        """
+        Tests that every comment includes an is_liked field, which is False
+        for a requester who has not liked any of them.
+        """
+        url = reverse('get_comments_for_thread', kwargs={
+            'comment_thread_identifier': str(self.comment_thread_identifier),
+            'batch': 0
+        })
+
+        response = self.client.get(url, **self.valid_header)
+
+        self.assertEqual(response.status_code, 200)
+        comments = response.json()
+        self.assertTrue(len(comments) > 0)
+        for comment in comments:
+            self.assertIn(Fields.is_liked, comment)
+            self.assertFalse(comment[Fields.is_liked])
+
+    def test_is_liked_true_for_comment_liked_by_requester(self):
+        """
+        Tests that is_liked is True only for the comment the requester liked.
+        """
+        url = reverse('get_comments_for_thread', kwargs={
+            'comment_thread_identifier': str(self.comment_thread_identifier),
+            'batch': 0
+        })
+
+        # The local user (a fresh user who authored none of the comments) likes one.
+        comments = self.client.get(url, **self.valid_header).json()
+        target_id = comments[0][Fields.comment_identifier]
+
+        like_url = reverse('like_comment', kwargs={
+            'post_identifier': str(self.post_identifier),
+            'comment_thread_identifier': str(self.comment_thread_identifier),
+            'comment_identifier': target_id
+        })
+        like_response = self.client.post(like_url, **self.valid_header)
+        self.assertEqual(like_response.status_code, 200)
+
+        # Re-fetch and verify only the liked comment is marked is_liked.
+        comments_after = self.client.get(url, **self.valid_header).json()
+        for comment in comments_after:
+            if comment[Fields.comment_identifier] == target_id:
+                self.assertTrue(comment[Fields.is_liked])
+            else:
+                self.assertFalse(comment[Fields.is_liked])
 
     def test_last_batch_returns_good_response(self):
         """

--- a/backend/user_system/tests/test_get_post_details_view.py
+++ b/backend/user_system/tests/test_get_post_details_view.py
@@ -18,6 +18,16 @@ class GetPostDetailsTests(PositiveOnlySocialTestCase):
         # Define the valid URL for the test
         self.url = reverse('get_post_details', kwargs={'post_identifier': str(self.post_identifier)})
 
+        # get_post_details now requires authentication
+        self.header = {'HTTP_AUTHORIZATION': f'Bearer {self.session_management_token}'}
+
+    def test_missing_auth_returns_unauthorized(self):
+        """
+        Tests that an unauthenticated request is rejected with 401.
+        """
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 401)
+
     def test_invalid_post_identifier_returns_bad_response(self):
         """
         Tests that a malformed post_identifier in the URL
@@ -41,7 +51,7 @@ class GetPostDetailsTests(PositiveOnlySocialTestCase):
 
         invalid_url = reverse('get_post_details', kwargs={'post_identifier': non_existent_uuid})
 
-        response = self.client.get(invalid_url)
+        response = self.client.get(invalid_url, **self.header)
 
         # Fails at 'get_post_with_identifier'
         self.assertEqual(response.status_code, 400)
@@ -51,7 +61,7 @@ class GetPostDetailsTests(PositiveOnlySocialTestCase):
         Tests that a valid request for an existing post returns
         a 200 OK and the correct post data.
         """
-        response = self.client.get(self.url)
+        response = self.client.get(self.url, **self.header)
 
         self.assertEqual(response.status_code, 200)
 
@@ -66,3 +76,23 @@ class GetPostDetailsTests(PositiveOnlySocialTestCase):
 
         # Check default/calculated values
         self.assertEqual(data[Fields.post_likes], 0)
+        # The author has not liked their own post
+        self.assertFalse(data[Fields.is_liked])
+
+    def test_is_liked_true_when_requesting_user_liked_post(self):
+        """
+        Tests that is_liked is True when the authenticated requester has
+        liked the post.
+        """
+        # A second user likes the post (users cannot like their own post)
+        liker = self.make_user_with_prefix(prefix='liker')
+        liker_header = {'HTTP_AUTHORIZATION': f'Bearer {liker[Fields.session_management_token]}'}
+
+        like_url = reverse('like_post', kwargs={'post_identifier': str(self.post_identifier)})
+        like_response = self.client.post(like_url, **liker_header)
+        self.assertEqual(like_response.status_code, 200)
+
+        # Fetch details as the liker
+        response = self.client.get(self.url, **liker_header)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()[Fields.is_liked])

--- a/backend/user_system/tests/test_make_post_view.py
+++ b/backend/user_system/tests/test_make_post_view.py
@@ -149,6 +149,27 @@ class MakePostTests(PositiveOnlySocialTestCase):
         self.assertEqual(post.caption, POSITIVE_TEXT)
         self.assertEqual(post.image_url, self.valid_data['image_url'])
 
+    @patch.dict(os.environ, {"TESTING": "True"}, clear=True)
+    def test_image_classifier_not_called_when_caption_fails(self):
+        """
+        When the caption fails the text classifier, the image classifier must not be invoked.
+        This guards the ordering: text check runs before the more expensive image check.
+        """
+        data = self.valid_data.copy()
+        data['caption'] = NEGATIVE_TEXT
+
+        with patch('user_system.views.image_classifier_class.is_image_positive') as mock_image:
+            response = self.client.post(
+                self.url,
+                data=data,
+                content_type='application/json',
+                **self.valid_header
+            )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Text is not positive", response.json().get('error', ''))
+        mock_image.assert_not_called()
+
     def test_image_url_with_wrong_user_prefix_returns_bad_response(self):
         """
         A valid S3 URL whose key is prefixed with a different user's ID must be rejected.

--- a/backend/user_system/views.py
+++ b/backend/user_system/views.py
@@ -967,8 +967,9 @@ def get_posts_for_user(request, username, batch):
         return log_and_return_json("get_posts_for_user", [], safe=False)
 
 
-@ratelimit(key=_get_client_ip, rate='60/m', block=True)
-@require_GET  # Publicly viewable, no @api_login_required
+@api_login_required
+@ratelimit(key='user', rate='60/m', block=True)
+@require_GET
 def get_post_details(request, post_identifier):
     logger.info("Endpoint get_post_details invoked by IP or User")
     if not is_valid_pattern(post_identifier, Patterns.uuid4):
@@ -982,6 +983,7 @@ def get_post_details(request, post_identifier):
             Fields.image_url: get_compressed_image_url(post.image_url),
             Fields.caption: post.caption,
             Fields.post_likes: total_likes,
+            Fields.is_liked: post.postlike_set.filter(user=request.user).exists(),
             Fields.author_username: post.author.username
         }
         return log_and_return_json("get_post_details", post_data)
@@ -1291,6 +1293,13 @@ def get_comments_for_thread(request, comment_thread_identifier, batch):
         return log_and_return_json("get_comments_for_thread", [], safe=False)
 
     batched_comments = get_batch(batch, COMMENT_BATCH_SIZE, relevant_comments)
+    # Single query to find which of these comments the requesting user has liked,
+    # avoiding an N+1 .exists() call per comment.
+    liked_comment_ids = set(
+        request.user.commentlike_set
+        .filter(comment__in=batched_comments)
+        .values_list('comment_id', flat=True)
+    )
     comments_data = [
         {
             Fields.comment_identifier: comment.comment_identifier,
@@ -1298,7 +1307,8 @@ def get_comments_for_thread(request, comment_thread_identifier, batch):
             Fields.author_username: comment.author.username,
             Fields.creation_time: comment.creation_time,
             Fields.updated_time: comment.updated_time,
-            Fields.comment_likes: comment.commentlike_set.count()
+            Fields.comment_likes: comment.commentlike_set.count(),
+            Fields.is_liked: comment.comment_identifier in liked_comment_ids
         }
         for comment in batched_comments
     ]

--- a/backend/user_system/views.py
+++ b/backend/user_system/views.py
@@ -719,13 +719,13 @@ def make_post(request):
         logger.warning(f"Make post failed: Invalid fields {invalid_fields} for user_id: {request.user.id}")
         return log_and_return_json("make_post", {'error': f"Invalid fields {invalid_fields}"}, status=400)
 
-    if not image_classifier_class.is_image_positive(image_url):
-        logger.warning(f"Make post failed: Image not positive for user_id: {request.user.id}")
-        return log_and_return_json("make_post", {'error': "Image is not positive"}, status=400)
-
     if not text_classifier_class.is_text_positive(caption):
         logger.warning(f"Make post failed: Caption not positive for user_id: {request.user.id}")
         return log_and_return_json("make_post", {'error': "Text is not positive"}, status=400)
+
+    if not image_classifier_class.is_image_positive(image_url):
+        logger.warning(f"Make post failed: Image not positive for user_id: {request.user.id}")
+        return log_and_return_json("make_post", {'error': "Image is not positive"}, status=400)
 
     new_post = request.user.post_set.create(image_url=image_url, caption=caption)
     logger.info(f"Post created successfully: post_id: {new_post.post_identifier} for user_id: {request.user.id}")

--- a/ios/Positive Only Social/Positive Only Social/PostDetailView.swift
+++ b/ios/Positive Only Social/Positive Only Social/PostDetailView.swift
@@ -68,7 +68,7 @@ struct PostDetailView: View {
                     VStack(alignment: .leading, spacing: 8) {
                         HStack {
                             Image(systemName: isPostLiked ? "heart.fill" : "heart")
-                                .foregroundColor(.red)
+                                .foregroundColor(Color(UIColor.systemRed))
                                 .accessibilityLabel(isPostLiked ? "Liked" : "Like")
                             Text("\(post.likeCount) likes")
                                 .font(.headline)
@@ -219,7 +219,7 @@ struct PostDetailView: View {
                             .foregroundColor(.secondary)
 
                         Image(systemName: isLiked ? "heart.fill" : "heart")
-                            .foregroundColor(.red)
+                            .foregroundColor(Color(UIColor.systemRed))
                             .font(.caption)
                             .accessibilityLabel(isLiked ? "Liked" : "Like")
 

--- a/ios/Positive Only Social/Positive Only Social/PostDetailView.swift
+++ b/ios/Positive Only Social/Positive Only Social/PostDetailView.swift
@@ -69,6 +69,7 @@ struct PostDetailView: View {
                         HStack {
                             Image(systemName: isPostLiked ? "heart.fill" : "heart")
                                 .foregroundColor(.red)
+                                .accessibilityLabel(isPostLiked ? "Liked" : "Like")
                             Text("\(post.likeCount) likes")
                                 .font(.headline)
                                 .accessibilityIdentifier("PostLikesText")
@@ -220,6 +221,7 @@ struct PostDetailView: View {
                         Image(systemName: isLiked ? "heart.fill" : "heart")
                             .foregroundColor(.red)
                             .font(.caption)
+                            .accessibilityLabel(isLiked ? "Liked" : "Like")
 
                         Text("\(comment.likeCount) likes")
                             .font(.caption)

--- a/ios/Positive Only Social/Positive Only Social/PostDetailView.swift
+++ b/ios/Positive Only Social/Positive Only Social/PostDetailView.swift
@@ -67,8 +67,7 @@ struct PostDetailView: View {
                     // --- POST DETAILS (CAPTION, LIKES) ---
                     VStack(alignment: .leading, spacing: 8) {
                         HStack {
-                            // You could add a like button here
-                            Image(systemName: "heart.fill")
+                            Image(systemName: isPostLiked ? "heart.fill" : "heart")
                                 .foregroundColor(.red)
                             Text("\(post.likeCount) likes")
                                 .font(.headline)
@@ -217,7 +216,11 @@ struct PostDetailView: View {
                         Text(comment.createdDate, style: .relative)
                             .font(.caption)
                             .foregroundColor(.secondary)
-                        
+
+                        Image(systemName: isLiked ? "heart.fill" : "heart")
+                            .foregroundColor(.red)
+                            .font(.caption)
+
                         Text("\(comment.likeCount) likes")
                             .font(.caption)
                             .foregroundColor(.secondary)

--- a/ios/Positive Only Social/Positive Only Social/PostDetailView.swift
+++ b/ios/Positive Only Social/Positive Only Social/PostDetailView.swift
@@ -13,10 +13,6 @@ struct PostDetailView: View {
     // Use @StateObject to create and own the ViewModel
     @StateObject private var viewModel: PostDetailViewModel
 
-    // This state tracks the *user's action* (like or unlike)
-    // for the main post.
-    @State private var isPostLiked = false
-    
     // Public init
     init(postIdentifier: String, api: Networking, keychainHelper: KeychainHelperProtocol) {
         _viewModel = StateObject(wrappedValue: PostDetailViewModel(postIdentifier: postIdentifier, api: api, keychainHelper: keychainHelper))
@@ -50,14 +46,11 @@ struct PostDetailView: View {
                     // --- Image Interactions ---
                     // --- UPDATED ---
                     .onTapGesture(count: 2) {
-                        // Toggle the local like state
-                        isPostLiked.toggle()
-                        
-                        // Call the correct view model function
-                        if isPostLiked {
-                            viewModel.likePost()
-                        } else {
+                        // Drive the action from the server-backed like state
+                        if post.isLiked {
                             viewModel.unlikePost()
+                        } else {
+                            viewModel.likePost()
                         }
                     }
                     .onLongPressGesture {
@@ -67,9 +60,9 @@ struct PostDetailView: View {
                     // --- POST DETAILS (CAPTION, LIKES) ---
                     VStack(alignment: .leading, spacing: 8) {
                         HStack {
-                            Image(systemName: isPostLiked ? "heart.fill" : "heart")
+                            Image(systemName: post.isLiked ? "heart.fill" : "heart")
                                 .foregroundColor(Color(UIColor.systemRed))
-                                .accessibilityLabel(isPostLiked ? "Liked" : "Like")
+                                .accessibilityLabel(post.isLiked ? "Liked" : "Like")
                             Text("\(post.likeCount) likes")
                                 .font(.headline)
                                 .accessibilityIdentifier("PostLikesText")
@@ -184,8 +177,6 @@ struct PostDetailView: View {
     struct CommentRowView: View {
         let comment: CommentViewData
 
-        @State private var isLiked = false
-        
         let isReported: Bool
         
         // Actions passed from the parent
@@ -218,10 +209,10 @@ struct PostDetailView: View {
                             .font(.caption)
                             .foregroundColor(.secondary)
 
-                        Image(systemName: isLiked ? "heart.fill" : "heart")
+                        Image(systemName: comment.isLiked ? "heart.fill" : "heart")
                             .foregroundColor(Color(UIColor.systemRed))
                             .font(.caption)
-                            .accessibilityLabel(isLiked ? "Liked" : "Like")
+                            .accessibilityLabel(comment.isLiked ? "Liked" : "Like")
 
                         Text("\(comment.likeCount) likes")
                             .font(.caption)
@@ -243,14 +234,11 @@ struct PostDetailView: View {
             // --- Interactions ---
             // --- UPDATED ---
             .onTapGesture(count: 2) {
-                // Toggle the local like state
-                isLiked.toggle()
-                
-                // Call the correct action
-                if isLiked {
-                    onLike()
-                } else {
+                // Drive the action from the server-backed like state
+                if comment.isLiked {
                     onUnlike()
+                } else {
+                    onLike()
                 }
             }
             .onLongPressGesture {

--- a/ios/Positive Only Social/Positive Only Social/api/Models.swift
+++ b/ios/Positive Only Social/Positive Only Social/api/Models.swift
@@ -110,6 +110,7 @@ struct PostDisplayData: Identifiable, Equatable {
     let imageURL: String
     let caption: String
     let likeCount: Int
+    let isLiked: Bool // Whether the current user has liked this post
     let authorUsername: String // Added for context
 }
 
@@ -120,6 +121,7 @@ struct CommentViewData: Identifiable, Equatable {
     let authorUsername: String
     let body: String
     let likeCount: Int
+    let isLiked: Bool // Whether the current user has liked this comment
     let createdDate: Date
 }
 

--- a/ios/Positive Only Social/Positive Only Social/api/Networking.swift
+++ b/ios/Positive Only Social/Positive Only Social/api/Networking.swift
@@ -78,8 +78,9 @@ protocol Networking {
     /// Gets a batch of posts for another user.
     func getPostsForUser(sessionManagementToken: String, username: String, batch: Int) async throws -> Data
 
-    /// Gets the details for a single post.
-    func getPostDetails(postIdentifier: String) async throws -> Data
+    /// Gets the details for a single post. Requires auth so the response can
+    /// include whether the current user has liked the post.
+    func getPostDetails(sessionManagementToken: String, postIdentifier: String) async throws -> Data
     
     // MARK: - Comment Management
 
@@ -103,7 +104,8 @@ protocol Networking {
     func getCommentsForPost(postIdentifier: String, batch: Int) async throws -> Data
 
     /// Gets a batch of comments for a specific comment thread (i.e., replies to a comment).
-    func getCommentsForThread(commentThreadIdentifier: String, batch: Int) async throws -> Data
+    /// Requires auth so each comment can include whether the current user has liked it.
+    func getCommentsForThread(sessionManagementToken: String, commentThreadIdentifier: String, batch: Int) async throws -> Data
 
     /// Replies to a comment thread.
     func replyToCommentThread(sessionManagementToken: String, postIdentifier: String, commentThreadIdentifier: String, commentText: String) async throws -> Data

--- a/ios/Positive Only Social/Positive Only Social/api/Networking.swift
+++ b/ios/Positive Only Social/Positive Only Social/api/Networking.swift
@@ -100,8 +100,8 @@ protocol Networking {
     /// Reports a comment for a specific reason.
     func reportComment(sessionManagementToken: String, postIdentifier: String, commentThreadIdentifier: String, commentIdentifier: String, reason: String) async throws -> Data
 
-    /// Gets a batch of comments for a post.
-    func getCommentsForPost(postIdentifier: String, batch: Int) async throws -> Data
+    /// Gets a batch of comment threads for a post. Requires auth.
+    func getCommentsForPost(sessionManagementToken: String, postIdentifier: String, batch: Int) async throws -> Data
 
     /// Gets a batch of comments for a specific comment thread (i.e., replies to a comment).
     /// Requires auth so each comment can include whether the current user has liked it.

--- a/ios/Positive Only Social/Positive Only Social/api/RealAPI.swift
+++ b/ios/Positive Only Social/Positive Only Social/api/RealAPI.swift
@@ -430,11 +430,12 @@ final class RealAPI: Networking {
     }
     
     /// Gets the details for a single post.
-    func getPostDetails(postIdentifier: String) async throws -> Data {
-        // This is a public GET request, no body, no auth. ID is in path.
+    func getPostDetails(sessionManagementToken: String, postIdentifier: String) async throws -> Data {
+        // Authenticated GET so the response can include the current user's like state. ID is in path.
         return try await performRequest(
             pathSegments: ["posts", postIdentifier, "details"],
-            method: .get
+            method: .get,
+            authToken: sessionManagementToken
         )
     }
     
@@ -506,11 +507,12 @@ final class RealAPI: Networking {
     }
     
     /// Gets a batch of comments for a specific comment thread.
-    func getCommentsForThread(commentThreadIdentifier: String, batch: Int) async throws -> Data {
-        // This is a GET request, no body, with no auth. ID/Batch are in path.
+    func getCommentsForThread(sessionManagementToken: String, commentThreadIdentifier: String, batch: Int) async throws -> Data {
+        // Authenticated GET so each comment can include the current user's like state. ID/Batch are in path.
         return try await performRequest(
             pathSegments: ["threads", commentThreadIdentifier, "comments", String(batch)],
             method: .get,
+            authToken: sessionManagementToken
         )
     }
     

--- a/ios/Positive Only Social/Positive Only Social/api/RealAPI.swift
+++ b/ios/Positive Only Social/Positive Only Social/api/RealAPI.swift
@@ -497,12 +497,13 @@ final class RealAPI: Networking {
         )
     }
     
-    /// Gets a batch of comments for a post.
-    func getCommentsForPost(postIdentifier: String, batch: Int) async throws -> Data {
-        // This is a GET request, no body, with no auth. ID/Batch are in path.
+    /// Gets a batch of comment threads for a post.
+    func getCommentsForPost(sessionManagementToken: String, postIdentifier: String, batch: Int) async throws -> Data {
+        // Authenticated GET. ID/Batch are in path.
         return try await performRequest(
             pathSegments: ["posts", postIdentifier, "comments", String(batch)],
             method: .get,
+            authToken: sessionManagementToken
         )
     }
     

--- a/ios/Positive Only Social/Positive Only Social/api/StatefulStubbedAPI.swift
+++ b/ios/Positive Only Social/Positive Only Social/api/StatefulStubbedAPI.swift
@@ -515,11 +515,12 @@ final class StatefulStubbedAPI: Networking {
         return try createSerializedListResponse(fieldsList: fieldObjects)
     }
 
-    func getPostDetails(postIdentifier: String) async throws -> Data {
+    func getPostDetails(sessionManagementToken: String, postIdentifier: String) async throws -> Data {
         await simulateNetwork()
+        guard let user = findUser(bySessionToken: sessionManagementToken) else { throw APIError.badServerResponse(statusCode: 401) }
         guard let post = findPost(byIdentifier: postIdentifier) else { throw APIError.badServerResponse(statusCode: 400) }
-        struct Fields: Codable { let post_identifier, image_url, caption: String; let post_likes: Int; let author_username: String }
-        let fields = Fields(post_identifier: post.postIdentifier, image_url: post.imageURL, caption: post.caption, post_likes: post.likes.count, author_username: users.first(where: {$0.id == post.authorId})?.username ?? "Unknown User")
+        struct Fields: Codable { let post_identifier, image_url, caption: String; let post_likes: Int; let is_liked: Bool; let author_username: String }
+        let fields = Fields(post_identifier: post.postIdentifier, image_url: post.imageURL, caption: post.caption, post_likes: post.likes.count, is_liked: post.likes.contains(user.username), author_username: users.first(where: {$0.id == post.authorId})?.username ?? "Unknown User")
         return try createSerializedResponse(fields: fields)
     }
 
@@ -613,10 +614,11 @@ final class StatefulStubbedAPI: Networking {
         return try createSerializedListResponse(fieldsList: fieldObjects)
     }
 
-    func getCommentsForThread(commentThreadIdentifier: String, batch: Int) async throws -> Data {
+    func getCommentsForThread(sessionManagementToken: String, commentThreadIdentifier: String, batch: Int) async throws -> Data {
         await simulateNetwork()
+        guard let user = findUser(bySessionToken: sessionManagementToken) else { throw APIError.badServerResponse(statusCode: 401) }
         let relevantComments = comments.filter { $0.threadId == commentThreadIdentifier && !$0.isHidden }.sorted { $0.createdDate < $1.createdDate }
-        
+
         if relevantComments.isEmpty {
             // If there are no comments return gracefully
             return try createSerializedListResponse(fieldsList: [Fields]())
@@ -626,6 +628,7 @@ final class StatefulStubbedAPI: Networking {
             let comment_identifier, body, author_username: String
             let creation_time, updated_time: String
             let comment_likes: Int
+            let is_liked: Bool
         }
 
         let dateFormatter = ISO8601DateFormatter()
@@ -633,7 +636,8 @@ final class StatefulStubbedAPI: Networking {
             Fields(comment_identifier: comment.commentIdentifier, body: comment.body, author_username: comment.authorUsername,
                    creation_time: dateFormatter.string(from: comment.createdDate),
                    updated_time: dateFormatter.string(from: comment.updatedDate),
-                   comment_likes: comment.likes.count)
+                   comment_likes: comment.likes.count,
+                   is_liked: comment.likes.contains(user.username))
         }
         return try createSerializedListResponse(fieldsList: fieldObjects)
     }

--- a/ios/Positive Only Social/Positive Only Social/api/StatefulStubbedAPI.swift
+++ b/ios/Positive Only Social/Positive Only Social/api/StatefulStubbedAPI.swift
@@ -600,8 +600,9 @@ final class StatefulStubbedAPI: Networking {
         return try createEmptySuccessResponse()
     }
 
-    func getCommentsForPost(postIdentifier: String, batch: Int) async throws -> Data {
+    func getCommentsForPost(sessionManagementToken: String, postIdentifier: String, batch: Int) async throws -> Data {
         await simulateNetwork()
+        guard findUser(bySessionToken: sessionManagementToken) != nil else { throw APIError.badServerResponse(statusCode: 401) }
         let relevantThreads = commentThreads.filter { $0.postId == postIdentifier }
         
         // If there are no threads return gracefully

--- a/ios/Positive Only Social/Positive Only Social/preview/PreviewHelpers.swift
+++ b/ios/Positive Only Social/Positive Only Social/preview/PreviewHelpers.swift
@@ -160,21 +160,23 @@ struct MockedAPI: Networking {
         return try encode(posts)
     }
 
-    func getPostDetails(postIdentifier: String) async throws -> Data {
+    func getPostDetails(sessionManagementToken: String, postIdentifier: String) async throws -> Data {
         // Matches PostDetailViewModel.PostDetailsFields
         struct PostDetailsResponse: Codable {
             let post_identifier: String
             let image_url: String
             let caption: String
             let post_likes: Int
+            let is_liked: Bool
             let author_username: String
         }
-        
+
         let detail = PostDetailsResponse(
             post_identifier: postIdentifier,
             image_url: "https://picsum.photos/400/400",
             caption: "Detailed view of the post",
             post_likes: 100,
+            is_liked: false,
             author_username: "mock_author"
         )
         return try encode(detail)
@@ -215,7 +217,7 @@ struct MockedAPI: Networking {
         return try encode(threads)
     }
 
-    func getCommentsForThread(commentThreadIdentifier: String, batch: Int) async throws -> Data {
+    func getCommentsForThread(sessionManagementToken: String, commentThreadIdentifier: String, batch: Int) async throws -> Data {
         // Matches PostDetailViewModel.CommentFields
         struct CommentResponse: Codable {
             let comment_identifier: String
@@ -224,6 +226,7 @@ struct MockedAPI: Networking {
             let creation_time: String
             let updated_time: String
             let comment_likes: Int
+            let is_liked: Bool
         }
 
         let comments = [
@@ -233,7 +236,8 @@ struct MockedAPI: Networking {
                 author_username: "fan_1",
                 creation_time: "2023-01-01T12:00:00Z",
                 updated_time: "2023-01-01T12:00:00Z",
-                comment_likes: 5
+                comment_likes: 5,
+                is_liked: false
             ),
             CommentResponse(
                 comment_identifier: "c2",
@@ -241,7 +245,8 @@ struct MockedAPI: Networking {
                 author_username: "fan_2",
                 creation_time: "2023-01-01T12:05:00Z",
                 updated_time: "2023-01-01T12:05:00Z",
-                comment_likes: 2
+                comment_likes: 2,
+                is_liked: true
             )
         ]
         return try encode(comments)

--- a/ios/Positive Only Social/Positive Only Social/preview/PreviewHelpers.swift
+++ b/ios/Positive Only Social/Positive Only Social/preview/PreviewHelpers.swift
@@ -204,7 +204,7 @@ struct MockedAPI: Networking {
         return try encodeGenericSuccess()
     }
 
-    func getCommentsForPost(postIdentifier: String, batch: Int) async throws -> Data {
+    func getCommentsForPost(sessionManagementToken: String, postIdentifier: String, batch: Int) async throws -> Data {
         // Matches PostDetailViewModel.ThreadIDFields
         struct ThreadIDResponse: Codable {
             let comment_thread_identifier: String

--- a/ios/Positive Only Social/Positive Only Social/viewmodels/PostDetailViewModel.swift
+++ b/ios/Positive Only Social/Positive Only Social/viewmodels/PostDetailViewModel.swift
@@ -64,34 +64,45 @@ final class PostDetailViewModel: ObservableObject {
         
         Task {
             do {
+                // These authenticated GETs need the session token so the backend can
+                // report whether the current user has liked the post / each comment.
+                guard let userSession = try keychainHelper.load(UserSession.self, from: keychainService, account: account) else {
+                    NSLog("%@", "No active session — cannot load post details")
+                    self.alertMessage = "Session not found."
+                    self.isLoading = false
+                    return
+                }
+                let token = userSession.sessionToken
+
                 // 1. Fetch the main post details
-                let postData = try await api.getPostDetails(postIdentifier: postIdentifier)
+                let postData = try await api.getPostDetails(sessionManagementToken: token, postIdentifier: postIdentifier)
                 let postFields = try self.decodeSingle(from: postData, type: PostDetailsFields.self)
-                
+
                 self.postDetail = PostDisplayData(
                     id: postFields.post_identifier,
                     imageURL: postFields.image_url,
                     caption: postFields.caption,
                     likeCount: postFields.post_likes,
+                    isLiked: postFields.is_liked,
                     authorUsername: postFields.author_username
                 )
-                
+
                 // 2. Fetch the list of comment thread IDs for this post
                 let threadListData = try await api.getCommentsForPost(postIdentifier: postIdentifier, batch: 0)
                 let threadIDFields = try self.decodeList(from: threadListData, type: ThreadIDFields.self)
                 let threadIdentifiers = threadIDFields.map { $0.comment_thread_identifier }
-                
+
                 // 3. Fetch all comments for *each* thread in parallel
                 var loadedThreads: [CommentThreadViewData] = []
-                
+
                 try await withThrowingTaskGroup(of: [CommentViewData].self) { group in
                     for threadId in threadIdentifiers {
                         group.addTask {
-                            let commentsData = try await self.api.getCommentsForThread(commentThreadIdentifier: threadId, batch: 0)
-                            
+                            let commentsData = try await self.api.getCommentsForThread(sessionManagementToken: token, commentThreadIdentifier: threadId, batch: 0)
+
                             // *** FIXED: Removed 'await' here, as decodeList is not async ***
                             let commentFields = try await self.decodeList(from: commentsData, type: CommentFields.self)
-                            
+
                             // 4. Convert network models to View Models
                             return commentFields.map { field in
                                 CommentViewData(
@@ -100,6 +111,7 @@ final class PostDetailViewModel: ObservableObject {
                                     authorUsername: field.author_username,
                                     body: field.body,
                                     likeCount: field.comment_likes,
+                                    isLiked: field.is_liked,
                                     createdDate: Self.parseDate(field.creation_time)
                                 )
                             }
@@ -141,6 +153,7 @@ final class PostDetailViewModel: ObservableObject {
                 imageURL: post.imageURL,
                 caption: post.caption,
                 likeCount: post.likeCount + 1, // Optimistic update
+                isLiked: true,
                 authorUsername: post.authorUsername
             )
             self.postDetail = post
@@ -173,6 +186,7 @@ final class PostDetailViewModel: ObservableObject {
                 imageURL: post.imageURL,
                 caption: post.caption,
                 likeCount: max(0, post.likeCount - 1), // Optimistic update
+                isLiked: false,
                 authorUsername: post.authorUsername
             )
             self.postDetail = post
@@ -245,6 +259,7 @@ final class PostDetailViewModel: ObservableObject {
             authorUsername: oldComment.authorUsername,
             body: oldComment.body,
             likeCount: oldComment.likeCount + 1, // The update
+            isLiked: true,
             createdDate: oldComment.createdDate
         )
         
@@ -294,6 +309,7 @@ final class PostDetailViewModel: ObservableObject {
             authorUsername: oldComment.authorUsername,
             body: oldComment.body,
             likeCount: newLikeCount, // The update
+            isLiked: false,
             createdDate: oldComment.createdDate
         )
         
@@ -409,6 +425,7 @@ final class PostDetailViewModel: ObservableObject {
         let image_url: String
         let caption: String
         let post_likes: Int
+        let is_liked: Bool
         let author_username: String
     }
     
@@ -423,6 +440,7 @@ final class PostDetailViewModel: ObservableObject {
         let creation_time: String
         let updated_time: String
         let comment_likes: Int
+        let is_liked: Bool
     }
 
     private func decodeSingle<T: Decodable>(from data: Data, type: T.Type) throws -> T {

--- a/ios/Positive Only Social/Positive Only Social/viewmodels/PostDetailViewModel.swift
+++ b/ios/Positive Only Social/Positive Only Social/viewmodels/PostDetailViewModel.swift
@@ -88,7 +88,7 @@ final class PostDetailViewModel: ObservableObject {
                 )
 
                 // 2. Fetch the list of comment thread IDs for this post
-                let threadListData = try await api.getCommentsForPost(postIdentifier: postIdentifier, batch: 0)
+                let threadListData = try await api.getCommentsForPost(sessionManagementToken: token, postIdentifier: postIdentifier, batch: 0)
                 let threadIDFields = try self.decodeList(from: threadListData, type: ThreadIDFields.self)
                 let threadIdentifiers = threadIDFields.map { $0.comment_thread_identifier }
 

--- a/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_PostDetailViewModel.swift
+++ b/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_PostDetailViewModel.swift
@@ -123,10 +123,14 @@ struct Positive_Only_SocialTests_PostDetailViewModel {
         #expect(sut.postDetail?.id == postID)
         #expect(sut.postDetail?.caption == "Test Post 1")
         #expect(sut.postDetail?.authorUsername == "postOwner")
-        
+        // And: The current user has not liked the post, so it seeds as not-liked
+        #expect(sut.postDetail?.isLiked == false)
+
         // And: The comment threads should be loaded
         #expect(sut.commentThreads.count == 1, "Should be 1 comment thread")
         #expect(sut.commentThreads.first?.comments.count == 2, "Thread should have 2 comments")
+        // And: Comments seed as not-liked for a user who hasn't liked them
+        #expect(sut.commentThreads.first?.comments.first?.isLiked == false)
         
         // And: Comments should be sorted by creation date (oldest first)
         let firstComment = sut.commentThreads.first?.comments.first
@@ -151,7 +155,9 @@ struct Positive_Only_SocialTests_PostDetailViewModel {
         
         // Then: The like count is optimistically updated immediately
         #expect(sut.postDetail?.likeCount == 1, "Like count should immediately increment")
-        
+        // And: The heart reflects the liked state
+        #expect(sut.postDetail?.isLiked == true, "Post should be marked liked")
+
         // And: After the network call finishes, the count remains 1
         await yield()
         #expect(sut.postDetail?.likeCount == 1)
@@ -169,7 +175,9 @@ struct Positive_Only_SocialTests_PostDetailViewModel {
         
         // Then: The like count is optimistically updated immediately
         #expect(sut.postDetail?.likeCount == 0, "Like count should immediately decrement")
-        
+        // And: The heart reflects the not-liked state
+        #expect(sut.postDetail?.isLiked == false, "Post should be marked not liked")
+
         // And: After the network call finishes, the count remains 0
         await yield()
         #expect(sut.postDetail?.likeCount == 0)
@@ -204,7 +212,9 @@ struct Positive_Only_SocialTests_PostDetailViewModel {
         // Then: The like count is optimistically updated immediately
         let updatedComment = sut.commentThreads.first?.comments.first(where: { $0.id == commentID })
         #expect(updatedComment?.likeCount == 1, "Like count should immediately increment")
-        
+        // And: The heart reflects the liked state
+        #expect(updatedComment?.isLiked == true, "Comment should be marked liked")
+
         // And: After the network call finishes, the count remains 1
         await yield()
         #expect(sut.commentThreads.first?.comments.first?.likeCount == 1)
@@ -232,7 +242,9 @@ struct Positive_Only_SocialTests_PostDetailViewModel {
         // Then: The like count is optimistically updated immediately
         let unlikedComment = sut.commentThreads.first?.comments.first(where: { $0.id == commentID })
         #expect(unlikedComment?.likeCount == 0, "Like count should immediately decrement")
-        
+        // And: The heart reflects the not-liked state
+        #expect(unlikedComment?.isLiked == false, "Comment should be marked not liked")
+
         // And: After the network call finishes, the count remains 0
         await yield()
         #expect(sut.commentThreads.first?.comments.first?.likeCount == 0)


### PR DESCRIPTION
## Summary
Post and comment hearts now show whether **the current user** has liked the item — filled when liked, outline when not — seeded from the server rather than from a local default. Also reorders the `make_post` classifier checks.

### Heart like-state (iOS, Android, backend)
- Hearts render filled (`heart.fill` / `Favorite`) when liked and outline (`heart` / `FavoriteBorder`) when not, with state-dependent accessibility labels.
- **Root cause fixed:** the like flag previously always started `false` and was never seeded from persisted state, so a post/comment you'd already liked showed an outline heart and the next double-tap re-hit the like endpoint (which the backend rejects as a duplicate).
- No endpoint exposed per-user like state, so it's now exposed:
  - `get_post_details` **requires auth** and returns `is_liked` for the requester.
  - `get_comments_for_thread` returns `is_liked` per comment (single prefetch query, no N+1).
  - Added `Fields.is_liked`.
- Clients now send the session token on `getPostDetails`, `getCommentsForPost`, and `getCommentsForThread` (all backend-authenticated), thread `is_liked` through the DTOs/view-data, and drive the hearts from server state. iOS keeps its optimistic like/unlike updates in sync; Android reloads after each mutation.
- iOS hearts use `Color(UIColor.systemRed)` so they adapt to light/dark and iOS 26 colour styles.

### `make_post` classifier order (backend)
- Text classifier now runs **before** the image classifier, so an invalid caption is rejected cheaply without the more expensive image classification call.

### Drive-by fix
- Android `Post.likeCount` was missing `@SerializedName("post_likes")`, so the detail screen's like count always deserialized to `0` against the real backend. Now mapped, with a Gson test locking it in.

## Tests
- **Backend:** updated `get_post_details` tests for the new auth requirement; added `is_liked` coverage (true/false) on both read endpoints; added a `make_post` regression test asserting the image classifier is skipped when the caption fails. Full `user_system` suite green (210 tests).
- **iOS:** `is_liked` assertions added to the PostDetail view-model tests; stubs/preview updated.
- **Android:** `PostDeserializationTest` (Gson mapping) added; view-model test mocks updated for the new signatures.

## Notes / test plan
- [ ] Double-tap a post you've already liked — heart should start filled and toggle correctly (no duplicate-like error).
- [ ] Comment hearts reflect prior likes on load.
- [ ] Post with a non-positive caption is rejected before the image classifier runs; positive caption + non-positive image still rejected.
- iOS/Android apps couldn't be compiled in the dev environment (no Xcode/JDK) — Swift/Kotlin changes verified by inspection; worth a CI build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)