### PR TITLE
Add retries and per-attempt timeout for iOS test shards

### DIFF
--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -125,6 +125,7 @@ jobs:
           shell: bash
           command: |
             cd "ios/Positive Only Social"
+            rm -rf TestResults.xcresult xcodebuild.log
             case "${{ matrix.test-group }}" in
               Unit_Tests)
                 TESTS=(

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -85,9 +85,6 @@ jobs:
     name: Test (${{ matrix.test-group }})
     needs: build
     runs-on: macos-15
-    timeout-minutes: 60
-    retry:
-      max-attempts: 3
     strategy:
       fail-fast: false
       matrix:
@@ -121,70 +118,75 @@ jobs:
           find build/Build/Products -name "*.xctestrun"
 
       - name: Run Tests
-        working-directory: "ios/Positive Only Social"
-        run: |
-          case "${{ matrix.test-group }}" in
-            Unit_Tests)
-              TESTS=(
-                "Positive Only SocialTests"
-              )
-              # "Positive Only Social Unit Tests" plan covers unit tests only
-              XCTESTRUN=$(find build/Build/Products -name "*.xctestrun" | grep "Unit Tests" | head -1)
-              ;;
-            UI_Tests_Alpha)
-              TESTS=(
-                "Positive Only SocialUITests/Positive_Only_SocialUITests/testAutomaticLoginAfterRememberMe"
-                "Positive Only SocialUITests/Positive_Only_SocialUITests/testDeleteAccount"
-                "Positive Only SocialUITests/Positive_Only_SocialUITests/testResetPassword"
-              )
-              # "Positive Only Social" (default) plan covers both unit and UI tests
-              XCTESTRUN=$(find build/Build/Products -name "*.xctestrun" | grep -v "Unit Tests" | head -1)
-              ;;
-            UI_Tests_Beta)
-              TESTS=(
-                "Positive Only SocialUITests/Positive_Only_SocialUITests/testFollowAndUnfollowFromSearch"
-                "Positive Only SocialUITests/Positive_Only_SocialUITests/testFollowAndUnfollowFromPost"
-                "Positive Only SocialUITests/Positive_Only_SocialUITests/testLikeAndUnlikePost"
-              )
-              # "Positive Only Social" (default) plan covers both unit and UI tests
-              XCTESTRUN=$(find build/Build/Products -name "*.xctestrun" | grep -v "Unit Tests" | head -1)
-              ;;
-            UI_Tests_Gamma)
-              TESTS=(
-                "Positive Only SocialUITests/Positive_Only_SocialUITests/testVerifyIdentity"
-                "Positive Only SocialUITests/Positive_Only_SocialUITests/testLikeAndUnlikeCommentOnPostAndThread"
-                "Positive Only SocialUITests/Positive_Only_SocialUITests/testReportPost"
-              )
-              # "Positive Only Social" (default) plan covers both unit and UI tests
-              XCTESTRUN=$(find build/Build/Products -name "*.xctestrun" | grep -v "Unit Tests" | head -1)
-              ;;
-            UI_Tests_Delta)
-              TESTS=(
-                "Positive Only SocialUITests/Positive_Only_SocialUITests/testReportComment"
-                "Positive Only SocialUITests/Positive_Only_SocialUITests/testLaunchPerformance"
-                "Positive Only SocialUITests/Positive_Only_SocialUITests/testBlockAndUnblockUser"
-              )
-              # "Positive Only Social" (default) plan covers both unit and UI tests
-              XCTESTRUN=$(find build/Build/Products -name "*.xctestrun" | grep -v "Unit Tests" | head -1)
-              ;;
-          esac
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 60
+          max_attempts: 3
+          shell: bash
+          command: |
+            cd "ios/Positive Only Social"
+            case "${{ matrix.test-group }}" in
+              Unit_Tests)
+                TESTS=(
+                  "Positive Only SocialTests"
+                )
+                # "Positive Only Social Unit Tests" plan covers unit tests only
+                XCTESTRUN=$(find build/Build/Products -name "*.xctestrun" | grep "Unit Tests" | head -1)
+                ;;
+              UI_Tests_Alpha)
+                TESTS=(
+                  "Positive Only SocialUITests/Positive_Only_SocialUITests/testAutomaticLoginAfterRememberMe"
+                  "Positive Only SocialUITests/Positive_Only_SocialUITests/testDeleteAccount"
+                  "Positive Only SocialUITests/Positive_Only_SocialUITests/testResetPassword"
+                )
+                # "Positive Only Social" (default) plan covers both unit and UI tests
+                XCTESTRUN=$(find build/Build/Products -name "*.xctestrun" | grep -v "Unit Tests" | head -1)
+                ;;
+              UI_Tests_Beta)
+                TESTS=(
+                  "Positive Only SocialUITests/Positive_Only_SocialUITests/testFollowAndUnfollowFromSearch"
+                  "Positive Only SocialUITests/Positive_Only_SocialUITests/testFollowAndUnfollowFromPost"
+                  "Positive Only SocialUITests/Positive_Only_SocialUITests/testLikeAndUnlikePost"
+                )
+                # "Positive Only Social" (default) plan covers both unit and UI tests
+                XCTESTRUN=$(find build/Build/Products -name "*.xctestrun" | grep -v "Unit Tests" | head -1)
+                ;;
+              UI_Tests_Gamma)
+                TESTS=(
+                  "Positive Only SocialUITests/Positive_Only_SocialUITests/testVerifyIdentity"
+                  "Positive Only SocialUITests/Positive_Only_SocialUITests/testLikeAndUnlikeCommentOnPostAndThread"
+                  "Positive Only SocialUITests/Positive_Only_SocialUITests/testReportPost"
+                )
+                # "Positive Only Social" (default) plan covers both unit and UI tests
+                XCTESTRUN=$(find build/Build/Products -name "*.xctestrun" | grep -v "Unit Tests" | head -1)
+                ;;
+              UI_Tests_Delta)
+                TESTS=(
+                  "Positive Only SocialUITests/Positive_Only_SocialUITests/testReportComment"
+                  "Positive Only SocialUITests/Positive_Only_SocialUITests/testLaunchPerformance"
+                  "Positive Only SocialUITests/Positive_Only_SocialUITests/testBlockAndUnblockUser"
+                )
+                # "Positive Only Social" (default) plan covers both unit and UI tests
+                XCTESTRUN=$(find build/Build/Products -name "*.xctestrun" | grep -v "Unit Tests" | head -1)
+                ;;
+            esac
 
-          # Fallback: if the pattern found nothing, take the first available file
-          XCTESTRUN=${XCTESTRUN:-$(find build/Build/Products -name "*.xctestrun" | head -1)}
-          echo "Using xctestrun: $XCTESTRUN"
+            # Fallback: if the pattern found nothing, take the first available file
+            XCTESTRUN=${XCTESTRUN:-$(find build/Build/Products -name "*.xctestrun" | head -1)}
+            echo "Using xctestrun: $XCTESTRUN"
 
-          ONLY_TESTING_ARGS=()
-          for t in "${TESTS[@]}"; do
-            ONLY_TESTING_ARGS+=("-only-testing:$t")
-          done
+            ONLY_TESTING_ARGS=()
+            for t in "${TESTS[@]}"; do
+              ONLY_TESTING_ARGS+=("-only-testing:$t")
+            done
 
-          xcodebuild test-without-building \
-            -xctestrun "$XCTESTRUN" \
-            -destination "platform=iOS Simulator,name=iPhone 16,OS=26.2" \
-            -resultBundlePath TestResults.xcresult \
-            "${ONLY_TESTING_ARGS[@]}" \
-          | tee xcodebuild.log | xcpretty
-          exit ${PIPESTATUS[0]}
+            xcodebuild test-without-building \
+              -xctestrun "$XCTESTRUN" \
+              -destination "platform=iOS Simulator,name=iPhone 16,OS=26.2" \
+              -resultBundlePath TestResults.xcresult \
+              "${ONLY_TESTING_ARGS[@]}" \
+            | tee xcodebuild.log | xcpretty
+            exit ${PIPESTATUS[0]}
 
       - name: Show failed tests
         if: failure()

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -85,7 +85,9 @@ jobs:
     name: Test (${{ matrix.test-group }})
     needs: build
     runs-on: macos-15
-    timeout-minutes: 90
+    timeout-minutes: 60
+    retry:
+      max-attempts: 3
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- Wrap each test shard's "Run Tests" command in [`nick-fields/retry@v3`](https://github.com/nick-fields/retry) with `max_attempts: 3` (1 initial attempt + 2 retries). GitHub Actions has no native job-level retry, so this is done at the step level.
- Set a per-attempt `timeout_minutes: 60`, so each attempt is capped at an hour (down from the old single-run job timeout of 90 minutes).
- Removed the job-level `timeout-minutes` — a 60-minute cap on the whole job would have killed retries before they could run. Each attempt is now bounded by the retry action's 60-minute timeout instead (worst case 3 × 60 min, under the 360-min default job cap).

## Notes
- The "an hour" timeout now applies **per attempt** rather than to the whole job, which is the meaningful bound now that a shard can run up to 3 times. If you'd rather cap total wall-clock time across all attempts instead, let me know.
- `shell: bash` is set on the action because the command uses bash arrays and `PIPESTATUS`.

## Test plan
- [ ] Verify the workflow triggers on a PR touching `ios/**`
- [ ] Confirm a flaky shard retries automatically (up to 3 attempts) rather than failing the whole run on the first failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)