### PR TITLE
Add complete password reset flow and placeholder Home page (website)

### DIFF
--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -3,6 +3,9 @@ import LandingPage from './pages/LandingPage'
 import LoginPage from './pages/LoginPage'
 import RegisterPage from './pages/RegisterPage'
 import RequestResetPage from './pages/RequestResetPage'
+import VerifyResetPage from './pages/VerifyResetPage'
+import ResetPasswordPage from './pages/ResetPasswordPage'
+import HomePage from './pages/HomePage'
 
 function App() {
   return (
@@ -11,6 +14,9 @@ function App() {
       <Route path="/login" element={<LoginPage />} />
       <Route path="/register" element={<RegisterPage />} />
       <Route path="/request-reset" element={<RequestResetPage />} />
+      <Route path="/verify-reset" element={<VerifyResetPage />} />
+      <Route path="/reset-password" element={<ResetPasswordPage />} />
+      <Route path="/home" element={<HomePage />} />
     </Routes>
   )
 }

--- a/website/src/pages/HomePage.test.tsx
+++ b/website/src/pages/HomePage.test.tsx
@@ -1,0 +1,7 @@
+import { render, screen } from '@testing-library/react'
+import HomePage from './HomePage'
+
+test('renders Home View placeholder', () => {
+  render(<HomePage />)
+  expect(screen.getByRole('heading', { name: 'Home View' })).toBeInTheDocument()
+})

--- a/website/src/pages/HomePage.tsx
+++ b/website/src/pages/HomePage.tsx
@@ -1,0 +1,9 @@
+function HomePage() {
+  return (
+    <div>
+      <h1>Home View</h1>
+    </div>
+  )
+}
+
+export default HomePage

--- a/website/src/pages/LoginPage.test.tsx
+++ b/website/src/pages/LoginPage.test.tsx
@@ -18,7 +18,7 @@ function renderLoginPage() {
     <MemoryRouter initialEntries={['/login']}>
       <Routes>
         <Route path="/login" element={<LoginPage />} />
-        <Route path="/" element={<div>Home</div>} />
+        <Route path="/home" element={<div>Home</div>} />
         <Route path="/request-reset" element={<div>Reset page</div>} />
       </Routes>
     </MemoryRouter>,

--- a/website/src/pages/LoginPage.tsx
+++ b/website/src/pages/LoginPage.tsx
@@ -30,7 +30,7 @@ function LoginPage() {
       if (response.username) {
         localStorage.setItem('username', response.username)
       }
-      navigate('/')
+      navigate('/home')
     } catch (err) {
       const apiErr = err as ApiError
       setErrorMessage(apiErr.message ?? 'Login failed. Please check your credentials.')

--- a/website/src/pages/RequestResetPage.test.tsx
+++ b/website/src/pages/RequestResetPage.test.tsx
@@ -17,6 +17,7 @@ function renderPage() {
       <Routes>
         <Route path="/request-reset" element={<RequestResetPage />} />
         <Route path="/login" element={<div>Login page</div>} />
+        <Route path="/verify-reset" element={<div>Verify reset page</div>} />
       </Routes>
     </MemoryRouter>,
   )
@@ -44,20 +45,20 @@ test('Request Reset button is enabled when field has input', async () => {
   expect(screen.getByRole('button', { name: 'Request Reset' })).toBeEnabled()
 })
 
-test('shows success message when account exists', async () => {
+test('navigates to verify-reset when account exists', async () => {
   mockRequestReset.mockResolvedValueOnce({ message: 'Reset email sent' })
   renderPage()
   await userEvent.type(screen.getByLabelText('Username or Email'), 'ada')
   await userEvent.click(screen.getByRole('button', { name: 'Request Reset' }))
-  expect(await screen.findByText(/if an account with that/i)).toBeInTheDocument()
+  expect(await screen.findByText('Verify reset page')).toBeInTheDocument()
 })
 
-test('shows the same success message when account does not exist (no user enumeration)', async () => {
+test('navigates to verify-reset when account does not exist (no user enumeration)', async () => {
   mockRequestReset.mockRejectedValueOnce({ message: 'No user with that username or email' })
   renderPage()
   await userEvent.type(screen.getByLabelText('Username or Email'), 'unknown')
   await userEvent.click(screen.getByRole('button', { name: 'Request Reset' }))
-  expect(await screen.findByText(/if an account with that/i)).toBeInTheDocument()
+  expect(await screen.findByText('Verify reset page')).toBeInTheDocument()
   expect(screen.queryByRole('alert')).not.toBeInTheDocument()
 })
 
@@ -78,7 +79,7 @@ test('error clears when retry succeeds', async () => {
   await userEvent.click(screen.getByRole('button', { name: 'Request Reset' }))
   await screen.findByRole('alert')
   await userEvent.click(screen.getByRole('button', { name: 'Request Reset' }))
-  expect(await screen.findByText(/if an account with that/i)).toBeInTheDocument()
+  expect(await screen.findByText('Verify reset page')).toBeInTheDocument()
   expect(screen.queryByRole('alert')).not.toBeInTheDocument()
 })
 

--- a/website/src/pages/ResetPasswordPage.test.tsx
+++ b/website/src/pages/ResetPasswordPage.test.tsx
@@ -1,0 +1,143 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { vi, beforeEach, afterEach } from 'vitest'
+import ResetPasswordPage from './ResetPasswordPage'
+
+vi.mock('../api/client', () => ({
+  apiClient: { resetPassword: vi.fn(), login: vi.fn() },
+}))
+
+import { apiClient } from '../api/client'
+const mockResetPassword = vi.mocked(apiClient.resetPassword)
+const mockLogin = vi.mocked(apiClient.login)
+
+let mockSetItem: ReturnType<typeof vi.fn>
+
+function renderPage(usernameOrEmail = 'ada', resetToken = 'rt-tok') {
+  return render(
+    <MemoryRouter
+      initialEntries={[{ pathname: '/reset-password', state: { usernameOrEmail, resetToken } }]}
+    >
+      <Routes>
+        <Route path="/reset-password" element={<ResetPasswordPage />} />
+        <Route path="/verify-reset" element={<div>Verify reset page</div>} />
+        <Route path="/home" element={<div>Home page</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  mockResetPassword.mockReset()
+  mockLogin.mockReset()
+  mockSetItem = vi.fn()
+  vi.stubGlobal('localStorage', {
+    setItem: mockSetItem,
+    getItem: vi.fn(),
+    removeItem: vi.fn(),
+    clear: vi.fn(),
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+test('renders the form with all fields', () => {
+  renderPage()
+  expect(screen.getByRole('heading', { name: 'Set New Password' })).toBeInTheDocument()
+  expect(screen.getByLabelText('Username')).toBeInTheDocument()
+  expect(screen.getByLabelText('Email')).toBeInTheDocument()
+  expect(screen.getByLabelText('New Password')).toBeInTheDocument()
+})
+
+test('pre-fills username when usernameOrEmail has no @', () => {
+  renderPage('ada')
+  expect(screen.getByLabelText<HTMLInputElement>('Username').value).toBe('ada')
+  expect(screen.getByLabelText<HTMLInputElement>('Email').value).toBe('')
+})
+
+test('pre-fills email when usernameOrEmail contains @', () => {
+  renderPage('ada@example.com')
+  expect(screen.getByLabelText<HTMLInputElement>('Email').value).toBe('ada@example.com')
+  expect(screen.getByLabelText<HTMLInputElement>('Username').value).toBe('')
+})
+
+test('submit button is disabled when fields are incomplete', () => {
+  renderPage('ada')
+  expect(screen.getByRole('button', { name: 'Reset Password and Login' })).toBeDisabled()
+})
+
+test('submit button is enabled when all fields are filled', async () => {
+  renderPage('ada')
+  await userEvent.type(screen.getByLabelText('Email'), 'ada@example.com')
+  await userEvent.type(screen.getByLabelText('New Password'), 'newpass')
+  expect(screen.getByRole('button', { name: 'Reset Password and Login' })).toBeEnabled()
+})
+
+test('navigates to /home on successful reset and login', async () => {
+  mockResetPassword.mockResolvedValueOnce({ message: 'Password reset successfully' })
+  mockLogin.mockResolvedValueOnce({
+    session_management_token: 'tok',
+    user_id: 'uid',
+    username: 'ada',
+  })
+  renderPage('ada')
+  await userEvent.type(screen.getByLabelText('Email'), 'ada@example.com')
+  await userEvent.type(screen.getByLabelText('New Password'), 'newpass')
+  await userEvent.click(screen.getByRole('button', { name: 'Reset Password and Login' }))
+  expect(await screen.findByText('Home page')).toBeInTheDocument()
+})
+
+test('stores session token and user_id in localStorage on success', async () => {
+  mockResetPassword.mockResolvedValueOnce({ message: 'Password reset successfully' })
+  mockLogin.mockResolvedValueOnce({
+    session_management_token: 'my-token',
+    user_id: 'uuid-xyz',
+    username: 'ada',
+  })
+  renderPage('ada')
+  await userEvent.type(screen.getByLabelText('Email'), 'ada@example.com')
+  await userEvent.type(screen.getByLabelText('New Password'), 'newpass')
+  await userEvent.click(screen.getByRole('button', { name: 'Reset Password and Login' }))
+  await screen.findByText('Home page')
+  expect(mockSetItem).toHaveBeenCalledWith('session_token', 'my-token')
+  expect(mockSetItem).toHaveBeenCalledWith('user_id', 'uuid-xyz')
+})
+
+test('shows error banner when reset fails', async () => {
+  mockResetPassword.mockRejectedValueOnce({ message: 'Invalid reset token' })
+  renderPage('ada')
+  await userEvent.type(screen.getByLabelText('Email'), 'ada@example.com')
+  await userEvent.type(screen.getByLabelText('New Password'), 'newpass')
+  await userEvent.click(screen.getByRole('button', { name: 'Reset Password and Login' }))
+  expect(await screen.findByRole('alert')).toHaveTextContent('Invalid reset token')
+})
+
+test('shows error banner when auto-login fails after reset', async () => {
+  mockResetPassword.mockResolvedValueOnce({ message: 'Password reset successfully' })
+  mockLogin.mockRejectedValueOnce({ message: 'Invalid username or password' })
+  renderPage('ada')
+  await userEvent.type(screen.getByLabelText('Email'), 'ada@example.com')
+  await userEvent.type(screen.getByLabelText('New Password'), 'newpass')
+  await userEvent.click(screen.getByRole('button', { name: 'Reset Password and Login' }))
+  expect(await screen.findByRole('alert')).toHaveTextContent('Invalid username or password')
+})
+
+test('error banner can be dismissed', async () => {
+  mockResetPassword.mockRejectedValueOnce({ message: 'Invalid reset token' })
+  renderPage('ada')
+  await userEvent.type(screen.getByLabelText('Email'), 'ada@example.com')
+  await userEvent.type(screen.getByLabelText('New Password'), 'newpass')
+  await userEvent.click(screen.getByRole('button', { name: 'Reset Password and Login' }))
+  await screen.findByRole('alert')
+  await userEvent.click(screen.getByRole('button', { name: 'Dismiss error' }))
+  expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+})
+
+test('Back button navigates to /verify-reset', async () => {
+  renderPage('ada', 'rt-tok')
+  await userEvent.click(screen.getByRole('button', { name: 'Back to verify reset' }))
+  expect(screen.getByText('Verify reset page')).toBeInTheDocument()
+})

--- a/website/src/pages/ResetPasswordPage.test.tsx
+++ b/website/src/pages/ResetPasswordPage.test.tsx
@@ -141,3 +141,15 @@ test('Back button navigates to /verify-reset', async () => {
   await userEvent.click(screen.getByRole('button', { name: 'Back to verify reset' }))
   expect(screen.getByText('Verify reset page')).toBeInTheDocument()
 })
+
+test('redirects to /request-reset when resetToken is missing from state', () => {
+  render(
+    <MemoryRouter initialEntries={['/reset-password']}>
+      <Routes>
+        <Route path="/reset-password" element={<ResetPasswordPage />} />
+        <Route path="/request-reset" element={<div>Request reset page</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+  expect(screen.getByText('Request reset page')).toBeInTheDocument()
+})

--- a/website/src/pages/ResetPasswordPage.tsx
+++ b/website/src/pages/ResetPasswordPage.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from 'react'
-import { useNavigate, useLocation } from 'react-router-dom'
+import { Navigate, useNavigate, useLocation } from 'react-router-dom'
 import Logo from '../components/Logo'
 import { apiClient } from '../api/client'
 import type { ApiError } from '../api/client'
@@ -22,6 +22,10 @@ function ResetPasswordPage() {
   const [isLoading, setIsLoading] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
+  if (!resetToken) {
+    return <Navigate to="/request-reset" replace />
+  }
+
   const isFormValid =
     username.trim().length > 0 && email.trim().length > 0 && newPassword.length > 0
 
@@ -34,7 +38,7 @@ function ResetPasswordPage() {
         username: username.trim(),
         email: email.trim(),
         password: newPassword,
-        reset_token: resetToken,
+        reset_token: resetToken.trim(),
       })
       const response = await apiClient.login({
         username_or_email: username.trim() || email.trim(),

--- a/website/src/pages/ResetPasswordPage.tsx
+++ b/website/src/pages/ResetPasswordPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, type FormEvent } from 'react'
+import { useState, type FormEvent } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
 import Logo from '../components/Logo'
 import { apiClient } from '../api/client'
@@ -12,19 +12,15 @@ function ResetPasswordPage() {
   const usernameOrEmail = state?.usernameOrEmail ?? ''
   const resetToken = state?.resetToken ?? ''
 
-  const [username, setUsername] = useState('')
-  const [email, setEmail] = useState('')
+  const [username, setUsername] = useState(
+    usernameOrEmail && !usernameOrEmail.includes('@') ? usernameOrEmail : '',
+  )
+  const [email, setEmail] = useState(
+    usernameOrEmail.includes('@') ? usernameOrEmail : '',
+  )
   const [newPassword, setNewPassword] = useState('')
   const [isLoading, setIsLoading] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
-
-  useEffect(() => {
-    if (usernameOrEmail.includes('@')) {
-      setEmail(usernameOrEmail)
-    } else if (usernameOrEmail) {
-      setUsername(usernameOrEmail)
-    }
-  }, [usernameOrEmail])
 
   const isFormValid =
     username.trim().length > 0 && email.trim().length > 0 && newPassword.length > 0

--- a/website/src/pages/ResetPasswordPage.tsx
+++ b/website/src/pages/ResetPasswordPage.tsx
@@ -1,0 +1,160 @@
+import { useState, useEffect, type FormEvent } from 'react'
+import { useNavigate, useLocation } from 'react-router-dom'
+import Logo from '../components/Logo'
+import { apiClient } from '../api/client'
+import type { ApiError } from '../api/client'
+import './LoginPage.css'
+
+function ResetPasswordPage() {
+  const navigate = useNavigate()
+  const location = useLocation()
+  const state = location.state as { usernameOrEmail?: string; resetToken?: string } | null
+  const usernameOrEmail = state?.usernameOrEmail ?? ''
+  const resetToken = state?.resetToken ?? ''
+
+  const [username, setUsername] = useState('')
+  const [email, setEmail] = useState('')
+  const [newPassword, setNewPassword] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (usernameOrEmail.includes('@')) {
+      setEmail(usernameOrEmail)
+    } else if (usernameOrEmail) {
+      setUsername(usernameOrEmail)
+    }
+  }, [usernameOrEmail])
+
+  const isFormValid =
+    username.trim().length > 0 && email.trim().length > 0 && newPassword.length > 0
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    if (!isFormValid) return
+    setIsLoading(true)
+    try {
+      await apiClient.resetPassword({
+        username: username.trim(),
+        email: email.trim(),
+        password: newPassword,
+        reset_token: resetToken,
+      })
+      const response = await apiClient.login({
+        username_or_email: username.trim() || email.trim(),
+        password: newPassword,
+      })
+      localStorage.setItem('session_token', response.session_management_token)
+      localStorage.setItem('user_id', response.user_id)
+      if (response.username) {
+        localStorage.setItem('username', response.username)
+      }
+      navigate('/home')
+    } catch (err) {
+      const apiErr = err as ApiError
+      setErrorMessage(apiErr.message ?? 'Password reset failed. Please try again.')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <div className="auth-page">
+      <div className="auth-card">
+        <button
+          type="button"
+          className="auth-back"
+          onClick={() => navigate('/verify-reset', { state: { usernameOrEmail } })}
+          aria-label="Back to verify reset"
+        >
+          ← Back
+        </button>
+
+        <div className="auth-logo">
+          <Logo size={80} />
+        </div>
+
+        <h1 className="auth-title">Set New Password</h1>
+
+        {errorMessage && (
+          <div className="auth-error" role="alert">
+            <p>{errorMessage}</p>
+            <button
+              type="button"
+              className="auth-error__dismiss"
+              aria-label="Dismiss error"
+              onClick={() => setErrorMessage(null)}
+            >
+              ✕
+            </button>
+          </div>
+        )}
+
+        <form className="auth-form" onSubmit={handleSubmit} noValidate>
+          <div className="auth-field">
+            <label className="auth-label" htmlFor="username">
+              Username
+            </label>
+            <input
+              id="username"
+              className="auth-input"
+              type="text"
+              autoComplete="username"
+              autoCapitalize="none"
+              value={username}
+              onChange={e => setUsername(e.target.value)}
+              disabled={isLoading}
+            />
+          </div>
+
+          <div className="auth-field">
+            <label className="auth-label" htmlFor="email">
+              Email
+            </label>
+            <input
+              id="email"
+              className="auth-input"
+              type="email"
+              autoComplete="email"
+              autoCapitalize="none"
+              value={email}
+              onChange={e => setEmail(e.target.value)}
+              disabled={isLoading}
+            />
+          </div>
+
+          <div className="auth-field">
+            <label className="auth-label" htmlFor="newPassword">
+              New Password
+            </label>
+            <input
+              id="newPassword"
+              className="auth-input"
+              type="password"
+              autoComplete="new-password"
+              value={newPassword}
+              onChange={e => setNewPassword(e.target.value)}
+              disabled={isLoading}
+            />
+          </div>
+
+          {isLoading ? (
+            <div className="auth-spinner" aria-label="Resetting password…">
+              <span className="spinner" />
+            </div>
+          ) : (
+            <button
+              type="submit"
+              className="auth-button"
+              disabled={!isFormValid}
+            >
+              Reset Password and Login
+            </button>
+          )}
+        </form>
+      </div>
+    </div>
+  )
+}
+
+export default ResetPasswordPage

--- a/website/src/pages/VerifyResetPage.test.tsx
+++ b/website/src/pages/VerifyResetPage.test.tsx
@@ -91,3 +91,15 @@ test('Back button navigates to /request-reset', async () => {
   await userEvent.click(screen.getByRole('button', { name: 'Back to request reset' }))
   expect(screen.getByText('Request reset page')).toBeInTheDocument()
 })
+
+test('redirects to /request-reset when usernameOrEmail is missing from state', () => {
+  render(
+    <MemoryRouter initialEntries={['/verify-reset']}>
+      <Routes>
+        <Route path="/verify-reset" element={<VerifyResetPage />} />
+        <Route path="/request-reset" element={<div>Request reset page</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+  expect(screen.getByText('Request reset page')).toBeInTheDocument()
+})

--- a/website/src/pages/VerifyResetPage.test.tsx
+++ b/website/src/pages/VerifyResetPage.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { vi, beforeEach } from 'vitest'
+import VerifyResetPage from './VerifyResetPage'
+
+vi.mock('../api/client', () => ({
+  apiClient: { verifyReset: vi.fn() },
+}))
+
+import { apiClient } from '../api/client'
+const mockVerifyReset = vi.mocked(apiClient.verifyReset)
+
+function renderPage(usernameOrEmail = 'ada') {
+  return render(
+    <MemoryRouter
+      initialEntries={[{ pathname: '/verify-reset', state: { usernameOrEmail } }]}
+    >
+      <Routes>
+        <Route path="/verify-reset" element={<VerifyResetPage />} />
+        <Route path="/request-reset" element={<div>Request reset page</div>} />
+        <Route path="/reset-password" element={<div>Reset password page</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  mockVerifyReset.mockReset()
+})
+
+test('renders the form with the target address', () => {
+  renderPage('ada@example.com')
+  expect(screen.getByRole('heading', { name: 'Enter Verification Token' })).toBeInTheDocument()
+  expect(screen.getByLabelText('Verification Token')).toBeInTheDocument()
+  expect(screen.getByText(/ada@example.com/)).toBeInTheDocument()
+})
+
+test('Verify button is disabled when token field is empty', () => {
+  renderPage()
+  expect(screen.getByRole('button', { name: 'Verify' })).toBeDisabled()
+})
+
+test('Verify button is enabled when token field has input', async () => {
+  renderPage()
+  await userEvent.type(screen.getByLabelText('Verification Token'), 'abc123')
+  expect(screen.getByRole('button', { name: 'Verify' })).toBeEnabled()
+})
+
+test('navigates to /reset-password on successful verification', async () => {
+  mockVerifyReset.mockResolvedValueOnce({ message: 'Verification successful', reset_token: 'rt-tok' })
+  renderPage()
+  await userEvent.type(screen.getByLabelText('Verification Token'), 'abc123')
+  await userEvent.click(screen.getByRole('button', { name: 'Verify' }))
+  expect(await screen.findByText('Reset password page')).toBeInTheDocument()
+})
+
+test('shows error banner on invalid token', async () => {
+  mockVerifyReset.mockRejectedValueOnce({ message: 'Invalid or expired verification token' })
+  renderPage()
+  await userEvent.type(screen.getByLabelText('Verification Token'), 'bad')
+  await userEvent.click(screen.getByRole('button', { name: 'Verify' }))
+  expect(await screen.findByRole('alert')).toHaveTextContent('Invalid or expired verification token')
+})
+
+test('error banner can be dismissed', async () => {
+  mockVerifyReset.mockRejectedValueOnce({ message: 'Invalid or expired verification token' })
+  renderPage()
+  await userEvent.type(screen.getByLabelText('Verification Token'), 'bad')
+  await userEvent.click(screen.getByRole('button', { name: 'Verify' }))
+  await screen.findByRole('alert')
+  await userEvent.click(screen.getByRole('button', { name: 'Dismiss error' }))
+  expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+})
+
+test('error clears when retry succeeds', async () => {
+  mockVerifyReset
+    .mockRejectedValueOnce({ message: 'Invalid or expired verification token' })
+    .mockResolvedValueOnce({ message: 'Verification successful', reset_token: 'rt-tok' })
+  renderPage()
+  await userEvent.type(screen.getByLabelText('Verification Token'), 'bad')
+  await userEvent.click(screen.getByRole('button', { name: 'Verify' }))
+  await screen.findByRole('alert')
+  await userEvent.click(screen.getByRole('button', { name: 'Verify' }))
+  expect(await screen.findByText('Reset password page')).toBeInTheDocument()
+  expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+})
+
+test('Back button navigates to /request-reset', async () => {
+  renderPage()
+  await userEvent.click(screen.getByRole('button', { name: 'Back to request reset' }))
+  expect(screen.getByText('Request reset page')).toBeInTheDocument()
+})

--- a/website/src/pages/VerifyResetPage.tsx
+++ b/website/src/pages/VerifyResetPage.tsx
@@ -1,31 +1,36 @@
 import { useState, type FormEvent } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useLocation } from 'react-router-dom'
 import Logo from '../components/Logo'
 import { apiClient } from '../api/client'
 import type { ApiError } from '../api/client'
 import './LoginPage.css'
 
-function RequestResetPage() {
+function VerifyResetPage() {
   const navigate = useNavigate()
-  const [usernameOrEmail, setUsernameOrEmail] = useState('')
+  const location = useLocation()
+  const usernameOrEmail =
+    (location.state as { usernameOrEmail?: string } | null)?.usernameOrEmail ?? ''
+
+  const [verificationToken, setVerificationToken] = useState('')
   const [isLoading, setIsLoading] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault()
-    if (usernameOrEmail.trim().length === 0) return
+    if (verificationToken.trim().length === 0) return
     setIsLoading(true)
     try {
-      await apiClient.requestReset({ username_or_email: usernameOrEmail.trim() })
-      navigate('/verify-reset', { state: { usernameOrEmail: usernameOrEmail.trim() } })
+      const response = await apiClient.verifyReset({
+        username_or_email: usernameOrEmail,
+        verification_token: verificationToken.trim(),
+      })
+      setErrorMessage(null)
+      navigate('/reset-password', {
+        state: { usernameOrEmail, resetToken: response.reset_token },
+      })
     } catch (err) {
       const apiErr = err as ApiError
-      // Treat "account not found" the same as success to prevent user enumeration.
-      if (apiErr.message === 'No user with that username or email') {
-        navigate('/verify-reset', { state: { usernameOrEmail: usernameOrEmail.trim() } })
-      } else {
-        setErrorMessage(apiErr.message ?? 'Reset request failed. Please try again.')
-      }
+      setErrorMessage(apiErr.message ?? 'Invalid token or an unknown error occurred.')
     } finally {
       setIsLoading(false)
     }
@@ -37,8 +42,8 @@ function RequestResetPage() {
         <button
           type="button"
           className="auth-back"
-          onClick={() => navigate('/login')}
-          aria-label="Back to login"
+          onClick={() => navigate('/request-reset')}
+          aria-label="Back to request reset"
         >
           ← Back
         </button>
@@ -47,7 +52,13 @@ function RequestResetPage() {
           <Logo size={80} />
         </div>
 
-        <h1 className="auth-title">Reset Password</h1>
+        <h1 className="auth-title">Enter Verification Token</h1>
+
+        {usernameOrEmail && (
+          <p style={{ color: 'rgba(255,255,255,0.8)', textAlign: 'center', lineHeight: 1.5, margin: 0 }}>
+            Enter the verification token sent to {usernameOrEmail}.
+          </p>
+        )}
 
         {errorMessage && (
           <div className="auth-error" role="alert">
@@ -65,33 +76,32 @@ function RequestResetPage() {
 
         <form className="auth-form" onSubmit={handleSubmit} noValidate>
           <div className="auth-field">
-            <label className="auth-label" htmlFor="usernameOrEmail">
-              Username or Email
+            <label className="auth-label" htmlFor="verificationToken">
+              Verification Token
             </label>
             <input
-              id="usernameOrEmail"
+              id="verificationToken"
               className="auth-input"
               type="text"
-              inputMode="email"
-              autoComplete="username"
+              autoComplete="one-time-code"
               autoCapitalize="none"
-              value={usernameOrEmail}
-              onChange={e => setUsernameOrEmail(e.target.value)}
+              value={verificationToken}
+              onChange={e => setVerificationToken(e.target.value)}
               disabled={isLoading}
             />
           </div>
 
           {isLoading ? (
-            <div className="auth-spinner" aria-label="Submitting…">
+            <div className="auth-spinner" aria-label="Verifying…">
               <span className="spinner" />
             </div>
           ) : (
             <button
               type="submit"
               className="auth-button"
-              disabled={usernameOrEmail.trim().length === 0}
+              disabled={verificationToken.trim().length === 0}
             >
-              Request Reset
+              Verify
             </button>
           )}
         </form>
@@ -100,4 +110,4 @@ function RequestResetPage() {
   )
 }
 
-export default RequestResetPage
+export default VerifyResetPage

--- a/website/src/pages/VerifyResetPage.tsx
+++ b/website/src/pages/VerifyResetPage.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from 'react'
-import { useNavigate, useLocation } from 'react-router-dom'
+import { Navigate, useNavigate, useLocation } from 'react-router-dom'
 import Logo from '../components/Logo'
 import { apiClient } from '../api/client'
 import type { ApiError } from '../api/client'
@@ -15,18 +15,22 @@ function VerifyResetPage() {
   const [isLoading, setIsLoading] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
+  if (!usernameOrEmail) {
+    return <Navigate to="/request-reset" replace />
+  }
+
   async function handleSubmit(e: FormEvent) {
     e.preventDefault()
     if (verificationToken.trim().length === 0) return
     setIsLoading(true)
     try {
       const response = await apiClient.verifyReset({
-        username_or_email: usernameOrEmail,
+        username_or_email: usernameOrEmail.trim(),
         verification_token: verificationToken.trim(),
       })
       setErrorMessage(null)
       navigate('/reset-password', {
-        state: { usernameOrEmail, resetToken: response.reset_token },
+        state: { usernameOrEmail: usernameOrEmail.trim(), resetToken: response.reset_token },
       })
     } catch (err) {
       const apiErr = err as ApiError


### PR DESCRIPTION
## Summary

- **VerifyResetPage** (`/verify-reset`): receives `usernameOrEmail` via React Router state from RequestResetPage, calls `verifyReset` API, forwards `usernameOrEmail` + `reset_token` to ResetPasswordPage on success
- **ResetPasswordPage** (`/reset-password`): receives `usernameOrEmail` + `resetToken` from state, auto-fills the username or email field (mirrors iOS/Android logic), calls `resetPassword` then immediately auto-logs in, stores session in `localStorage`, navigates to `/home`
- **HomePage** (`/home`): placeholder page showing "Home View" — to be filled in later
- **RequestResetPage** updated: on success (and on "account not found" to prevent user enumeration) navigates to `/verify-reset` instead of showing an inline message
- **LoginPage** updated: navigates to `/home` after successful login instead of `/`
- **App.tsx**: wired up `/verify-reset`, `/reset-password`, `/home` routes

## Test plan

- [ ] 65 tests pass (`npx vitest run` in `website/`) — 8 new for VerifyResetPage, 11 new for ResetPasswordPage, 1 new for HomePage, existing RequestResetPage + LoginPage tests updated for new routing
- [ ] Manual: login → lands on "Home View"
- [ ] Manual: login → Forgot Password → enter username/email → enter verification token → enter new password → auto-logs in → lands on "Home View"
- [ ] Manual: user enumeration check — "account not found" still navigates to verify-reset page rather than revealing whether the account exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)