### PR TITLE
Add pull-to-refresh to home, feed, and post detail screens (iOS + Android)

### DIFF
--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/FeedViewModel.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/FeedViewModel.kt
@@ -27,9 +27,46 @@ class FeedViewModel(
     private val _isLoadingNextPage = MutableStateFlow(false)
     val isLoadingNextPage: StateFlow<Boolean> = _isLoadingNextPage.asStateFlow()
 
+    private val _isRefreshing = MutableStateFlow(false)
+    val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
+
     private var canLoadMore = true
     private var currentPage = 0
     private val service = "positive-only-social.Positive-Only-Social"
+
+    /**
+     * Pull-to-refresh: resets pagination and reloads the feed from the first
+     * page, replacing the existing posts with the newest ones from the backend.
+     */
+    fun refreshFeed() {
+        if (_isRefreshing.value || _isLoadingNextPage.value) return
+
+        _isRefreshing.value = true
+
+        viewModelScope.launch {
+            try {
+                val userSession = keychainHelper.load(UserSession::class.java, service, account)
+                if (userSession == null) {
+                    Log.e(TAG, "No active session found — cannot refresh feed")
+                    return@launch
+                }
+
+                val response = api.getPostsInFeed(userSession.sessionToken, 0)
+                if (response.isSuccessful) {
+                    val newPosts = response.body() ?: emptyList()
+                    _feedPosts.value = newPosts
+                    canLoadMore = newPosts.isNotEmpty()
+                    currentPage = if (newPosts.isEmpty()) 0 else 1
+                } else {
+                    Log.e(TAG, "Failed to refresh feed: ${response.errorBody()?.string()}")
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to refresh feed", e)
+            } finally {
+                _isRefreshing.value = false
+            }
+        }
+    }
 
     fun fetchFeed() {
         if (_isLoadingNextPage.value || !canLoadMore) return

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/FollowingFeedViewModel.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/FollowingFeedViewModel.kt
@@ -26,9 +26,46 @@ class FollowingFeedViewModel(
     private val _isLoadingNextPage = MutableStateFlow(false)
     val isLoadingNextPage: StateFlow<Boolean> = _isLoadingNextPage.asStateFlow()
 
+    private val _isRefreshing = MutableStateFlow(false)
+    val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
+
     private var canLoadMore = true
     private var currentPage = 0
     private val service = "positive-only-social.Positive-Only-Social"
+
+    /**
+     * Pull-to-refresh: resets pagination and reloads the following feed from the
+     * first page, replacing the existing posts with the newest ones from the backend.
+     */
+    fun refreshFollowingFeed() {
+        if (_isRefreshing.value || _isLoadingNextPage.value) return
+
+        _isRefreshing.value = true
+
+        viewModelScope.launch {
+            try {
+                val userSession = keychainHelper.load(UserSession::class.java, service, account)
+                if (userSession == null) {
+                    Log.e(TAG, "No active session found — cannot refresh following feed")
+                    return@launch
+                }
+
+                val response = api.getFollowedPosts(userSession.sessionToken, 0)
+                if (response.isSuccessful) {
+                    val newPosts = response.body() ?: emptyList()
+                    _followingPosts.value = newPosts
+                    canLoadMore = newPosts.isNotEmpty()
+                    currentPage = if (newPosts.isEmpty()) 0 else 1
+                } else {
+                    Log.e(TAG, "Failed to refresh following feed: ${response.errorBody()?.string()}")
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to refresh following feed", e)
+            } finally {
+                _isRefreshing.value = false
+            }
+        }
+    }
 
     fun fetchFollowingFeed() {
         if (_isLoadingNextPage.value || !canLoadMore) return

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/HomeViewModel.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/HomeViewModel.kt
@@ -42,6 +42,9 @@ class HomeViewModel(
     private val _errorMessage = MutableStateFlow<String?>(null)
     val errorMessage: StateFlow<String?> = _errorMessage.asStateFlow()
 
+    private val _isRefreshing = MutableStateFlow(false)
+    val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
+
     private var canLoadMorePosts = true
     private var currentPage = 0
     private val service = "positive-only-social.Positive-Only-Social"
@@ -58,6 +61,43 @@ class HomeViewModel(
 
     fun updateSearchText(text: String) {
         _searchText.value = text
+    }
+
+    /**
+     * Pull-to-refresh: resets pagination and reloads the user's posts from the
+     * first page, replacing the existing posts with the newest ones from the backend.
+     */
+    fun refreshMyPosts() {
+        if (_isRefreshing.value || _isLoadingNextPage.value) return
+
+        _isRefreshing.value = true
+
+        viewModelScope.launch {
+            try {
+                val userSession = keychainHelper.load(UserSession::class.java, service, account)
+                if (userSession == null) {
+                    Log.e(TAG, "No active session found — cannot refresh posts")
+                    return@launch
+                }
+
+                val username = userSession.username
+
+                val response = api.getPostsForUser(userSession.sessionToken, username, 0)
+                if (response.isSuccessful) {
+                    val newPosts = response.body() ?: emptyList()
+                    _userPosts.value = newPosts
+                    canLoadMorePosts = newPosts.isNotEmpty()
+                    currentPage = if (newPosts.isEmpty()) 0 else 1
+                } else {
+                    _errorMessage.value = response.errorBody()?.string()
+                }
+            } catch (e: Exception) {
+                _errorMessage.value = e.localizedMessage
+                Log.e(TAG, "Error refreshing my posts", e)
+            } finally {
+                _isRefreshing.value = false
+            }
+        }
     }
 
     fun fetchMyPosts() {

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/PostDetailViewModel.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/PostDetailViewModel.kt
@@ -39,6 +39,9 @@ class PostDetailViewModel(
     private val _isLoading = MutableStateFlow(true)
     val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
 
+    private val _isRefreshing = MutableStateFlow(false)
+    val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
+
     private val _alertMessage = MutableStateFlow<String?>(null)
     val alertMessage: StateFlow<String?> = _alertMessage.asStateFlow()
 
@@ -86,69 +89,93 @@ class PostDetailViewModel(
 
         viewModelScope.launch {
             try {
-                // These authenticated GETs need the session token so the backend can
-                // report whether the current user has liked the post / each comment.
-                val userSession = keychainHelper.load(UserSession::class.java, service, account)
-                if (userSession == null) {
-                    Log.e(TAG, "No active session found — cannot load post details")
-                    _alertMessage.value = "Not logged in."
-                    return@launch
-                }
-                val token = userSession.sessionToken
-
-                // 1. Fetch the main post details
-                val postResponse = api.getPostDetails(token, postIdentifier)
-                if (postResponse.isSuccessful) {
-                    _postDetail.value = postResponse.body()
-                } else {
-                    throw Exception("Failed to load post details")
-                }
-
-                // 2. Fetch the list of comment thread IDs for this post
-                val threadListResponse = api.getCommentsForPost(token, postIdentifier, 0)
-                val threadDtos = threadListResponse.body() ?: emptyList()
-                val threadIdentifiers = threadDtos.map { it.threadIdentifier }
-
-                // 3. Fetch all comments for *each* thread in parallel
-                val loadedThreads = coroutineScope {
-                    threadIdentifiers.map { threadId ->
-                        async {
-                            val commentsResponse = api.getCommentsForThread(token, threadId, 0)
-                            val comments = commentsResponse.body() ?: emptyList()
-                            // Sort comments by date (oldest first)
-                            val sortedComments = comments.sortedBy { it.creationTime }
-
-                            // Convert to CommentViewData
-                            val commentViewDataList = sortedComments.map { c ->
-                                CommentViewData(
-                                    id = c.commentIdentifier,
-                                    threadId = threadId,
-                                    authorUsername = c.authorUsername,
-                                    body = c.body,
-                                    likeCount = c.likeCount,
-                                    isLiked = c.isLiked,
-                                    createdDate = Date() // TODO: Parse c.creationTime string to Date
-                                )
-                            }
-
-                            CommentThreadViewData(threadId, commentViewDataList)
-                        }
-                    }.awaitAll()
-                }
-
-                // Filter out empty threads if needed, or keep them
-                val nonEmptyThreads = loadedThreads.filter { it.comments.isNotEmpty() }
-
-                // Sort threads by their first comment's date (using dummy date for now as parsing is TODO)
-                _commentThreads.value = nonEmptyThreads
-                // .sortedBy { it.comments.firstOrNull()?.createdDate } 
-
-            } catch (e: Exception) {
-                Log.e(TAG, "Error loading post details", e)
-                _alertMessage.value = "Failed to load post: ${e.localizedMessage}"
+                loadAllDataInternal()
             } finally {
                 _isLoading.value = false
             }
+        }
+    }
+
+    /**
+     * Pull-to-refresh: reloads the post details and comments from the backend.
+     * Uses a separate [isRefreshing] flag so the pull-to-refresh indicator is
+     * shown instead of the initial full-screen loading spinner.
+     */
+    fun refresh() {
+        if (_isRefreshing.value) return
+        _isRefreshing.value = true
+
+        viewModelScope.launch {
+            try {
+                loadAllDataInternal()
+            } finally {
+                _isRefreshing.value = false
+            }
+        }
+    }
+
+    private suspend fun loadAllDataInternal() {
+        try {
+            // These authenticated GETs need the session token so the backend can
+            // report whether the current user has liked the post / each comment.
+            val userSession = keychainHelper.load(UserSession::class.java, service, account)
+            if (userSession == null) {
+                Log.e(TAG, "No active session found — cannot load post details")
+                _alertMessage.value = "Not logged in."
+                return
+            }
+            val token = userSession.sessionToken
+
+            // 1. Fetch the main post details
+            val postResponse = api.getPostDetails(token, postIdentifier)
+            if (postResponse.isSuccessful) {
+                _postDetail.value = postResponse.body()
+            } else {
+                throw Exception("Failed to load post details")
+            }
+
+            // 2. Fetch the list of comment thread IDs for this post
+            val threadListResponse = api.getCommentsForPost(token, postIdentifier, 0)
+            val threadDtos = threadListResponse.body() ?: emptyList()
+            val threadIdentifiers = threadDtos.map { it.threadIdentifier }
+
+            // 3. Fetch all comments for *each* thread in parallel
+            val loadedThreads = coroutineScope {
+                threadIdentifiers.map { threadId ->
+                    async {
+                        val commentsResponse = api.getCommentsForThread(token, threadId, 0)
+                        val comments = commentsResponse.body() ?: emptyList()
+                        // Sort comments by date (oldest first)
+                        val sortedComments = comments.sortedBy { it.creationTime }
+
+                        // Convert to CommentViewData
+                        val commentViewDataList = sortedComments.map { c ->
+                            CommentViewData(
+                                id = c.commentIdentifier,
+                                threadId = threadId,
+                                authorUsername = c.authorUsername,
+                                body = c.body,
+                                likeCount = c.likeCount,
+                                isLiked = c.isLiked,
+                                createdDate = Date() // TODO: Parse c.creationTime string to Date
+                            )
+                        }
+
+                        CommentThreadViewData(threadId, commentViewDataList)
+                    }
+                }.awaitAll()
+            }
+
+            // Filter out empty threads if needed, or keep them
+            val nonEmptyThreads = loadedThreads.filter { it.comments.isNotEmpty() }
+
+            // Sort threads by their first comment's date (using dummy date for now as parsing is TODO)
+            _commentThreads.value = nonEmptyThreads
+            // .sortedBy { it.comments.firstOrNull()?.createdDate }
+
+        } catch (e: Exception) {
+            Log.e(TAG, "Error loading post details", e)
+            _alertMessage.value = "Failed to load post: ${e.localizedMessage}"
         }
     }
 

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/PostDetailViewModel.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/PostDetailViewModel.kt
@@ -102,7 +102,12 @@ class PostDetailViewModel(
      * shown instead of the initial full-screen loading spinner.
      */
     fun refresh() {
-        if (_isRefreshing.value) return
+        // Don't start a refresh while another load is already in flight (the
+        // initial loadAllData() from init or an action-triggered reload). Two
+        // concurrent loadAllDataInternal() calls both write _postDetail and
+        // _commentThreads, so an older response could otherwise overwrite the
+        // fresher refreshed data.
+        if (_isRefreshing.value || _isLoading.value) return
         _isRefreshing.value = true
 
         viewModelScope.launch {

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/FeedScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/FeedScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.*
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
@@ -54,6 +55,7 @@ fun FeedScreen(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ForYouFeed(
     navController: NavController,
@@ -65,6 +67,7 @@ fun ForYouFeed(
     )
     val posts by viewModel.feedPosts.collectAsState()
     val isLoadingNextPage by viewModel.isLoadingNextPage.collectAsState()
+    val isRefreshing by viewModel.isRefreshing.collectAsState()
 
     LaunchedEffect(Unit) {
         if (posts.isEmpty()) {
@@ -72,30 +75,38 @@ fun ForYouFeed(
         }
     }
 
-    LazyColumn(
-        contentPadding = PaddingValues(16.dp),
-        verticalArrangement = Arrangement.spacedBy(24.dp)
+    PullToRefreshBox(
+        isRefreshing = isRefreshing,
+        onRefresh = { viewModel.refreshFeed() },
+        modifier = Modifier.fillMaxSize()
     ) {
-        items(posts) { post ->
-            PostItem(post = post, navController = navController)
-            
-            if (post == posts.lastOrNull()) {
-                LaunchedEffect(Unit) {
-                    viewModel.fetchFeed()
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(24.dp)
+        ) {
+            items(posts) { post ->
+                PostItem(post = post, navController = navController)
+
+                if (post == posts.lastOrNull()) {
+                    LaunchedEffect(Unit) {
+                        viewModel.fetchFeed()
+                    }
                 }
             }
-        }
-        
-        if (isLoadingNextPage) {
-            item {
-                Box(modifier = Modifier.fillMaxWidth(), contentAlignment = androidx.compose.ui.Alignment.Center) {
-                    CircularProgressIndicator()
+
+            if (isLoadingNextPage) {
+                item {
+                    Box(modifier = Modifier.fillMaxWidth(), contentAlignment = androidx.compose.ui.Alignment.Center) {
+                        CircularProgressIndicator()
+                    }
                 }
             }
         }
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun FollowingFeed(
     navController: NavController,
@@ -107,6 +118,7 @@ fun FollowingFeed(
     )
     val posts by viewModel.followingPosts.collectAsState()
     val isLoadingNextPage by viewModel.isLoadingNextPage.collectAsState()
+    val isRefreshing by viewModel.isRefreshing.collectAsState()
 
     LaunchedEffect(Unit) {
         if (posts.isEmpty()) {
@@ -114,24 +126,31 @@ fun FollowingFeed(
         }
     }
 
-    LazyColumn(
-        contentPadding = PaddingValues(16.dp),
-        verticalArrangement = Arrangement.spacedBy(24.dp)
+    PullToRefreshBox(
+        isRefreshing = isRefreshing,
+        onRefresh = { viewModel.refreshFollowingFeed() },
+        modifier = Modifier.fillMaxSize()
     ) {
-        items(posts) { post ->
-            PostItem(post = post, navController = navController)
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(24.dp)
+        ) {
+            items(posts) { post ->
+                PostItem(post = post, navController = navController)
 
-            if (post == posts.lastOrNull()) {
-                LaunchedEffect(Unit) {
-                    viewModel.fetchFollowingFeed()
+                if (post == posts.lastOrNull()) {
+                    LaunchedEffect(Unit) {
+                        viewModel.fetchFollowingFeed()
+                    }
                 }
             }
-        }
 
-        if (isLoadingNextPage) {
-            item {
-                Box(modifier = Modifier.fillMaxWidth(), contentAlignment = androidx.compose.ui.Alignment.Center) {
-                    CircularProgressIndicator()
+            if (isLoadingNextPage) {
+                item {
+                    Box(modifier = Modifier.fillMaxWidth(), contentAlignment = androidx.compose.ui.Alignment.Center) {
+                        CircularProgressIndicator()
+                    }
                 }
             }
         }

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/HomeScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/HomeScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material3.*
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
@@ -43,6 +44,7 @@ fun HomeScreen(
         val userPosts by viewModel.userPosts.collectAsState()
         val searchedUsers by viewModel.searchedUsers.collectAsState()
         val searchText by viewModel.searchText.collectAsState()
+        val isRefreshing by viewModel.isRefreshing.collectAsState()
         
         // Trigger initial fetch
         LaunchedEffect(Unit) {
@@ -112,28 +114,35 @@ fun HomeScreen(
                 }
             } else {
                 // User Posts Grid
-                LazyVerticalGrid(
-                    columns = GridCells.Fixed(3),
-                    contentPadding = PaddingValues(2.dp),
-                    horizontalArrangement = Arrangement.spacedBy(2.dp),
-                    verticalArrangement = Arrangement.spacedBy(2.dp)
+                PullToRefreshBox(
+                    isRefreshing = isRefreshing,
+                    onRefresh = { viewModel.refreshMyPosts() },
+                    modifier = Modifier.fillMaxSize()
                 ) {
-                    items(userPosts) { post ->
-                        AsyncImage(
-                            model = post.imageUrl,
-                            contentDescription = "Post Image",
-                            modifier = Modifier
-                                .aspectRatio(1f)
-                                .clickable {
-                                    navController.navigate(Screen.PostDetail.createRoute(post.postIdentifier))
-                                },
-                            contentScale = ContentScale.Crop
-                        )
-                        
-                        // Infinite scroll trigger
-                        if (post == userPosts.lastOrNull()) {
-                            LaunchedEffect(Unit) {
-                                viewModel.fetchMyPosts()
+                    LazyVerticalGrid(
+                        columns = GridCells.Fixed(3),
+                        modifier = Modifier.fillMaxSize(),
+                        contentPadding = PaddingValues(2.dp),
+                        horizontalArrangement = Arrangement.spacedBy(2.dp),
+                        verticalArrangement = Arrangement.spacedBy(2.dp)
+                    ) {
+                        items(userPosts) { post ->
+                            AsyncImage(
+                                model = post.imageUrl,
+                                contentDescription = "Post Image",
+                                modifier = Modifier
+                                    .aspectRatio(1f)
+                                    .clickable {
+                                        navController.navigate(Screen.PostDetail.createRoute(post.postIdentifier))
+                                    },
+                                contentScale = ContentScale.Crop
+                            )
+
+                            // Infinite scroll trigger
+                            if (post == userPosts.lastOrNull()) {
+                                LaunchedEffect(Unit) {
+                                    viewModel.fetchMyPosts()
+                                }
                             }
                         }
                     }

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/PostDetailScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/PostDetailScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material.icons.filled.Flag
 import androidx.compose.material3.*
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -34,7 +35,7 @@ import androidx.navigation.compose.rememberNavController
 import com.example.positiveonlysocial.ui.preview.PreviewHelpers
 import com.example.positiveonlysocial.ui.theme.PositiveOnlySocialTheme
 
-@OptIn(ExperimentalFoundationApi::class)
+@OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun PostDetailScreen(
     navController: NavController,
@@ -50,6 +51,7 @@ fun PostDetailScreen(
         val postDetail by viewModel.postDetail.collectAsState()
         val commentThreads by viewModel.commentThreads.collectAsState()
         val isLoading by viewModel.isLoading.collectAsState()
+        val isRefreshing by viewModel.isRefreshing.collectAsState()
         val alertMessage by viewModel.alertMessage.collectAsState()
         
         // Local state for interactions
@@ -98,6 +100,11 @@ fun PostDetailScreen(
             )
         }
 
+        PullToRefreshBox(
+            isRefreshing = isRefreshing,
+            onRefresh = { viewModel.refresh() },
+            modifier = Modifier.fillMaxSize()
+        ) {
         LazyColumn(
             modifier = Modifier.fillMaxSize(),
             contentPadding = PaddingValues(bottom = 16.dp)
@@ -182,6 +189,7 @@ fun PostDetailScreen(
                     Text("Post not found.", modifier = Modifier.padding(16.dp))
                 }
             }
+        }
         }
     }
 }

--- a/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/FeedViewModelTest.kt
+++ b/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/FeedViewModelTest.kt
@@ -73,9 +73,62 @@ class FeedViewModelTest {
         viewModel.fetchFeed()
 
         assertTrue(viewModel.feedPosts.value.isEmpty())
-        
+
         // Try fetching again, should not call API because canLoadMore is false
         viewModel.fetchFeed()
         verify(api).getPostsInFeed("token123", 0) // Verified called once
+    }
+
+    @Test
+    fun `refreshFeed replaces feedPosts with fresh data`() = runTest {
+        val initialPosts = listOf(Post("1", "url1", "caption1", "user1", 0))
+        whenever(api.getPostsInFeed("token123", 0)).thenReturn(Response.success(initialPosts))
+
+        viewModel.fetchFeed()
+        assertEquals(initialPosts, viewModel.feedPosts.value)
+
+        val refreshedPosts = listOf(
+            Post("2", "url2", "caption2", "user2", 0),
+            Post("3", "url3", "caption3", "user3", 0)
+        )
+        whenever(api.getPostsInFeed("token123", 0)).thenReturn(Response.success(refreshedPosts))
+
+        viewModel.refreshFeed()
+
+        assertEquals(refreshedPosts, viewModel.feedPosts.value)
+        assertFalse(viewModel.isRefreshing.value)
+    }
+
+    @Test
+    fun `refreshFeed resets pagination after it was exhausted`() = runTest {
+        // Exhaust pagination so canLoadMore becomes false.
+        whenever(api.getPostsInFeed("token123", 0)).thenReturn(Response.success(emptyList()))
+        viewModel.fetchFeed()
+        assertTrue(viewModel.feedPosts.value.isEmpty())
+
+        // Backend now has posts again; refresh should pull them in.
+        val refreshedPosts = listOf(Post("1", "url1", "caption1", "user1", 0))
+        whenever(api.getPostsInFeed("token123", 0)).thenReturn(Response.success(refreshedPosts))
+        viewModel.refreshFeed()
+        assertEquals(refreshedPosts, viewModel.feedPosts.value)
+
+        // And the next page can be fetched again (page 1).
+        val nextPage = listOf(Post("2", "url2", "caption2", "user2", 0))
+        whenever(api.getPostsInFeed("token123", 1)).thenReturn(Response.success(nextPage))
+        viewModel.fetchFeed()
+        assertEquals(refreshedPosts + nextPage, viewModel.feedPosts.value)
+    }
+
+    @Test
+    fun `refreshFeed failure keeps existing posts`() = runTest {
+        val initialPosts = listOf(Post("1", "url1", "caption1", "user1", 0))
+        whenever(api.getPostsInFeed("token123", 0)).thenReturn(Response.success(initialPosts))
+        viewModel.fetchFeed()
+
+        whenever(api.getPostsInFeed("token123", 0)).thenReturn(Response.error(400, "error".toResponseBody()))
+        viewModel.refreshFeed()
+
+        assertEquals(initialPosts, viewModel.feedPosts.value)
+        assertFalse(viewModel.isRefreshing.value)
     }
 }

--- a/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/FollowingFeedViewModelTest.kt
+++ b/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/FollowingFeedViewModelTest.kt
@@ -64,4 +64,54 @@ class FollowingFeedViewModelTest {
         assertTrue(viewModel.followingPosts.value.isEmpty())
         assertFalse(viewModel.isLoadingNextPage.value)
     }
+
+    @Test
+    fun `refreshFollowingFeed replaces followingPosts with fresh data`() = runTest {
+        val initialPosts = listOf(Post("1", "url1", "caption1", "user1", 0))
+        whenever(api.getFollowedPosts("token123", 0)).thenReturn(Response.success(initialPosts))
+
+        viewModel.fetchFollowingFeed()
+        assertEquals(initialPosts, viewModel.followingPosts.value)
+
+        val refreshedPosts = listOf(
+            Post("2", "url2", "caption2", "user2", 0),
+            Post("3", "url3", "caption3", "user3", 0)
+        )
+        whenever(api.getFollowedPosts("token123", 0)).thenReturn(Response.success(refreshedPosts))
+
+        viewModel.refreshFollowingFeed()
+
+        assertEquals(refreshedPosts, viewModel.followingPosts.value)
+        assertFalse(viewModel.isRefreshing.value)
+    }
+
+    @Test
+    fun `refreshFollowingFeed resets pagination after it was exhausted`() = runTest {
+        whenever(api.getFollowedPosts("token123", 0)).thenReturn(Response.success(emptyList()))
+        viewModel.fetchFollowingFeed()
+        assertTrue(viewModel.followingPosts.value.isEmpty())
+
+        val refreshedPosts = listOf(Post("1", "url1", "caption1", "user1", 0))
+        whenever(api.getFollowedPosts("token123", 0)).thenReturn(Response.success(refreshedPosts))
+        viewModel.refreshFollowingFeed()
+        assertEquals(refreshedPosts, viewModel.followingPosts.value)
+
+        val nextPage = listOf(Post("2", "url2", "caption2", "user2", 0))
+        whenever(api.getFollowedPosts("token123", 1)).thenReturn(Response.success(nextPage))
+        viewModel.fetchFollowingFeed()
+        assertEquals(refreshedPosts + nextPage, viewModel.followingPosts.value)
+    }
+
+    @Test
+    fun `refreshFollowingFeed failure keeps existing posts`() = runTest {
+        val initialPosts = listOf(Post("1", "url1", "caption1", "user1", 0))
+        whenever(api.getFollowedPosts("token123", 0)).thenReturn(Response.success(initialPosts))
+        viewModel.fetchFollowingFeed()
+
+        whenever(api.getFollowedPosts("token123", 0)).thenReturn(Response.error(400, "error".toResponseBody()))
+        viewModel.refreshFollowingFeed()
+
+        assertEquals(initialPosts, viewModel.followingPosts.value)
+        assertFalse(viewModel.isRefreshing.value)
+    }
 }

--- a/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/HomeViewModelTest.kt
+++ b/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/HomeViewModelTest.kt
@@ -68,6 +68,57 @@ class HomeViewModelTest {
     }
 
     @Test
+    fun `refreshMyPosts replaces userPosts with fresh data`() = runTest {
+        val initialPosts = listOf(Post("1", "url1", "caption1", "testuser", 1))
+        whenever(api.getPostsForUser("token123", "testuser", 0)).thenReturn(Response.success(initialPosts))
+
+        viewModel.fetchMyPosts()
+        assertEquals(initialPosts, viewModel.userPosts.value)
+
+        val refreshedPosts = listOf(
+            Post("2", "url2", "caption2", "testuser", 1),
+            Post("3", "url3", "caption3", "testuser", 1)
+        )
+        whenever(api.getPostsForUser("token123", "testuser", 0)).thenReturn(Response.success(refreshedPosts))
+
+        viewModel.refreshMyPosts()
+
+        assertEquals(refreshedPosts, viewModel.userPosts.value)
+        assertFalse(viewModel.isRefreshing.value)
+    }
+
+    @Test
+    fun `refreshMyPosts resets pagination after it was exhausted`() = runTest {
+        whenever(api.getPostsForUser("token123", "testuser", 0)).thenReturn(Response.success(emptyList()))
+        viewModel.fetchMyPosts()
+        assertTrue(viewModel.userPosts.value.isEmpty())
+
+        val refreshedPosts = listOf(Post("1", "url1", "caption1", "testuser", 1))
+        whenever(api.getPostsForUser("token123", "testuser", 0)).thenReturn(Response.success(refreshedPosts))
+        viewModel.refreshMyPosts()
+        assertEquals(refreshedPosts, viewModel.userPosts.value)
+
+        val nextPage = listOf(Post("2", "url2", "caption2", "testuser", 1))
+        whenever(api.getPostsForUser("token123", "testuser", 1)).thenReturn(Response.success(nextPage))
+        viewModel.fetchMyPosts()
+        assertEquals(refreshedPosts + nextPage, viewModel.userPosts.value)
+    }
+
+    @Test
+    fun `refreshMyPosts failure keeps existing posts and sets errorMessage`() = runTest {
+        val initialPosts = listOf(Post("1", "url1", "caption1", "testuser", 1))
+        whenever(api.getPostsForUser("token123", "testuser", 0)).thenReturn(Response.success(initialPosts))
+        viewModel.fetchMyPosts()
+
+        whenever(api.getPostsForUser("token123", "testuser", 0)).thenReturn(Response.error(400, "error".toResponseBody()))
+        viewModel.refreshMyPosts()
+
+        assertEquals(initialPosts, viewModel.userPosts.value)
+        assertEquals("error", viewModel.errorMessage.value)
+        assertFalse(viewModel.isRefreshing.value)
+    }
+
+    @Test
     fun `performSearch with valid query updates searchedUsers`() = runTest {
         val mockUsers = listOf(User("user1", true))
         whenever(api.searchUsers("token123", "query")).thenReturn(Response.success(mockUsers))

--- a/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/PostDetailViewModelTest.kt
+++ b/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/PostDetailViewModelTest.kt
@@ -86,6 +86,17 @@ class PostDetailViewModelTest {
     }
 
     @Test
+    fun `refresh reloads post details and comments`() = runTest {
+        // loadAllData already ran once in init.
+        viewModel.refresh()
+
+        // getPostDetails is called again on refresh (once in init, once here).
+        verify(api, org.mockito.kotlin.times(2)).getPostDetails("token123", postIdentifier)
+        assertNotNull(viewModel.postDetail.value)
+        assertFalse(viewModel.isRefreshing.value)
+    }
+
+    @Test
     fun `commentOnPost success clears newCommentText and reloads`() = runTest {
         viewModel.updateNewCommentText("Nice post!")
         whenever(api.commentOnPost(any(), any(), any())).thenReturn(Response.success(mock()))

--- a/ios/Positive Only Social/Positive Only Social/FeedView.swift
+++ b/ios/Positive Only Social/Positive Only Social/FeedView.swift
@@ -74,9 +74,9 @@ struct FeedView: View {
                  // Fetch fresh data whenever the tab changes
                  switch newValue {
                  case .forYou:
-                     forYouViewModel.refreshFeed()
+                     Task { await forYouViewModel.refreshFeed() }
                  case .following:
-                     followingViewModel.refreshFeed()
+                     Task { await followingViewModel.refreshFeed() }
                  }
              }
         }
@@ -137,6 +137,10 @@ struct ForYouFeedView: View {
             }
             .padding(.top)
         }
+        .refreshable {
+            // Pull-to-refresh: reload the newest posts from the backend.
+            await viewModel.refreshFeed()
+        }
         .onAppear {
             if viewModel.feedPosts.isEmpty {
                 viewModel.fetchFeed()
@@ -196,6 +200,10 @@ struct FollowingFeedView: View {
                 }
             }
             .padding(.top)
+        }
+        .refreshable {
+            // Pull-to-refresh: reload the newest posts from the backend.
+            await viewModel.refreshFeed()
         }
         // Add .onAppear to trigger the *initial* fetch
         .onAppear {

--- a/ios/Positive Only Social/Positive Only Social/HomeView.swift
+++ b/ios/Positive Only Social/Positive Only Social/HomeView.swift
@@ -77,6 +77,10 @@ struct MyPostsGridView: View {
             .navigationTitle("Your Posts")
             // The searchable modifier provides the search bar UI and manages its state.
             .searchable(text: $viewModel.searchText, prompt: "Search for Users")
+            .refreshable {
+                // Pull-to-refresh: reload the newest posts from the backend.
+                await viewModel.refreshMyPosts()
+            }
             .onAppear {
                 // Fetch initial posts only if the list is empty
                 if viewModel.userPosts.isEmpty {

--- a/ios/Positive Only Social/Positive Only Social/PostDetailView.swift
+++ b/ios/Positive Only Social/Positive Only Social/PostDetailView.swift
@@ -115,6 +115,10 @@ struct PostDetailView: View {
         }
         .navigationTitle("Post")
         .navigationBarTitleDisplayMode(.inline)
+        .refreshable {
+            // Pull-to-refresh: reload the post details and comments from the backend.
+            await viewModel.refresh()
+        }
         // --- Modals and Sheets ---
         .sheet(isPresented: $viewModel.showReportSheetForPost) {
             ReportView { reason in

--- a/ios/Positive Only Social/Positive Only Social/viewmodels/FeedViewModel.swift
+++ b/ios/Positive Only Social/Positive Only Social/viewmodels/FeedViewModel.swift
@@ -32,40 +32,54 @@ final class FeedViewModel: ObservableObject {
     func fetchFeed() {
         guard !isLoadingNextPage && canLoadMore else { return }
         isLoadingNextPage = true
-        
-        Task {
-            do {
-                guard let userSession = try keychainHelper.load(UserSession.self, from: keychainService, account: account) else {
-                    NSLog("%@", "No active session found — cannot fetch feed")
-                    isLoadingNextPage = false
-                    return
-                }
 
-                let responseData = try await api.getPostsInFeed(sessionManagementToken: userSession.sessionToken, batch: currentPage)
-                let newPosts = try JSONDecoder().decode([Post].self, from: responseData)
-                
-                if newPosts.isEmpty {
-                    canLoadMore = false
-                } else {
-                    feedPosts.append(contentsOf: newPosts)
-                    currentPage += 1
-                }
-            } catch {
-                NSLog("%@", "Failed to fetch feed: \(error)")
-            }
-            isLoadingNextPage = false
+        Task {
+            await loadNextPage()
         }
     }
-    
-    func refreshFeed() {
-        // 1. Reset pagination state
+
+    /// Resets pagination and reloads the feed from the first page.
+    ///
+    /// This is `async` so SwiftUI's `.refreshable` keeps the pull-to-refresh
+    /// spinner visible until the fresh posts have actually been loaded.
+    func refreshFeed() async {
+        // Avoid stomping on an in-flight page load.
+        guard !isLoadingNextPage else { return }
+
         currentPage = 0
         canLoadMore = true
-        
-        // 2. Clear existing posts (optional: remove this if you want to keep data while loading)
-        feedPosts.removeAll()
-        
-        // 3. Fetch fresh data
-        fetchFeed()
+        isLoadingNextPage = true
+        await loadNextPage(replacingExisting: true)
+    }
+
+    /// Fetches the current page of posts. When `replacingExisting` is true the
+    /// freshly fetched posts replace the existing list (used by pull-to-refresh);
+    /// otherwise they are appended (used by infinite scrolling).
+    private func loadNextPage(replacingExisting: Bool = false) async {
+        do {
+            guard let userSession = try keychainHelper.load(UserSession.self, from: keychainService, account: account) else {
+                NSLog("%@", "No active session found — cannot fetch feed")
+                isLoadingNextPage = false
+                return
+            }
+
+            let responseData = try await api.getPostsInFeed(sessionManagementToken: userSession.sessionToken, batch: currentPage)
+            let newPosts = try JSONDecoder().decode([Post].self, from: responseData)
+
+            if newPosts.isEmpty {
+                if replacingExisting { feedPosts = [] }
+                canLoadMore = false
+            } else {
+                if replacingExisting {
+                    feedPosts = newPosts
+                } else {
+                    feedPosts.append(contentsOf: newPosts)
+                }
+                currentPage += 1
+            }
+        } catch {
+            NSLog("%@", "Failed to fetch feed: \(error)")
+        }
+        isLoadingNextPage = false
     }
 }

--- a/ios/Positive Only Social/Positive Only Social/viewmodels/FeedViewModel.swift
+++ b/ios/Positive Only Social/Positive Only Social/viewmodels/FeedViewModel.swift
@@ -34,28 +34,31 @@ final class FeedViewModel: ObservableObject {
         isLoadingNextPage = true
 
         Task {
-            await loadNextPage()
+            await loadPage(currentPage, replacingExisting: false)
         }
     }
 
-    /// Resets pagination and reloads the feed from the first page.
+    /// Reloads the feed from the first page.
     ///
     /// This is `async` so SwiftUI's `.refreshable` keeps the pull-to-refresh
-    /// spinner visible until the fresh posts have actually been loaded.
+    /// spinner visible until the fresh posts have actually been loaded. The
+    /// pagination cursor is only reset once the first page successfully loads,
+    /// so a failed refresh leaves the existing cursor (and posts) intact and
+    /// can't cause the next infinite-scroll fetch to duplicate page 0.
     func refreshFeed() async {
         // Avoid stomping on an in-flight page load.
         guard !isLoadingNextPage else { return }
 
-        currentPage = 0
-        canLoadMore = true
         isLoadingNextPage = true
-        await loadNextPage(replacingExisting: true)
+        await loadPage(0, replacingExisting: true)
     }
 
-    /// Fetches the current page of posts. When `replacingExisting` is true the
-    /// freshly fetched posts replace the existing list (used by pull-to-refresh);
-    /// otherwise they are appended (used by infinite scrolling).
-    private func loadNextPage(replacingExisting: Bool = false) async {
+    /// Fetches the given page of posts. When `replacingExisting` is true the
+    /// freshly fetched posts replace the existing list and the pagination cursor
+    /// is reset (used by pull-to-refresh); otherwise they are appended (used by
+    /// infinite scrolling). Pagination state is only mutated on a successful
+    /// response so failures don't corrupt the cursor.
+    private func loadPage(_ page: Int, replacingExisting: Bool) async {
         do {
             guard let userSession = try keychainHelper.load(UserSession.self, from: keychainService, account: account) else {
                 NSLog("%@", "No active session found — cannot fetch feed")
@@ -63,18 +66,17 @@ final class FeedViewModel: ObservableObject {
                 return
             }
 
-            let responseData = try await api.getPostsInFeed(sessionManagementToken: userSession.sessionToken, batch: currentPage)
+            let responseData = try await api.getPostsInFeed(sessionManagementToken: userSession.sessionToken, batch: page)
             let newPosts = try JSONDecoder().decode([Post].self, from: responseData)
 
-            if newPosts.isEmpty {
-                if replacingExisting { feedPosts = [] }
+            if replacingExisting {
+                feedPosts = newPosts
+                canLoadMore = !newPosts.isEmpty
+                currentPage = newPosts.isEmpty ? 0 : 1
+            } else if newPosts.isEmpty {
                 canLoadMore = false
             } else {
-                if replacingExisting {
-                    feedPosts = newPosts
-                } else {
-                    feedPosts.append(contentsOf: newPosts)
-                }
+                feedPosts.append(contentsOf: newPosts)
                 currentPage += 1
             }
         } catch {

--- a/ios/Positive Only Social/Positive Only Social/viewmodels/FollowingFeedViewModel.swift
+++ b/ios/Positive Only Social/Positive Only Social/viewmodels/FollowingFeedViewModel.swift
@@ -34,28 +34,31 @@ final class FollowingFeedViewModel: ObservableObject {
         isLoadingNextPage = true
 
         Task {
-            await loadNextPage()
+            await loadPage(currentPage, replacingExisting: false)
         }
     }
 
-    /// Resets pagination and reloads the following feed from the first page.
+    /// Reloads the following feed from the first page.
     ///
     /// This is `async` so SwiftUI's `.refreshable` keeps the pull-to-refresh
-    /// spinner visible until the fresh posts have actually been loaded.
+    /// spinner visible until the fresh posts have actually been loaded. The
+    /// pagination cursor is only reset once the first page successfully loads,
+    /// so a failed refresh leaves the existing cursor (and posts) intact and
+    /// can't cause the next infinite-scroll fetch to duplicate page 0.
     func refreshFeed() async {
         // Avoid stomping on an in-flight page load.
         guard !isLoadingNextPage else { return }
 
-        currentPage = 0
-        canLoadMore = true
         isLoadingNextPage = true
-        await loadNextPage(replacingExisting: true)
+        await loadPage(0, replacingExisting: true)
     }
 
-    /// Fetches the current page of posts. When `replacingExisting` is true the
-    /// freshly fetched posts replace the existing list (used by pull-to-refresh);
-    /// otherwise they are appended (used by infinite scrolling).
-    private func loadNextPage(replacingExisting: Bool = false) async {
+    /// Fetches the given page of posts. When `replacingExisting` is true the
+    /// freshly fetched posts replace the existing list and the pagination cursor
+    /// is reset (used by pull-to-refresh); otherwise they are appended (used by
+    /// infinite scrolling). Pagination state is only mutated on a successful
+    /// response so failures don't corrupt the cursor.
+    private func loadPage(_ page: Int, replacingExisting: Bool) async {
         do {
             guard let userSession = try keychainHelper.load(UserSession.self, from: keychainService, account: account) else {
                 NSLog("%@", "No active session — cannot fetch following feed")
@@ -64,19 +67,18 @@ final class FollowingFeedViewModel: ObservableObject {
             }
 
             // Call the API endpoint for followed users
-            let responseData = try await api.getPostsForFollowedUsers(sessionManagementToken: userSession.sessionToken, batch: currentPage)
+            let responseData = try await api.getPostsForFollowedUsers(sessionManagementToken: userSession.sessionToken, batch: page)
 
             let newPosts = try JSONDecoder().decode([Post].self, from: responseData)
 
-            if newPosts.isEmpty {
-                if replacingExisting { followingPosts = [] }
+            if replacingExisting {
+                followingPosts = newPosts
+                canLoadMore = !newPosts.isEmpty
+                currentPage = newPosts.isEmpty ? 0 : 1
+            } else if newPosts.isEmpty {
                 canLoadMore = false
             } else {
-                if replacingExisting {
-                    followingPosts = newPosts
-                } else {
-                    followingPosts.append(contentsOf: newPosts)
-                }
+                followingPosts.append(contentsOf: newPosts)
                 currentPage += 1
             }
         } catch {

--- a/ios/Positive Only Social/Positive Only Social/viewmodels/FollowingFeedViewModel.swift
+++ b/ios/Positive Only Social/Positive Only Social/viewmodels/FollowingFeedViewModel.swift
@@ -32,45 +32,56 @@ final class FollowingFeedViewModel: ObservableObject {
     func fetchFollowingFeed() {
         guard !isLoadingNextPage && canLoadMore else { return }
         isLoadingNextPage = true
-        
+
         Task {
-            do {
-                guard let userSession = try keychainHelper.load(UserSession.self, from: keychainService, account: account) else {
-                    NSLog("%@", "No active session — cannot fetch following feed")
-                    isLoadingNextPage = false
-                    return
-                }
-
-                // --- KEY CHANGE ---
-                // Call the API endpoint for followed users
-                let responseData = try await api.getPostsForFollowedUsers(sessionManagementToken: userSession.sessionToken, batch: currentPage)
-                // --- END KEY CHANGE ---
-
-                let newPosts = try JSONDecoder().decode([Post].self, from: responseData)
-                
-                if newPosts.isEmpty {
-                    canLoadMore = false
-                } else {
-                    // Add new posts to the followingPosts array
-                    followingPosts.append(contentsOf: newPosts)
-                    currentPage += 1
-                }
-            } catch {
-                NSLog("%@", "Failed to fetch following feed: \(error)")
-            }
-            isLoadingNextPage = false
+            await loadNextPage()
         }
     }
-    
-    func refreshFeed() {
-        // 1. Reset pagination state
+
+    /// Resets pagination and reloads the following feed from the first page.
+    ///
+    /// This is `async` so SwiftUI's `.refreshable` keeps the pull-to-refresh
+    /// spinner visible until the fresh posts have actually been loaded.
+    func refreshFeed() async {
+        // Avoid stomping on an in-flight page load.
+        guard !isLoadingNextPage else { return }
+
         currentPage = 0
         canLoadMore = true
-        
-        // 2. Clear existing posts (optional: remove this if you want to keep data while loading)
-        followingPosts.removeAll()
-        
-        // 3. Fetch fresh data
-        fetchFollowingFeed()
+        isLoadingNextPage = true
+        await loadNextPage(replacingExisting: true)
+    }
+
+    /// Fetches the current page of posts. When `replacingExisting` is true the
+    /// freshly fetched posts replace the existing list (used by pull-to-refresh);
+    /// otherwise they are appended (used by infinite scrolling).
+    private func loadNextPage(replacingExisting: Bool = false) async {
+        do {
+            guard let userSession = try keychainHelper.load(UserSession.self, from: keychainService, account: account) else {
+                NSLog("%@", "No active session — cannot fetch following feed")
+                isLoadingNextPage = false
+                return
+            }
+
+            // Call the API endpoint for followed users
+            let responseData = try await api.getPostsForFollowedUsers(sessionManagementToken: userSession.sessionToken, batch: currentPage)
+
+            let newPosts = try JSONDecoder().decode([Post].self, from: responseData)
+
+            if newPosts.isEmpty {
+                if replacingExisting { followingPosts = [] }
+                canLoadMore = false
+            } else {
+                if replacingExisting {
+                    followingPosts = newPosts
+                } else {
+                    followingPosts.append(contentsOf: newPosts)
+                }
+                currentPage += 1
+            }
+        } catch {
+            NSLog("%@", "Failed to fetch following feed: \(error)")
+        }
+        isLoadingNextPage = false
     }
 }

--- a/ios/Positive Only Social/Positive Only Social/viewmodels/HomeViewModel.swift
+++ b/ios/Positive Only Social/Positive Only Social/viewmodels/HomeViewModel.swift
@@ -59,28 +59,31 @@ final class HomeViewModel: ObservableObject {
         isLoadingNextPage = true
 
         Task {
-            await loadNextPage()
+            await loadPage(currentPage, replacingExisting: false)
         }
     }
 
-    /// Resets pagination and reloads the user's posts from the first page.
+    /// Reloads the user's posts from the first page.
     ///
     /// This is `async` so SwiftUI's `.refreshable` keeps the pull-to-refresh
-    /// spinner visible until the fresh posts have actually been loaded.
+    /// spinner visible until the fresh posts have actually been loaded. The
+    /// pagination cursor is only reset once the first page successfully loads,
+    /// so a failed refresh leaves the existing cursor (and posts) intact and
+    /// can't cause the next infinite-scroll fetch to duplicate page 0.
     func refreshMyPosts() async {
         // Avoid stomping on an in-flight page load.
         guard !isLoadingNextPage else { return }
 
-        currentPage = 0
-        canLoadMorePosts = true
         isLoadingNextPage = true
-        await loadNextPage(replacingExisting: true)
+        await loadPage(0, replacingExisting: true)
     }
 
-    /// Fetches the current page of the user's posts. When `replacingExisting`
-    /// is true the freshly fetched posts replace the existing list (used by
-    /// pull-to-refresh); otherwise they are appended (used by infinite scrolling).
-    private func loadNextPage(replacingExisting: Bool = false) async {
+    /// Fetches the given page of the user's posts. When `replacingExisting` is
+    /// true the freshly fetched posts replace the existing list and the
+    /// pagination cursor is reset (used by pull-to-refresh); otherwise they are
+    /// appended (used by infinite scrolling). Pagination state is only mutated
+    /// on a successful response so failures don't corrupt the cursor.
+    private func loadPage(_ page: Int, replacingExisting: Bool) async {
         do {
             guard let user = try keychainHelper.load(UserSession.self, from: keychainService, account: account) else {
                 NSLog("%@", "No active session found — cannot fetch posts")
@@ -89,18 +92,17 @@ final class HomeViewModel: ObservableObject {
             }
 
             // Call the API
-            let newPosts = try await fetchPosts(for: user.username, token: user.sessionToken, page: currentPage)
+            let newPosts = try await fetchPosts(for: user.username, token: user.sessionToken, page: page)
 
-            if newPosts.isEmpty {
+            if replacingExisting {
+                self.userPosts = newPosts
+                self.canLoadMorePosts = !newPosts.isEmpty
+                self.currentPage = newPosts.isEmpty ? 0 : 1
+            } else if newPosts.isEmpty {
                 // No more posts to load
-                if replacingExisting { self.userPosts = [] }
                 self.canLoadMorePosts = false
             } else {
-                if replacingExisting {
-                    self.userPosts = newPosts
-                } else {
-                    self.userPosts.append(contentsOf: newPosts)
-                }
+                self.userPosts.append(contentsOf: newPosts)
                 self.currentPage += 1
             }
 

--- a/ios/Positive Only Social/Positive Only Social/viewmodels/HomeViewModel.swift
+++ b/ios/Positive Only Social/Positive Only Social/viewmodels/HomeViewModel.swift
@@ -55,35 +55,61 @@ final class HomeViewModel: ObservableObject {
     func fetchMyPosts() {
         // Prevent multiple fetches at the same time or fetching beyond the end
         guard !isLoadingNextPage && canLoadMorePosts else { return }
-        
+
         isLoadingNextPage = true
-        
+
         Task {
-            do {
-                guard let user = try keychainHelper.load(UserSession.self, from: keychainService, account: account) else {
-                    NSLog("%@", "No active session found — cannot fetch posts")
-                    isLoadingNextPage = false
-                    return
-                }
+            await loadNextPage()
+        }
+    }
 
-                // Call the API
-                let newPosts = try await fetchPosts(for: user.username, token: user.sessionToken, page: currentPage)
+    /// Resets pagination and reloads the user's posts from the first page.
+    ///
+    /// This is `async` so SwiftUI's `.refreshable` keeps the pull-to-refresh
+    /// spinner visible until the fresh posts have actually been loaded.
+    func refreshMyPosts() async {
+        // Avoid stomping on an in-flight page load.
+        guard !isLoadingNextPage else { return }
 
-                if newPosts.isEmpty {
-                    // No more posts to load
-                    self.canLoadMorePosts = false
-                } else {
-                    self.userPosts.append(contentsOf: newPosts)
-                    self.currentPage += 1
-                }
-                
-            } catch {
-                self.errorMessage = error.localizedDescription
-                NSLog("%@", "Error fetching my posts: \(error)")
+        currentPage = 0
+        canLoadMorePosts = true
+        isLoadingNextPage = true
+        await loadNextPage(replacingExisting: true)
+    }
+
+    /// Fetches the current page of the user's posts. When `replacingExisting`
+    /// is true the freshly fetched posts replace the existing list (used by
+    /// pull-to-refresh); otherwise they are appended (used by infinite scrolling).
+    private func loadNextPage(replacingExisting: Bool = false) async {
+        do {
+            guard let user = try keychainHelper.load(UserSession.self, from: keychainService, account: account) else {
+                NSLog("%@", "No active session found — cannot fetch posts")
+                isLoadingNextPage = false
+                return
             }
 
-            self.isLoadingNextPage = false
+            // Call the API
+            let newPosts = try await fetchPosts(for: user.username, token: user.sessionToken, page: currentPage)
+
+            if newPosts.isEmpty {
+                // No more posts to load
+                if replacingExisting { self.userPosts = [] }
+                self.canLoadMorePosts = false
+            } else {
+                if replacingExisting {
+                    self.userPosts = newPosts
+                } else {
+                    self.userPosts.append(contentsOf: newPosts)
+                }
+                self.currentPage += 1
+            }
+
+        } catch {
+            self.errorMessage = error.localizedDescription
+            NSLog("%@", "Error fetching my posts: \(error)")
         }
+
+        self.isLoadingNextPage = false
     }
 
     // MARK: - Private Helpers

--- a/ios/Positive Only Social/Positive Only Social/viewmodels/PostDetailViewModel.swift
+++ b/ios/Positive Only Social/Positive Only Social/viewmodels/PostDetailViewModel.swift
@@ -70,6 +70,11 @@ final class PostDetailViewModel: ObservableObject {
     /// Pull-to-refresh entry point. Awaitable so SwiftUI's `.refreshable`
     /// keeps the spinner visible until the post and comments have reloaded.
     func refresh() async {
+        // Don't start a refresh while another load is already in flight (the
+        // initial `loadAllData()` or an action-triggered reload). Two concurrent
+        // loads both write `postDetail`/`commentThreads`, so an older response
+        // could otherwise overwrite the fresher refreshed data.
+        guard !isLoading else { return }
         isLoading = true
         await performLoad()
     }

--- a/ios/Positive Only Social/Positive Only Social/viewmodels/PostDetailViewModel.swift
+++ b/ios/Positive Only Social/Positive Only Social/viewmodels/PostDetailViewModel.swift
@@ -61,8 +61,20 @@ final class PostDetailViewModel: ObservableObject {
     
     func loadAllData() {
         isLoading = true
-        
+
         Task {
+            await performLoad()
+        }
+    }
+
+    /// Pull-to-refresh entry point. Awaitable so SwiftUI's `.refreshable`
+    /// keeps the spinner visible until the post and comments have reloaded.
+    func refresh() async {
+        isLoading = true
+        await performLoad()
+    }
+
+    private func performLoad() async {
             do {
                 // These authenticated GETs need the session token so the backend can
                 // report whether the current user has liked the post / each comment.
@@ -137,11 +149,10 @@ final class PostDetailViewModel: ObservableObject {
                 NSLog("%@", "Error loading post details: \(error)")
                 self.alertMessage = "Failed to load post: \(error.localizedDescription)"
             }
-            
+
             self.isLoading = false
-        }
     }
-    
+
     // MARK: - User Actions
     
     func likePost() {

--- a/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_FeedViewModel.swift
+++ b/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_FeedViewModel.swift
@@ -225,5 +225,43 @@ struct Positive_Only_SocialTests_FeedViewModel {
         await yield()
         #expect(sut.feedPosts.count == 3)
     }
+
+    @Test func testRefreshFeed_Failure_PreservesPaginationCursor() async throws {
+        stubAPI.pageSize = 2
+        let account = "refreshFeedFailurePreservesCursor"
+        let sut = FeedViewModel(api: stubAPI, keychainHelper: keychainHelper, account: account)
+
+        let userAToken = try await registerUserAndGetToken(username: "userA")
+        let userBToken = try await registerUserAndGetToken(username: "userB")
+        let userSession = UserSession(sessionToken: userAToken, username: "userA", userId: "1", isIdentityVerified: false)
+        try keychainHelper.save(userSession, for: AppConstants.keychainService, account: account)
+
+        // Given: 3 posts exist and we've loaded the first page (cursor at page 1)
+        _ = try await stubAPI.makePost(sessionManagementToken: userBToken, imageURL: "image.url/1", caption: "Post 1")
+        _ = try await stubAPI.makePost(sessionManagementToken: userBToken, imageURL: "image.url/2", caption: "Post 2")
+        _ = try await stubAPI.makePost(sessionManagementToken: userBToken, imageURL: "image.url/3", caption: "Post 3")
+        sut.fetchFeed()
+        await yield()
+        #expect(sut.feedPosts.count == 2)
+        #expect(sut.feedPosts.first?.imageUrl == "image.url/3")
+
+        // When: A refresh fails (session is unavailable for the duration of the refresh)
+        try keychainHelper.delete(service: AppConstants.keychainService, account: account)
+        await sut.refreshFeed()
+        try keychainHelper.save(userSession, for: AppConstants.keychainService, account: account)
+
+        // Then: The existing posts are untouched and the loading flag is reset
+        #expect(sut.isLoadingNextPage == false)
+        #expect(sut.feedPosts.count == 2)
+
+        // And: The cursor was NOT reset, so the next fetch loads page 1 (not page 0
+        // again), appending the third post without duplicating the first page.
+        sut.fetchFeed()
+        await yield()
+        #expect(sut.feedPosts.count == 3)
+        #expect(sut.feedPosts.last?.imageUrl == "image.url/1")
+        // Page 0's posts appear exactly once (no duplication).
+        #expect(sut.feedPosts.filter { $0.imageUrl == "image.url/3" }.count == 1)
+    }
 }
 

--- a/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_FeedViewModel.swift
+++ b/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_FeedViewModel.swift
@@ -161,5 +161,69 @@ struct Positive_Only_SocialTests_FeedViewModel {
         #expect(sut.feedPosts.count == 3)
         #expect(stubAPI.getPostsInFeedCallCount == 3)
     }
+
+    @Test func testRefreshFeed_PullsNewestPostsAndReplacesList() async throws {
+        stubAPI.pageSize = 2
+        let sut = FeedViewModel(api: stubAPI, keychainHelper: keychainHelper, account: "refreshFeedPullsNewest")
+
+        // Given: A logged-in user and another user with one post
+        let userAToken = try await registerUserAndGetToken(username: "userA")
+        let userBToken = try await registerUserAndGetToken(username: "userB")
+        let userSession = UserSession(sessionToken: userAToken, username: "userA", userId: "1", isIdentityVerified: false)
+        try keychainHelper.save(userSession, for: AppConstants.keychainService, account: "refreshFeedPullsNewest")
+        _ = try await stubAPI.makePost(sessionManagementToken: userBToken, imageURL: "image.url/1", caption: "Post 1")
+
+        // And: The feed has been loaded once
+        sut.fetchFeed()
+        await yield()
+        #expect(sut.feedPosts.count == 1)
+        #expect(stubAPI.getPostsInFeedCallCount == 1)
+
+        // When: New posts appear on the backend and we pull-to-refresh
+        _ = try await stubAPI.makePost(sessionManagementToken: userBToken, imageURL: "image.url/2", caption: "Post 2")
+        _ = try await stubAPI.makePost(sessionManagementToken: userBToken, imageURL: "image.url/3", caption: "Post 3")
+        await sut.refreshFeed()
+
+        // Then: The list is replaced with the freshest first page (newest first)
+        #expect(sut.isLoadingNextPage == false)
+        #expect(sut.feedPosts.count == 2)
+        #expect(sut.feedPosts.first?.imageUrl == "image.url/3")
+        #expect(sut.feedPosts.last?.imageUrl == "image.url/2")
+        #expect(stubAPI.getPostsInFeedCallCount == 2)
+    }
+
+    @Test func testRefreshFeed_ResetsPaginationAfterEndReached() async throws {
+        stubAPI.pageSize = 2
+        let sut = FeedViewModel(api: stubAPI, keychainHelper: keychainHelper, account: "refreshFeedResetsPagination")
+
+        let userAToken = try await registerUserAndGetToken(username: "userA")
+        let userBToken = try await registerUserAndGetToken(username: "userB")
+        let userSession = UserSession(sessionToken: userAToken, username: "userA", userId: "1", isIdentityVerified: false)
+        try keychainHelper.save(userSession, for: AppConstants.keychainService, account: "refreshFeedResetsPagination")
+        _ = try await stubAPI.makePost(sessionManagementToken: userBToken, imageURL: "image.url/1", caption: "Post 1")
+
+        // Given: We have paged to the end (canLoadMore becomes false)
+        sut.fetchFeed()
+        await yield()
+        sut.fetchFeed() // empty page 1 -> canLoadMore = false
+        await yield()
+        #expect(sut.feedPosts.count == 1)
+        #expect(stubAPI.getPostsInFeedCallCount == 2)
+
+        // And: Two more posts now exist on the backend (3 total = 2 pages)
+        _ = try await stubAPI.makePost(sessionManagementToken: userBToken, imageURL: "image.url/2", caption: "Post 2")
+        _ = try await stubAPI.makePost(sessionManagementToken: userBToken, imageURL: "image.url/3", caption: "Post 3")
+
+        // When: We refresh
+        await sut.refreshFeed()
+
+        // Then: The freshest first page (2 newest) replaces the list...
+        #expect(sut.feedPosts.count == 2)
+
+        // ...and pagination is reset, so a subsequent fetch loads page 1 again.
+        sut.fetchFeed()
+        await yield()
+        #expect(sut.feedPosts.count == 3)
+    }
 }
 

--- a/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_FollowingFeedViewModel.swift
+++ b/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_FollowingFeedViewModel.swift
@@ -221,6 +221,44 @@ struct Positive_Only_SocialTests_FollowingFeedViewModel {
         await yield()
         #expect(sut.followingPosts.count == 3)
     }
+
+    @Test func testRefreshFeed_Failure_PreservesPaginationCursor() async throws {
+        stubAPI.pageSize = 2
+        let account = "refreshFollowingFailurePreservesCursor"
+        let sut = FollowingFeedViewModel(api: stubAPI, keychainHelper: keychainHelper, account: account)
+
+        let userAToken = try await registerUserAndGetToken(username: "userA")
+        let userBToken = try await registerUserAndGetToken(username: "userB")
+        let userSession = UserSession(sessionToken: userAToken, username: "userA", userId: "1", isIdentityVerified: false)
+        try keychainHelper.save(userSession, for: AppConstants.keychainService, account: account)
+        _ = try await stubAPI.followUser(sessionManagementToken: userAToken, username: "userB")
+
+        // Given: 3 posts exist and we've loaded the first page (cursor at page 1)
+        _ = try await stubAPI.makePost(sessionManagementToken: userBToken, imageURL: "image.url/1", caption: "Post 1")
+        _ = try await stubAPI.makePost(sessionManagementToken: userBToken, imageURL: "image.url/2", caption: "Post 2")
+        _ = try await stubAPI.makePost(sessionManagementToken: userBToken, imageURL: "image.url/3", caption: "Post 3")
+        sut.fetchFollowingFeed()
+        await yield()
+        #expect(sut.followingPosts.count == 2)
+        #expect(sut.followingPosts.first?.imageUrl == "image.url/3")
+
+        // When: A refresh fails (session is unavailable for the duration of the refresh)
+        try keychainHelper.delete(service: AppConstants.keychainService, account: account)
+        await sut.refreshFeed()
+        try keychainHelper.save(userSession, for: AppConstants.keychainService, account: account)
+
+        // Then: The existing posts are untouched and the loading flag is reset
+        #expect(sut.isLoadingNextPage == false)
+        #expect(sut.followingPosts.count == 2)
+
+        // And: The cursor was NOT reset, so the next fetch loads page 1 (not page 0
+        // again), appending the third post without duplicating the first page.
+        sut.fetchFollowingFeed()
+        await yield()
+        #expect(sut.followingPosts.count == 3)
+        #expect(sut.followingPosts.last?.imageUrl == "image.url/1")
+        #expect(sut.followingPosts.filter { $0.imageUrl == "image.url/3" }.count == 1)
+    }
 }
 
 

--- a/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_FollowingFeedViewModel.swift
+++ b/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_FollowingFeedViewModel.swift
@@ -155,6 +155,72 @@ struct Positive_Only_SocialTests_FollowingFeedViewModel {
         #expect(sut.followingPosts.count == 3)
         #expect(stubAPI.getPostsForFollowedUsersCallCount == 3)
     }
+
+    @Test func testRefreshFeed_PullsNewestPostsAndReplacesList() async throws {
+        stubAPI.pageSize = 2
+        let sut = FollowingFeedViewModel(api: stubAPI, keychainHelper: keychainHelper, account: "refreshFollowingPullsNewest")
+
+        // Given: A logged-in user following userB, who has one post
+        let userAToken = try await registerUserAndGetToken(username: "userA")
+        let userBToken = try await registerUserAndGetToken(username: "userB")
+        let userSession = UserSession(sessionToken: userAToken, username: "userA", userId: "1", isIdentityVerified: false)
+        try keychainHelper.save(userSession, for: AppConstants.keychainService, account: "refreshFollowingPullsNewest")
+        _ = try await stubAPI.followUser(sessionManagementToken: userAToken, username: "userB")
+        _ = try await stubAPI.makePost(sessionManagementToken: userBToken, imageURL: "image.url/1", caption: "Post 1")
+
+        // And: The feed has been loaded once
+        sut.fetchFollowingFeed()
+        await yield()
+        #expect(sut.followingPosts.count == 1)
+        #expect(stubAPI.getPostsForFollowedUsersCallCount == 1)
+
+        // When: New posts appear and we pull-to-refresh
+        _ = try await stubAPI.makePost(sessionManagementToken: userBToken, imageURL: "image.url/2", caption: "Post 2")
+        _ = try await stubAPI.makePost(sessionManagementToken: userBToken, imageURL: "image.url/3", caption: "Post 3")
+        await sut.refreshFeed()
+
+        // Then: The list is replaced with the freshest first page (newest first)
+        #expect(sut.isLoadingNextPage == false)
+        #expect(sut.followingPosts.count == 2)
+        #expect(sut.followingPosts.first?.imageUrl == "image.url/3")
+        #expect(sut.followingPosts.last?.imageUrl == "image.url/2")
+        #expect(stubAPI.getPostsForFollowedUsersCallCount == 2)
+    }
+
+    @Test func testRefreshFeed_ResetsPaginationAfterEndReached() async throws {
+        stubAPI.pageSize = 2
+        let sut = FollowingFeedViewModel(api: stubAPI, keychainHelper: keychainHelper, account: "refreshFollowingResetsPagination")
+
+        let userAToken = try await registerUserAndGetToken(username: "userA")
+        let userBToken = try await registerUserAndGetToken(username: "userB")
+        let userSession = UserSession(sessionToken: userAToken, username: "userA", userId: "1", isIdentityVerified: false)
+        try keychainHelper.save(userSession, for: AppConstants.keychainService, account: "refreshFollowingResetsPagination")
+        _ = try await stubAPI.followUser(sessionManagementToken: userAToken, username: "userB")
+        _ = try await stubAPI.makePost(sessionManagementToken: userBToken, imageURL: "image.url/1", caption: "Post 1")
+
+        // Given: We have paged to the end (canLoadMore becomes false)
+        sut.fetchFollowingFeed()
+        await yield()
+        sut.fetchFollowingFeed() // empty page 1 -> canLoadMore = false
+        await yield()
+        #expect(sut.followingPosts.count == 1)
+        #expect(stubAPI.getPostsForFollowedUsersCallCount == 2)
+
+        // And: Two more posts now exist on the backend (3 total = 2 pages)
+        _ = try await stubAPI.makePost(sessionManagementToken: userBToken, imageURL: "image.url/2", caption: "Post 2")
+        _ = try await stubAPI.makePost(sessionManagementToken: userBToken, imageURL: "image.url/3", caption: "Post 3")
+
+        // When: We refresh
+        await sut.refreshFeed()
+
+        // Then: The freshest first page replaces the list...
+        #expect(sut.followingPosts.count == 2)
+
+        // ...and pagination is reset, so a subsequent fetch loads page 1 again.
+        sut.fetchFollowingFeed()
+        await yield()
+        #expect(sut.followingPosts.count == 3)
+    }
 }
 
 

--- a/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_HomeViewModel.swift
+++ b/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_HomeViewModel.swift
@@ -110,6 +110,70 @@ struct Positive_Only_SocialTests_HomeViewModel {
         #expect(sut.userPosts.isEmpty == true)
     }
 
+    @Test func testRefreshMyPosts_PullsNewestPostsAndReplacesList() async throws {
+        stubAPI.pageSize = 2
+
+        try await setupLoggedInUser(username: "refreshMyPostsPullsNewest")
+        let sut = HomeViewModel(api: stubAPI, keychainHelper: keychainHelper, account: "refreshMyPostsPullsNewest_account")
+
+        let session = try keychainHelper.load(UserSession.self, from: AppConstants.keychainService, account: "refreshMyPostsPullsNewest_account")
+        let token = session!.sessionToken
+
+        // Given: One post exists and the grid has loaded once
+        _ = try await stubAPI.makePost(sessionManagementToken: token, imageURL: "my.image/1", caption: "Post 1")
+        sut.fetchMyPosts()
+        await yield()
+        #expect(sut.userPosts.count == 1)
+        #expect(stubAPI.getPostsForUserCallCount == 1)
+
+        // When: Two more posts are made and we pull-to-refresh
+        _ = try await stubAPI.makePost(sessionManagementToken: token, imageURL: "my.image/2", caption: "Post 2")
+        _ = try await stubAPI.makePost(sessionManagementToken: token, imageURL: "my.image/3", caption: "Post 3")
+        await sut.refreshMyPosts()
+
+        // Then: The list is replaced with the freshest first page (newest first)
+        #expect(sut.isLoadingNextPage == false)
+        #expect(sut.userPosts.count == 2)
+        #expect(sut.userPosts.first?.imageUrl == "my.image/3")
+        #expect(sut.userPosts.last?.imageUrl == "my.image/2")
+        #expect(stubAPI.getPostsForUserCallCount == 2)
+    }
+
+    @Test func testRefreshMyPosts_ResetsPaginationAfterEndReached() async throws {
+        stubAPI.pageSize = 2
+
+        try await setupLoggedInUser(username: "refreshMyPostsResetsPagination")
+        let sut = HomeViewModel(api: stubAPI, keychainHelper: keychainHelper, account: "refreshMyPostsResetsPagination_account")
+
+        let session = try keychainHelper.load(UserSession.self, from: AppConstants.keychainService, account: "refreshMyPostsResetsPagination_account")
+        let token = session!.sessionToken
+
+        _ = try await stubAPI.makePost(sessionManagementToken: token, imageURL: "my.image/1", caption: "Post 1")
+
+        // Given: We have paged to the end (canLoadMorePosts becomes false)
+        sut.fetchMyPosts()
+        await yield()
+        sut.fetchMyPosts() // empty page 1 -> canLoadMorePosts = false
+        await yield()
+        #expect(sut.userPosts.count == 1)
+        #expect(stubAPI.getPostsForUserCallCount == 2)
+
+        // And: Two more posts now exist on the backend (3 total = 2 pages)
+        _ = try await stubAPI.makePost(sessionManagementToken: token, imageURL: "my.image/2", caption: "Post 2")
+        _ = try await stubAPI.makePost(sessionManagementToken: token, imageURL: "my.image/3", caption: "Post 3")
+
+        // When: We refresh
+        await sut.refreshMyPosts()
+
+        // Then: The freshest first page replaces the list...
+        #expect(sut.userPosts.count == 2)
+
+        // ...and pagination is reset, so a subsequent fetch loads page 1 again.
+        sut.fetchMyPosts()
+        await yield()
+        #expect(sut.userPosts.count == 3)
+    }
+
     // --- Search Tests ---
 
     @Test func testSearch_Debouncer_Success() async throws {

--- a/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_HomeViewModel.swift
+++ b/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_HomeViewModel.swift
@@ -174,6 +174,43 @@ struct Positive_Only_SocialTests_HomeViewModel {
         #expect(sut.userPosts.count == 3)
     }
 
+    @Test func testRefreshMyPosts_Failure_PreservesPaginationCursor() async throws {
+        stubAPI.pageSize = 2
+        let account = "refreshMyPostsFailurePreservesCursor_account"
+        try await setupLoggedInUser(username: "refreshMyPostsFailurePreservesCursor")
+        let sut = HomeViewModel(api: stubAPI, keychainHelper: keychainHelper, account: account)
+
+        let session = try keychainHelper.load(UserSession.self, from: AppConstants.keychainService, account: account)
+        let userSession = session!
+        let token = userSession.sessionToken
+
+        // Given: 3 posts exist and we've loaded the first page (cursor at page 1)
+        _ = try await stubAPI.makePost(sessionManagementToken: token, imageURL: "my.image/1", caption: "Post 1")
+        _ = try await stubAPI.makePost(sessionManagementToken: token, imageURL: "my.image/2", caption: "Post 2")
+        _ = try await stubAPI.makePost(sessionManagementToken: token, imageURL: "my.image/3", caption: "Post 3")
+        sut.fetchMyPosts()
+        await yield()
+        #expect(sut.userPosts.count == 2)
+        #expect(sut.userPosts.first?.imageUrl == "my.image/3")
+
+        // When: A refresh fails (session is unavailable for the duration of the refresh)
+        try keychainHelper.delete(service: AppConstants.keychainService, account: account)
+        await sut.refreshMyPosts()
+        try keychainHelper.save(userSession, for: AppConstants.keychainService, account: account)
+
+        // Then: The existing posts are untouched and the loading flag is reset
+        #expect(sut.isLoadingNextPage == false)
+        #expect(sut.userPosts.count == 2)
+
+        // And: The cursor was NOT reset, so the next fetch loads page 1 (not page 0
+        // again), appending the third post without duplicating the first page.
+        sut.fetchMyPosts()
+        await yield()
+        #expect(sut.userPosts.count == 3)
+        #expect(sut.userPosts.last?.imageUrl == "my.image/1")
+        #expect(sut.userPosts.filter { $0.imageUrl == "my.image/3" }.count == 1)
+    }
+
     // --- Search Tests ---
 
     @Test func testSearch_Debouncer_Success() async throws {

--- a/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_PostDetailViewModel.swift
+++ b/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_PostDetailViewModel.swift
@@ -142,6 +142,23 @@ struct Positive_Only_SocialTests_PostDetailViewModel {
         #expect(secondComment?.authorUsername == "postOwner")
     }
 
+    @Test func testRefresh_PullsLatestCommentsFromBackend() async throws {
+        // Given: A fully loaded SUT with one comment thread
+        let (sut, postID, _, _) = try await setupTestEnvironment(account: "refresh_account")
+        #expect(sut.commentThreads.count == 1, "Pre-condition: Should have 1 thread")
+
+        // And: Another user adds a brand new comment thread on the backend
+        let otherCommenterToken = try await registerUserAndGetToken(username: "commenter2")
+        _ = try await commentOnPostAndGetIDs(token: otherCommenterToken, postID: postID, body: "Fresh comment")
+
+        // When: We pull-to-refresh
+        await sut.refresh()
+
+        // Then: The newest data is pulled in and loading is finished
+        #expect(sut.isLoading == false)
+        #expect(sut.commentThreads.count == 2, "Refreshed feed should include the new thread")
+    }
+
     // --- Post Action Tests ---
 
     @Test func testLikePost_OptimisticUpdate_IncrementsCount() async throws {

--- a/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_PostDetailViewModel.swift
+++ b/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_PostDetailViewModel.swift
@@ -159,6 +159,26 @@ struct Positive_Only_SocialTests_PostDetailViewModel {
         #expect(sut.commentThreads.count == 2, "Refreshed feed should include the new thread")
     }
 
+    @Test func testRefresh_WhileAlreadyLoading_DoesNotReload() async throws {
+        // Given: A fully loaded SUT with one comment thread
+        let (sut, postID, _, _) = try await setupTestEnvironment(account: "refreshWhileLoading_account")
+        #expect(sut.commentThreads.count == 1, "Pre-condition: Should have 1 thread")
+
+        // And: A new comment thread appears on the backend
+        let otherCommenterToken = try await registerUserAndGetToken(username: "commenter2")
+        _ = try await commentOnPostAndGetIDs(token: otherCommenterToken, postID: postID, body: "Fresh comment")
+
+        // And: A load is already in flight
+        sut.isLoading = true
+
+        // When: We pull-to-refresh
+        await sut.refresh()
+
+        // Then: The refresh is skipped (so a stale in-flight load can't be
+        // raced), and the new thread is NOT pulled in.
+        #expect(sut.commentThreads.count == 1, "Refresh should be a no-op while a load is already in flight")
+    }
+
     // --- Post Action Tests ---
 
     @Test func testLikePost_OptimisticUpdate_IncrementsCount() async throws {


### PR DESCRIPTION
## Summary

Adds pull-to-refresh across the app's main scrolling screens on **both iOS and Android**:
- **Home** (my posts grid)
- **Feed** (For You / Following)
- **Post detail** (post + comments)

Swiping down reloads the latest data from the backend. For the feeds this reloads the newest first page and resets pagination so subsequent infinite-scroll fetches keep working; for post detail it reloads the post and its comment threads.

To avoid an empty flash, existing content stays on screen until the fresh data loads, then it's replaced.

## iOS
- Feed/following/my-posts view models share an async page-loader; refresh is `async` so SwiftUI keeps the spinner up until new posts arrive.
- `PostDetailViewModel.loadAllData` is split into an awaitable `performLoad`, with a new `refresh() async`.
- `FeedView`, `HomeView`, and `PostDetailView` use the SwiftUI `.refreshable` modifier. The feed tab-switch handler awaits the now-async refresh.

## Android
- View models expose an `isRefreshing` `StateFlow` and a refresh function; `PostDetailViewModel` extracts a shared suspend `loadAllDataInternal`.
- `FeedScreen`, `HomeScreen`, and `PostDetailScreen` wrap their lists in Material3 `PullToRefreshBox`.

## Tests
Added view-model unit tests on both platforms covering:
- feeds/home: refresh replaces the list with the newest posts, pagination resets after the end was reached, and a failed refresh preserves existing posts,
- post detail: refresh reloads the post and comments.

Android `:app:testDebugUnitTest` for the changed view-model test classes passes locally (recompiled, not cached). iOS could not be built here (no Xcode on this machine); the logic mirrors the verified Android behavior and uses standard SwiftUI APIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
