### PR TITLE
Add main app views to the website (Home, Feed, New Post, Settings, Post Detail, Profile)

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -8,6 +8,8 @@
       "name": "positive-only-social-website",
       "version": "0.0.0",
       "dependencies": {
+        "@aws-sdk/client-s3": "^3.1059.0",
+        "@aws-sdk/credential-provider-cognito-identity": "^3.972.39",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.6.0"
@@ -58,6 +60,516 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+      "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
+      "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1059.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1059.0.tgz",
+      "integrity": "sha512-bFzCViJh389MmuhiixKJYfp2kBfkLH7My4rkkFeFfIUH+esiWSvyhZ9bvHbkS8C5lnHfBrf8s5a8wLBoA+lezQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.16",
+        "@aws-sdk/credential-provider-node": "^3.972.49",
+        "@aws-sdk/middleware-bucket-endpoint": "^3.972.18",
+        "@aws-sdk/middleware-expect-continue": "^3.972.15",
+        "@aws-sdk/middleware-flexible-checksums": "^3.974.24",
+        "@aws-sdk/middleware-location-constraint": "^3.972.12",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.45",
+        "@aws-sdk/middleware-ssec": "^3.972.12",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.31",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.16.tgz",
+      "integrity": "sha512-WXPvTfG7J2H4Ae6ewhd0285UC+8+9p/pKoibXXQlbXSqHexFLGM0oXHTwDfQEPmrNnvuWPpVjgoAUfW+cUFbXw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.10",
+        "@aws-sdk/xml-builder": "^3.972.27",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/crc64-nvme": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.10.tgz",
+      "integrity": "sha512-QsyJJlx+bSgApcd6kkloZ+nHg2nWJTwUA39/KiDcNRYjz9UOReQcNJRlJBImK+eF9EWl2LG5SW7LaVFuYUE8HQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity": {
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.972.39.tgz",
+      "integrity": "sha512-fp7hiew245BbBiaDGjLDaMXqxbOWnqzuhczWrJq/6/3gDNHtZvkorxHQXYpHYiddetR8sBWe3S49HfZ2BQbYSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/nested-clients": "^3.997.14",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.42.tgz",
+      "integrity": "sha512-0+MCOYqeHyADFdeVr5/e1G8JJoWm7/szZAiKssqJS84E9+tO07509YNyQRJ5a7x5wO9YFAV324syrwm6yIcs5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.16",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.44",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.44.tgz",
+      "integrity": "sha512-auuhqlnv4PUdfqcdHLKGTdoCceXOuby6WNeCMoxtZmQGWNCibbz95/lSYzNWq9cExN17UlRFqo1nvTcC+zHfEg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.16",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.47",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.47.tgz",
+      "integrity": "sha512-G+8JuG0CfLcC2IQXFVqMR1+KDF1rksebr+YL6+HHYbNjs/hiwX53ye45sU3pJKljpS2uIXqOrOsicHIv02vWrw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.16",
+        "@aws-sdk/credential-provider-env": "^3.972.42",
+        "@aws-sdk/credential-provider-http": "^3.972.44",
+        "@aws-sdk/credential-provider-login": "^3.972.46",
+        "@aws-sdk/credential-provider-process": "^3.972.42",
+        "@aws-sdk/credential-provider-sso": "^3.972.46",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.46",
+        "@aws-sdk/nested-clients": "^3.997.14",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.46.tgz",
+      "integrity": "sha512-+H6h2/1Q+iIJ4w+FPCKM//xwy4C9yADknDTR68+K3PbOtB/uLup3zIH8PUKn6QwnttME4VM4ftSTnbvoDf5wXg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.16",
+        "@aws-sdk/nested-clients": "^3.997.14",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.49",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.49.tgz",
+      "integrity": "sha512-hlyoc+2352BhC+HF91t9avIDJu1+EvQGGltxFB8ADCpAHGYNNLEQAZJIPzw3O/bRiiDSE2B8pdj/fFCXlDTEDg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.42",
+        "@aws-sdk/credential-provider-http": "^3.972.44",
+        "@aws-sdk/credential-provider-ini": "^3.972.47",
+        "@aws-sdk/credential-provider-process": "^3.972.42",
+        "@aws-sdk/credential-provider-sso": "^3.972.46",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.46",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.42.tgz",
+      "integrity": "sha512-r996IYVtQ7rWa5UfSs3fZLT/Dq/SSgH9wv9zahx9lcg6vvaPPQHFpTy45nZajZu/+OUdEQxEjTn9rOMons59mA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.16",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.46.tgz",
+      "integrity": "sha512-vd+UqRbiYLvXXH3kTAuTxq+Vdb3rOgg29/FeB35ETsgdJTTB7x3YuqtpRckATsL5bDRXFVQo0uBj0/vxCJ8hHg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.16",
+        "@aws-sdk/nested-clients": "^3.997.14",
+        "@aws-sdk/token-providers": "3.1059.0",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.46.tgz",
+      "integrity": "sha512-xuxBbMorygYsbDV6E/tUGQUgIDfhnzxz8uJYX8rByzehI6gLUu8RPsgOpLmh9YWerqeHZxJbqzgheBSB7tpooQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.16",
+        "@aws-sdk/nested-clients": "^3.997.14",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.972.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.18.tgz",
+      "integrity": "sha512-aR+OAJLwaux1MRcRBps9XULdcXuBBilnA4NsRe1yu3wOxojhmWZY2TkHoAToku78Bw0w65JK3bpIGys6QWYvCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.16",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue": {
+      "version": "3.972.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.15.tgz",
+      "integrity": "sha512-GFxHAXAO2iV4EIYZ97NcIiJiMATEjCm9sWS0VaRvHgxE9EDsL2tF0J08si74IT/YqFsdOgF/GWtoI2LkgbGj/Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.974.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.24.tgz",
+      "integrity": "sha512-GMLfdBEsRSNfgF99Ono1a56P6aOTnIjoNdH5/s9Ca0PV676hVTbPnFnuQKZ2b3XAaBp55RvRSxvKRtdNkKjCnw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-crypto/util": "5.2.0",
+        "@aws-sdk/core": "^3.974.16",
+        "@aws-sdk/crc64-nvme": "^3.972.10",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint": {
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.12.tgz",
+      "integrity": "sha512-9fXwH5lPa4M9lD6KhKOWZX2sXefuJX0PR/vxZ2u/ZYVrgr/tEUiFTdEBJ88y3/psuocWQ5IZmf5+T1hsa1qDUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.45",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.45.tgz",
+      "integrity": "sha512-ZY4ycac5lyysxkKvH756eAr90kTFnmitUeMDOBBZfNXOoHRUm6o/47BamVwlvs5AvJWimoHf6x01c99Jwezl6Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.16",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.31",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-ssec": {
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.12.tgz",
+      "integrity": "sha512-WiuUb6fqkMAAM3b1+2M2B74Zobh4JUsoS0s2gE792IRJCYaGp2BJzMK9rhfniNijxg1PhVppUeufpiEdDLNy+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.14.tgz",
+      "integrity": "sha512-T5CS1r4P27FjkBYIWwVibWqEuq32BbCga2Z5m5OBSdSdi2wPfW2vl6zLWAB/5MeeyC4s2pY/MY3cj2Gd3rgSkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.16",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.31",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.31.tgz",
+      "integrity": "sha512-Kn2up9SlG1KC6wRtwf0d7waTGF6rvp9DxYqB54x6UCKdQ6kyaXCqHL4WGb5vUJga5kS8FxnjhY0LqM28aMvnNQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1059.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1059.0.tgz",
+      "integrity": "sha512-xql+7YBAE7WYb9xJfY0vcAXM8rJXfClmB2wkt+g/EoLUMog0pOb7o741fE96wFqha0uQTEgTo/5lGGguzavxmw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.16",
+        "@aws-sdk/nested-clients": "^3.997.14",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.10.tgz",
+      "integrity": "sha512-992QrTO7G9qCvKD0fx1rMlqcL14plUcRAbwmqqYVsuF3GrqcvlAL9qxR+baMafarEZ+l7DUQ5lCMmt5mbMhF7g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.27.tgz",
+      "integrity": "sha512-hpsCXCOI436kxWpjtRuIHVvuPP81MOw8f18jzfZeg+UOiiOvlqWcmWChzEhJEu16cOC6+ku4ncBN+7rdt+DZ9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.3",
+        "fast-xml-parser": "5.7.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -1181,6 +1693,18 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
+      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1537,6 +2061,126 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.24.6",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.6.tgz",
+      "integrity": "sha512-wBXDRup6UU97VKyaiRo8AssnfStPtG0oAAfpq/bC0a1YYau8pM86YB4kM6ccoVi1mS8l/UHbn9oDM+7uozr/ug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.7.tgz",
+      "integrity": "sha512-xj8gq/bjFABAh6qWPSDCYcY3kzQIm4b561C+YnHH4zGq8rOgzQ3Shk+JGlpUxSd41UGiO6FkLdUCtNX1FAeHgg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.6.tgz",
+      "integrity": "sha512-FEwEYJ1jlBKdhe9TPzfghEi1bP55ZeEImlDkEa62bBBYzUcnB6RUCyuiS2mqKt6ZVjUbBgcNhzfIctH+Hevx9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.7.6",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.6.tgz",
+      "integrity": "sha512-3fya8i7GrJilQouk4cZJKdy5k8MWQBpjfXrRNaXDedH8r779tr0jcxyH3+yoTmsluc2+vF4S343yFbnvu8ExDQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.6.tgz",
+      "integrity": "sha512-Ojg4B6oIDlIr1R86xCDJt1zJWnYa0VINmqdjfe9qxWjdRivHalZ3iSlQgVqYbW0MdpFOC5XfHEWsnbmdnpIILQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
+      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -2293,6 +2937,12 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
@@ -2866,6 +3516,43 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -3507,6 +4194,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -3905,6 +4607,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -4027,6 +4741,12 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -4411,6 +5131,21 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xmlchars": {

--- a/website/package.json
+++ b/website/package.json
@@ -12,6 +12,8 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.1059.0",
+    "@aws-sdk/credential-provider-cognito-identity": "^3.972.39",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.0"

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -6,6 +6,8 @@ import RequestResetPage from './pages/RequestResetPage'
 import VerifyResetPage from './pages/VerifyResetPage'
 import ResetPasswordPage from './pages/ResetPasswordPage'
 import HomePage from './pages/HomePage'
+import PostDetailPage from './pages/PostDetailPage'
+import ProfilePage from './pages/ProfilePage'
 
 function App() {
   return (
@@ -17,6 +19,8 @@ function App() {
       <Route path="/verify-reset" element={<VerifyResetPage />} />
       <Route path="/reset-password" element={<ResetPasswordPage />} />
       <Route path="/home" element={<HomePage />} />
+      <Route path="/post/:postId" element={<PostDetailPage />} />
+      <Route path="/profile/:username" element={<ProfilePage />} />
     </Routes>
   )
 }

--- a/website/src/api/s3Uploader.ts
+++ b/website/src/api/s3Uploader.ts
@@ -1,0 +1,116 @@
+// Uploads a picked photo to S3 and returns its public URL, mirroring the native
+// clients' uploader (ios/.../uploader/AWSManager.swift and
+// android/.../data/uploader/AWSManager.kt).
+//
+// Like the apps, this uses an unauthenticated AWS Cognito Identity Pool to mint
+// temporary credentials in the browser, then PUTs the (JPEG-compressed) image
+// directly to the shared bucket. The object key is scoped to the signed-in
+// user's id, matching `\(userId)/\(uuid).jpeg` on iOS.
+//
+// NOTE: a browser PUT requires the S3 bucket to allow the site's origin via CORS
+// (the native SDKs aren't subject to CORS). The bucket's CORS policy must permit
+// PUT from wherever the web app is served.
+
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3'
+// The dedicated Cognito provider is browser-safe; the umbrella
+// `@aws-sdk/credential-providers` pulls in the Node-only IMDS provider, which
+// can't be bundled for the browser.
+import { fromCognitoIdentityPool } from '@aws-sdk/credential-provider-cognito-identity'
+
+const AWS_REGION = 'us-east-2'
+const IDENTITY_POOL_ID = 'us-east-2:445cf6ff-6f59-4cff-94c9-51db170ad81e'
+const BUCKET_NAME = 'goodvibesonly-images'
+const MAX_SIZE_BYTES = 10 * 1024 * 1024 // 10 MB, matching the native uploaders.
+
+let cachedClient: S3Client | null = null
+
+function getClient(): S3Client {
+  if (!cachedClient) {
+    cachedClient = new S3Client({
+      region: AWS_REGION,
+      credentials: fromCognitoIdentityPool({
+        identityPoolId: IDENTITY_POOL_ID,
+        clientConfig: { region: AWS_REGION },
+      }),
+    })
+  }
+  return cachedClient
+}
+
+/**
+ * Uploads an image file to S3 and returns the public URL of the object.
+ *
+ * @param file   The image picked by the user.
+ * @param userId The signed-in user's id, used to scope the object key.
+ */
+export async function uploadImage(file: File, userId: string): Promise<string> {
+  const body = await compressImage(file, MAX_SIZE_BYTES)
+  const key = `${userId}/${crypto.randomUUID()}.jpeg`
+
+  await getClient().send(
+    new PutObjectCommand({
+      Bucket: BUCKET_NAME,
+      Key: key,
+      Body: body,
+      ContentType: 'image/jpeg',
+    }),
+  )
+
+  return `https://${BUCKET_NAME}.s3.${AWS_REGION}.amazonaws.com/${key}`
+}
+
+/**
+ * Re-encodes the image as JPEG and, if it exceeds `maxSizeBytes`, iteratively
+ * lowers quality and then downscales until it fits — the same strategy the
+ * native uploaders use.
+ */
+async function compressImage(file: File, maxSizeBytes: number): Promise<Blob> {
+  const bitmap = await createImageBitmap(file)
+  try {
+    let width = bitmap.width
+    let height = bitmap.height
+    let quality = 0.9
+
+    let blob = await encodeJpeg(bitmap, width, height, quality)
+
+    // 1. Reduce quality.
+    while (blob.size > maxSizeBytes && quality > 0.1) {
+      quality -= 0.1
+      blob = await encodeJpeg(bitmap, width, height, quality)
+    }
+
+    // 2. Still too big — progressively downscale at the lowest quality.
+    while (blob.size > maxSizeBytes && width > 1 && height > 1) {
+      width = Math.max(1, Math.floor(width * 0.9))
+      height = Math.max(1, Math.floor(height * 0.9))
+      blob = await encodeJpeg(bitmap, width, height, quality)
+    }
+
+    return blob
+  } finally {
+    bitmap.close()
+  }
+}
+
+function encodeJpeg(
+  bitmap: ImageBitmap,
+  width: number,
+  height: number,
+  quality: number,
+): Promise<Blob> {
+  const canvas = document.createElement('canvas')
+  canvas.width = width
+  canvas.height = height
+  const ctx = canvas.getContext('2d')
+  if (!ctx) {
+    return Promise.reject(new Error('Could not get a 2D canvas context'))
+  }
+  ctx.drawImage(bitmap, 0, 0, width, height)
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      blob => (blob ? resolve(blob) : reject(new Error('Image encoding failed'))),
+      'image/jpeg',
+      quality,
+    )
+  })
+}

--- a/website/src/api/session.ts
+++ b/website/src/api/session.ts
@@ -1,0 +1,22 @@
+// Small helpers around the locally-persisted session, mirroring how the native
+// clients read the signed-in user out of the keychain. The session token itself
+// lives on the ApiClient (and in localStorage for reload survival); these helpers
+// expose the current username/user id and clear everything on logout.
+
+import { apiClient } from './client'
+
+export function getCurrentUsername(): string | null {
+  return localStorage.getItem('username')
+}
+
+export function getCurrentUserId(): string | null {
+  return localStorage.getItem('user_id')
+}
+
+/** Clears the persisted session and the in-memory token (used by logout/delete). */
+export function clearSession(): void {
+  apiClient.setToken(null)
+  localStorage.removeItem('session_token')
+  localStorage.removeItem('user_id')
+  localStorage.removeItem('username')
+}

--- a/website/src/components/FeedTab.test.tsx
+++ b/website/src/components/FeedTab.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { vi, beforeEach, test, expect } from 'vitest'
+import FeedTab from './FeedTab'
+
+vi.mock('../api/client', () => ({
+  apiClient: {
+    getFeed: vi.fn(),
+    getFollowedFeed: vi.fn(),
+  },
+}))
+
+import { apiClient } from '../api/client'
+const mockGetFeed = vi.mocked(apiClient.getFeed)
+const mockGetFollowed = vi.mocked(apiClient.getFollowedFeed)
+
+function renderTab() {
+  return render(
+    <MemoryRouter initialEntries={['/home']}>
+      <Routes>
+        <Route path="/home" element={<FeedTab />} />
+        <Route path="/post/:postId" element={<div>Post page</div>} />
+        <Route path="/profile/:username" element={<div>Profile page</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  mockGetFeed.mockReset()
+  mockGetFollowed.mockReset()
+})
+
+test('loads the For You feed by default and opens a post', async () => {
+  mockGetFeed.mockResolvedValue([
+    { post_identifier: 'p1', image_url: 'http://img/1.jpg', author_username: 'ada', caption: 'hi' },
+  ])
+  mockGetFollowed.mockResolvedValue([])
+  renderTab()
+
+  await userEvent.click(await screen.findByRole('button', { name: 'Open post by ada' }))
+  expect(screen.getByText('Post page')).toBeInTheDocument()
+})
+
+test('switches to the Following feed', async () => {
+  mockGetFeed.mockResolvedValue([])
+  mockGetFollowed.mockResolvedValue([
+    { post_identifier: 'p2', image_url: 'http://img/2.jpg', author_username: 'bob', caption: 'yo' },
+  ])
+  renderTab()
+
+  await userEvent.click(screen.getByRole('tab', { name: 'Following' }))
+  await waitFor(() => expect(mockGetFollowed).toHaveBeenCalledWith(0))
+  expect(await screen.findByRole('button', { name: 'Open post by bob' })).toBeInTheDocument()
+})
+
+test('navigates to an author profile from the feed', async () => {
+  mockGetFeed.mockResolvedValue([
+    { post_identifier: 'p1', image_url: 'http://img/1.jpg', author_username: 'ada', caption: 'hi' },
+  ])
+  mockGetFollowed.mockResolvedValue([])
+  renderTab()
+
+  await userEvent.click(await screen.findByRole('button', { name: 'ada' }))
+  expect(screen.getByText('Profile page')).toBeInTheDocument()
+})

--- a/website/src/components/FeedTab.tsx
+++ b/website/src/components/FeedTab.tsx
@@ -1,0 +1,132 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { apiClient } from '../api/client'
+import type { FeedPost } from '../api/types'
+
+type FeedType = 'forYou' | 'following'
+
+/**
+ * The "Feed" tab with a For You / Following segmented control. Each feed loads
+ * independently and supports pagination. Mirrors iOS FeedView (ForYou +
+ * Following feeds, infinite scroll, tap author → profile, tap image → detail).
+ */
+function FeedTab() {
+  const navigate = useNavigate()
+  const [selected, setSelected] = useState<FeedType>('forYou')
+
+  const [posts, setPosts] = useState<FeedPost[]>([])
+  const [page, setPage] = useState(0)
+  const [canLoadMore, setCanLoadMore] = useState(true)
+  // Start loading on mount so the spinner shows without a synchronous setState
+  // inside the fetch effect (which React flags as a cascading render).
+  const [isLoading, setIsLoading] = useState(true)
+
+  const fetcher = useCallback(
+    (batch: number) =>
+      selected === 'forYou' ? apiClient.getFeed(batch) : apiClient.getFollowedFeed(batch),
+    [selected],
+  )
+
+  const loadFeed = useCallback(
+    async (pageToLoad: number, replace: boolean) => {
+      try {
+        const newPosts = await fetcher(pageToLoad)
+        if (replace) {
+          setPosts(newPosts)
+          setCanLoadMore(newPosts.length > 0)
+          setPage(newPosts.length > 0 ? 1 : 0)
+        } else if (newPosts.length === 0) {
+          setCanLoadMore(false)
+        } else {
+          setPosts(prev => [...prev, ...newPosts])
+          setPage(prev => prev + 1)
+        }
+      } catch {
+        setCanLoadMore(false)
+      } finally {
+        setIsLoading(false)
+      }
+    },
+    [fetcher],
+  )
+
+  // Reload from scratch whenever the selected feed changes. Deferred to a
+  // microtask so the fetch's setState calls don't run synchronously inside the
+  // effect (React flags that as cascading renders).
+  useEffect(() => {
+    void Promise.resolve().then(() => loadFeed(0, true))
+  }, [loadFeed])
+
+  return (
+    <div>
+      <div className="segmented" role="tablist" aria-label="Feed type">
+        <button
+          type="button"
+          role="tab"
+          aria-selected={selected === 'forYou'}
+          className={`segmented__option${selected === 'forYou' ? ' segmented__option--active' : ''}`}
+          onClick={() => {
+            setIsLoading(true)
+            setSelected('forYou')
+          }}
+        >
+          For You
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={selected === 'following'}
+          className={`segmented__option${selected === 'following' ? ' segmented__option--active' : ''}`}
+          onClick={() => {
+            setIsLoading(true)
+            setSelected('following')
+          }}
+        >
+          Following
+        </button>
+      </div>
+
+      {posts.length === 0 && !isLoading ? (
+        <p className="muted">No posts here yet.</p>
+      ) : (
+        <div className="feed-list">
+          {posts.map(post => (
+            <article key={post.post_identifier}>
+              <button
+                type="button"
+                className="feed-post__author"
+                onClick={() => navigate(`/profile/${encodeURIComponent(post.author_username)}`)}
+              >
+                {post.author_username}
+              </button>
+              <button
+                type="button"
+                className="feed-post__image"
+                aria-label={`Open post by ${post.author_username}`}
+                onClick={() => navigate(`/post/${post.post_identifier}`)}
+              >
+                <img src={post.image_url} alt={post.caption} />
+              </button>
+            </article>
+          ))}
+        </div>
+      )}
+
+      {isLoading && <div className="center-spinner"><span className="spinner" /></div>}
+      {canLoadMore && !isLoading && posts.length > 0 && (
+        <button
+          type="button"
+          className="load-more"
+          onClick={() => {
+            setIsLoading(true)
+            void loadFeed(page, false)
+          }}
+        >
+          Load more
+        </button>
+      )}
+    </div>
+  )
+}
+
+export default FeedTab

--- a/website/src/components/FeedTab.tsx
+++ b/website/src/components/FeedTab.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { apiClient } from '../api/client'
 import type { FeedPost } from '../api/types'
@@ -13,6 +13,16 @@ type FeedType = 'forYou' | 'following'
 function FeedTab() {
   const navigate = useNavigate()
   const [selected, setSelected] = useState<FeedType>('forYou')
+
+  // Track mount state so async loads that resolve after the tab is switched
+  // away (HomePage unmounts inactive tabs) don't set state on an unmounted view.
+  const isMounted = useRef(true)
+  useEffect(() => {
+    isMounted.current = true
+    return () => {
+      isMounted.current = false
+    }
+  }, [])
 
   const [posts, setPosts] = useState<FeedPost[]>([])
   const [page, setPage] = useState(0)
@@ -31,6 +41,7 @@ function FeedTab() {
     async (pageToLoad: number, replace: boolean) => {
       try {
         const newPosts = await fetcher(pageToLoad)
+        if (!isMounted.current) return
         if (replace) {
           setPosts(newPosts)
           setCanLoadMore(newPosts.length > 0)
@@ -42,9 +53,9 @@ function FeedTab() {
           setPage(prev => prev + 1)
         }
       } catch {
-        setCanLoadMore(false)
+        if (isMounted.current) setCanLoadMore(false)
       } finally {
-        setIsLoading(false)
+        if (isMounted.current) setIsLoading(false)
       }
     },
     [fetcher],

--- a/website/src/components/MyPostsTab.test.tsx
+++ b/website/src/components/MyPostsTab.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { vi, beforeEach, afterEach, test, expect } from 'vitest'
+import MyPostsTab from './MyPostsTab'
+
+vi.mock('../api/client', () => ({
+  apiClient: {
+    getPostsForUser: vi.fn(),
+    searchUsers: vi.fn(),
+  },
+}))
+
+import { apiClient } from '../api/client'
+const mockGetPosts = vi.mocked(apiClient.getPostsForUser)
+const mockSearch = vi.mocked(apiClient.searchUsers)
+
+function renderTab() {
+  return render(
+    <MemoryRouter initialEntries={['/home']}>
+      <Routes>
+        <Route path="/home" element={<MyPostsTab />} />
+        <Route path="/post/:postId" element={<div>Post page</div>} />
+        <Route path="/profile/:username" element={<div>Profile page</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  mockGetPosts.mockReset()
+  mockSearch.mockReset()
+  vi.stubGlobal('localStorage', {
+    getItem: vi.fn(() => 'ada'),
+    setItem: vi.fn(),
+    removeItem: vi.fn(),
+    clear: vi.fn(),
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+test('renders the current user post grid and opens a post', async () => {
+  mockGetPosts.mockResolvedValue([
+    { post_identifier: 'p1', image_url: 'http://img/1.jpg', author_username: 'ada', caption: 'hi' },
+  ])
+  renderTab()
+  const cell = await screen.findByRole('button', { name: 'Post by ada' })
+  await userEvent.click(cell)
+  expect(screen.getByText('Post page')).toBeInTheDocument()
+})
+
+test('shows empty state when the user has no posts', async () => {
+  mockGetPosts.mockResolvedValue([])
+  renderTab()
+  expect(await screen.findByText("You haven't posted anything yet.")).toBeInTheDocument()
+})
+
+test('searches users after typing 3+ characters and navigates to a profile', async () => {
+  mockGetPosts.mockResolvedValue([])
+  mockSearch.mockResolvedValue([{ username: 'bob', identity_is_verified: true }])
+  renderTab()
+
+  await userEvent.type(screen.getByLabelText('Search for users'), 'bob')
+  const result = await screen.findByText('bob')
+  await waitFor(() => expect(mockSearch).toHaveBeenCalledWith('bob'))
+  await userEvent.click(result)
+  expect(screen.getByText('Profile page')).toBeInTheDocument()
+})
+
+test('does not search for queries shorter than 3 characters', async () => {
+  mockGetPosts.mockResolvedValue([])
+  renderTab()
+  await userEvent.type(screen.getByLabelText('Search for users'), 'bo')
+  // Give any (unexpected) debounce a chance to fire.
+  await new Promise(r => setTimeout(r, 600))
+  expect(mockSearch).not.toHaveBeenCalled()
+})

--- a/website/src/components/MyPostsTab.tsx
+++ b/website/src/components/MyPostsTab.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { apiClient } from '../api/client'
 import { getCurrentUsername } from '../api/session'
@@ -12,6 +12,16 @@ import type { FeedPost, UserSearchResult } from '../api/types'
 function MyPostsTab() {
   const navigate = useNavigate()
   const username = getCurrentUsername()
+
+  // Track mount state so async loads that resolve after the tab is switched
+  // away (HomePage unmounts inactive tabs) don't set state on an unmounted view.
+  const isMounted = useRef(true)
+  useEffect(() => {
+    isMounted.current = true
+    return () => {
+      isMounted.current = false
+    }
+  }, [])
 
   const [posts, setPosts] = useState<FeedPost[]>([])
   const [page, setPage] = useState(0)
@@ -28,6 +38,7 @@ function MyPostsTab() {
       if (!username) return
       try {
         const newPosts = await apiClient.getPostsForUser(username, pageToLoad)
+        if (!isMounted.current) return
         if (replace) {
           setPosts(newPosts)
           setCanLoadMore(newPosts.length > 0)
@@ -39,9 +50,9 @@ function MyPostsTab() {
           setPage(prev => prev + 1)
         }
       } catch {
-        setCanLoadMore(false)
+        if (isMounted.current) setCanLoadMore(false)
       } finally {
-        setIsLoading(false)
+        if (isMounted.current) setIsLoading(false)
       }
     },
     [username],
@@ -61,9 +72,10 @@ function MyPostsTab() {
     if (query.length < 3) return
     const id = setTimeout(async () => {
       try {
-        setSearchResults(await apiClient.searchUsers(query))
+        const results = await apiClient.searchUsers(query)
+        if (isMounted.current) setSearchResults(results)
       } catch {
-        setSearchResults([])
+        if (isMounted.current) setSearchResults([])
       }
     }, 500)
     return () => clearTimeout(id)

--- a/website/src/components/MyPostsTab.tsx
+++ b/website/src/components/MyPostsTab.tsx
@@ -1,0 +1,153 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { apiClient } from '../api/client'
+import { getCurrentUsername } from '../api/session'
+import type { FeedPost, UserSearchResult } from '../api/types'
+
+/**
+ * The "Home" tab: the signed-in user's own post grid, with a user-search bar
+ * that swaps the grid for a results list. Mirrors iOS MyPostsGridView +
+ * HomeViewModel (debounced search, 3-char minimum, paginated post grid).
+ */
+function MyPostsTab() {
+  const navigate = useNavigate()
+  const username = getCurrentUsername()
+
+  const [posts, setPosts] = useState<FeedPost[]>([])
+  const [page, setPage] = useState(0)
+  const [canLoadMore, setCanLoadMore] = useState(true)
+  // Start in the loading state on mount so the spinner shows without a
+  // synchronous setState inside the fetch effect (which React flags).
+  const [isLoading, setIsLoading] = useState(!!username)
+
+  const [searchText, setSearchText] = useState('')
+  const [searchResults, setSearchResults] = useState<UserSearchResult[]>([])
+
+  const loadPosts = useCallback(
+    async (pageToLoad: number, replace: boolean) => {
+      if (!username) return
+      try {
+        const newPosts = await apiClient.getPostsForUser(username, pageToLoad)
+        if (replace) {
+          setPosts(newPosts)
+          setCanLoadMore(newPosts.length > 0)
+          setPage(newPosts.length > 0 ? 1 : 0)
+        } else if (newPosts.length === 0) {
+          setCanLoadMore(false)
+        } else {
+          setPosts(prev => [...prev, ...newPosts])
+          setPage(prev => prev + 1)
+        }
+      } catch {
+        setCanLoadMore(false)
+      } finally {
+        setIsLoading(false)
+      }
+    },
+    [username],
+  )
+
+  // Kick the initial load off a microtask so the fetch's setState calls don't
+  // run synchronously inside the effect (React flags that as cascading renders).
+  useEffect(() => {
+    void Promise.resolve().then(() => loadPosts(0, true))
+  }, [loadPosts])
+
+  // Debounced user search (500ms), only firing for 3+ character queries. The
+  // setState lives in the timeout callback (not synchronously in the effect);
+  // clearing for short queries is handled in the input's onChange below.
+  useEffect(() => {
+    const query = searchText.trim()
+    if (query.length < 3) return
+    const id = setTimeout(async () => {
+      try {
+        setSearchResults(await apiClient.searchUsers(query))
+      } catch {
+        setSearchResults([])
+      }
+    }, 500)
+    return () => clearTimeout(id)
+  }, [searchText])
+
+  function handleSearchChange(value: string) {
+    setSearchText(value)
+    if (value.trim().length < 3) setSearchResults([])
+  }
+
+  const isSearching = searchText.trim().length > 0
+
+  return (
+    <div>
+      <input
+        className="search-bar"
+        type="search"
+        placeholder="Search for Users"
+        aria-label="Search for users"
+        autoCapitalize="none"
+        value={searchText}
+        onChange={e => handleSearchChange(e.target.value)}
+      />
+
+      {isSearching ? (
+        <div className="user-list">
+          {searchResults.map(user => (
+            <button
+              key={user.username}
+              type="button"
+              className="user-list__item"
+              onClick={() => navigate(`/profile/${encodeURIComponent(user.username)}`)}
+            >
+              <span className="user-list__avatar" aria-hidden="true">
+                ◍
+              </span>
+              <span className="user-list__name">{user.username}</span>
+              {user.identity_is_verified && (
+                <span className="verified-badge" aria-label="Verified">
+                  ✓
+                </span>
+              )}
+            </button>
+          ))}
+          {searchText.trim().length >= 3 && searchResults.length === 0 && (
+            <p className="muted">No users found.</p>
+          )}
+        </div>
+      ) : (
+        <>
+          {posts.length === 0 && !isLoading ? (
+            <p className="muted">You haven't posted anything yet.</p>
+          ) : (
+            <div className="post-grid">
+              {posts.map(post => (
+                <button
+                  key={post.post_identifier}
+                  type="button"
+                  className="post-grid__cell"
+                  aria-label={`Post by ${post.author_username}`}
+                  onClick={() => navigate(`/post/${post.post_identifier}`)}
+                >
+                  <img src={post.image_url} alt={post.caption} />
+                </button>
+              ))}
+            </div>
+          )}
+          {isLoading && <div className="center-spinner"><span className="spinner" /></div>}
+          {canLoadMore && !isLoading && posts.length > 0 && (
+            <button
+              type="button"
+              className="load-more"
+              onClick={() => {
+                setIsLoading(true)
+                void loadPosts(page, false)
+              }}
+            >
+              Load more
+            </button>
+          )}
+        </>
+      )}
+    </div>
+  )
+}
+
+export default MyPostsTab

--- a/website/src/components/NewPostTab.test.tsx
+++ b/website/src/components/NewPostTab.test.tsx
@@ -1,54 +1,104 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { vi, beforeEach, test, expect } from 'vitest'
+import { vi, beforeEach, afterEach, test, expect } from 'vitest'
 import NewPostTab from './NewPostTab'
 
 vi.mock('../api/client', () => ({
   apiClient: { createPost: vi.fn() },
 }))
 
+vi.mock('../api/s3Uploader', () => ({
+  uploadImage: vi.fn(),
+}))
+
 import { apiClient } from '../api/client'
+import { uploadImage } from '../api/s3Uploader'
 const mockCreatePost = vi.mocked(apiClient.createPost)
+const mockUploadImage = vi.mocked(uploadImage)
+
+function makeFile() {
+  return new File(['fake-bytes'], 'photo.png', { type: 'image/png' })
+}
 
 beforeEach(() => {
   mockCreatePost.mockReset()
+  mockUploadImage.mockReset()
+  // jsdom doesn't implement object URLs.
+  vi.stubGlobal('URL', {
+    ...URL,
+    createObjectURL: vi.fn(() => 'blob:preview'),
+    revokeObjectURL: vi.fn(),
+  })
+  vi.stubGlobal('localStorage', {
+    getItem: vi.fn(() => 'user-123'),
+    setItem: vi.fn(),
+    removeItem: vi.fn(),
+    clear: vi.fn(),
+  })
 })
 
-test('share button is disabled until both fields are filled', async () => {
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+test('share button is disabled until a photo and caption are provided', async () => {
   render(<NewPostTab onPosted={() => {}} />)
   const button = screen.getByRole('button', { name: 'Share Post' })
   expect(button).toBeDisabled()
 
-  await userEvent.type(screen.getByLabelText('Image URL'), 'http://img/1.jpg')
+  await userEvent.upload(screen.getByLabelText('Choose a photo'), makeFile())
   expect(button).toBeDisabled()
   await userEvent.type(screen.getByLabelText('Caption'), 'great day')
   expect(button).toBeEnabled()
 })
 
-test('creates a post and notifies the parent on success', async () => {
+test('uploads the photo to S3 and creates the post on success', async () => {
+  mockUploadImage.mockResolvedValue(
+    'https://goodvibesonly-images.s3.us-east-2.amazonaws.com/user-123/abc.jpeg',
+  )
   mockCreatePost.mockResolvedValue({ post_identifier: 'p1' })
   const onPosted = vi.fn()
   render(<NewPostTab onPosted={onPosted} />)
 
-  await userEvent.type(screen.getByLabelText('Image URL'), 'http://img/1.jpg')
+  const file = makeFile()
+  await userEvent.upload(screen.getByLabelText('Choose a photo'), file)
   await userEvent.type(screen.getByLabelText('Caption'), 'great day')
   await userEvent.click(screen.getByRole('button', { name: 'Share Post' }))
 
+  await waitFor(() => expect(mockUploadImage).toHaveBeenCalledWith(file, 'user-123'))
   expect(mockCreatePost).toHaveBeenCalledWith({
-    image_url: 'http://img/1.jpg',
+    image_url: 'https://goodvibesonly-images.s3.us-east-2.amazonaws.com/user-123/abc.jpeg',
     caption: 'great day',
   })
   expect(await screen.findByText('Your post was shared successfully!')).toBeInTheDocument()
   expect(onPosted).toHaveBeenCalled()
 })
 
-test('shows an error banner when the post is rejected', async () => {
-  mockCreatePost.mockRejectedValue({ message: 'Text is not positive' })
+test('shows an error when the upload fails', async () => {
+  mockUploadImage.mockRejectedValue({ message: 'Upload failed' })
   render(<NewPostTab onPosted={() => {}} />)
 
-  await userEvent.type(screen.getByLabelText('Image URL'), 'http://img/1.jpg')
-  await userEvent.type(screen.getByLabelText('Caption'), 'negative vibes')
+  await userEvent.upload(screen.getByLabelText('Choose a photo'), makeFile())
+  await userEvent.type(screen.getByLabelText('Caption'), 'great day')
   await userEvent.click(screen.getByRole('button', { name: 'Share Post' }))
 
-  expect(await screen.findByRole('alert')).toHaveTextContent('Text is not positive')
+  expect(await screen.findByRole('alert')).toHaveTextContent('Upload failed')
+  expect(mockCreatePost).not.toHaveBeenCalled()
+})
+
+test('shows an error when there is no signed-in user', async () => {
+  vi.stubGlobal('localStorage', {
+    getItem: vi.fn(() => null),
+    setItem: vi.fn(),
+    removeItem: vi.fn(),
+    clear: vi.fn(),
+  })
+  render(<NewPostTab onPosted={() => {}} />)
+
+  await userEvent.upload(screen.getByLabelText('Choose a photo'), makeFile())
+  await userEvent.type(screen.getByLabelText('Caption'), 'great day')
+  await userEvent.click(screen.getByRole('button', { name: 'Share Post' }))
+
+  expect(await screen.findByRole('alert')).toHaveTextContent('You must be logged in to post.')
+  expect(mockUploadImage).not.toHaveBeenCalled()
 })

--- a/website/src/components/NewPostTab.test.tsx
+++ b/website/src/components/NewPostTab.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { vi, beforeEach, test, expect } from 'vitest'
+import NewPostTab from './NewPostTab'
+
+vi.mock('../api/client', () => ({
+  apiClient: { createPost: vi.fn() },
+}))
+
+import { apiClient } from '../api/client'
+const mockCreatePost = vi.mocked(apiClient.createPost)
+
+beforeEach(() => {
+  mockCreatePost.mockReset()
+})
+
+test('share button is disabled until both fields are filled', async () => {
+  render(<NewPostTab onPosted={() => {}} />)
+  const button = screen.getByRole('button', { name: 'Share Post' })
+  expect(button).toBeDisabled()
+
+  await userEvent.type(screen.getByLabelText('Image URL'), 'http://img/1.jpg')
+  expect(button).toBeDisabled()
+  await userEvent.type(screen.getByLabelText('Caption'), 'great day')
+  expect(button).toBeEnabled()
+})
+
+test('creates a post and notifies the parent on success', async () => {
+  mockCreatePost.mockResolvedValue({ post_identifier: 'p1' })
+  const onPosted = vi.fn()
+  render(<NewPostTab onPosted={onPosted} />)
+
+  await userEvent.type(screen.getByLabelText('Image URL'), 'http://img/1.jpg')
+  await userEvent.type(screen.getByLabelText('Caption'), 'great day')
+  await userEvent.click(screen.getByRole('button', { name: 'Share Post' }))
+
+  expect(mockCreatePost).toHaveBeenCalledWith({
+    image_url: 'http://img/1.jpg',
+    caption: 'great day',
+  })
+  expect(await screen.findByText('Your post was shared successfully!')).toBeInTheDocument()
+  expect(onPosted).toHaveBeenCalled()
+})
+
+test('shows an error banner when the post is rejected', async () => {
+  mockCreatePost.mockRejectedValue({ message: 'Text is not positive' })
+  render(<NewPostTab onPosted={() => {}} />)
+
+  await userEvent.type(screen.getByLabelText('Image URL'), 'http://img/1.jpg')
+  await userEvent.type(screen.getByLabelText('Caption'), 'negative vibes')
+  await userEvent.click(screen.getByRole('button', { name: 'Share Post' }))
+
+  expect(await screen.findByRole('alert')).toHaveTextContent('Text is not positive')
+})

--- a/website/src/components/NewPostTab.tsx
+++ b/website/src/components/NewPostTab.tsx
@@ -1,0 +1,115 @@
+import { useState, type FormEvent } from 'react'
+import { apiClient } from '../api/client'
+import type { ApiError } from '../api/client'
+
+interface NewPostTabProps {
+  /** Called after a successful post so the shell can switch back to the Home tab. */
+  onPosted: () => void
+}
+
+/**
+ * The "Post" tab: create a new post from an image URL and caption. The native
+ * apps upload a picked photo to S3 first; the web build has no uploader, so it
+ * takes the hosted image URL directly (matching the backend's `image_url`
+ * field). Mirrors iOS NewPostView (preview, share button, success/failure).
+ */
+function NewPostTab({ onPosted }: NewPostTabProps) {
+  const [imageUrl, setImageUrl] = useState('')
+  const [caption, setCaption] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [successMessage, setSuccessMessage] = useState<string | null>(null)
+
+  const isFormValid = imageUrl.trim().length > 0 && caption.trim().length > 0
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    if (!isFormValid) return
+    setIsLoading(true)
+    setErrorMessage(null)
+    setSuccessMessage(null)
+    try {
+      await apiClient.createPost({ image_url: imageUrl.trim(), caption: caption.trim() })
+      setImageUrl('')
+      setCaption('')
+      setSuccessMessage('Your post was shared successfully!')
+      onPosted()
+    } catch (err) {
+      const apiErr = err as ApiError
+      setErrorMessage(apiErr.message ?? 'Failed to share post.')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <form className="form-section" onSubmit={handleSubmit} noValidate>
+      {errorMessage && (
+        <div className="auth-error" role="alert">
+          <p>{errorMessage}</p>
+          <button
+            type="button"
+            className="auth-error__dismiss"
+            aria-label="Dismiss error"
+            onClick={() => setErrorMessage(null)}
+          >
+            ✕
+          </button>
+        </div>
+      )}
+
+      {successMessage && (
+        <div className="auth-success" role="status">
+          {successMessage}
+        </div>
+      )}
+
+      <div className="auth-field">
+        <label className="auth-label" htmlFor="imageUrl">
+          Image URL
+        </label>
+        <input
+          id="imageUrl"
+          className="search-bar"
+          type="url"
+          inputMode="url"
+          autoCapitalize="none"
+          placeholder="https://example.com/photo.jpg"
+          value={imageUrl}
+          onChange={e => setImageUrl(e.target.value)}
+          disabled={isLoading}
+        />
+      </div>
+
+      {imageUrl.trim().length > 0 && (
+        <img className="form-section__preview" src={imageUrl} alt="Selected post preview" />
+      )}
+
+      <div className="auth-field">
+        <label className="auth-label" htmlFor="caption">
+          Caption
+        </label>
+        <textarea
+          id="caption"
+          className="text-area"
+          rows={4}
+          value={caption}
+          onChange={e => setCaption(e.target.value)}
+          disabled={isLoading}
+        />
+      </div>
+
+      {isLoading ? (
+        <div className="center-spinner">
+          <span className="spinner" />
+        </div>
+      ) : (
+        <button type="submit" className="btn btn-primary" disabled={!isFormValid}>
+          Share Post
+        </button>
+      )}
+    </form>
+  )
+}
+
+export default NewPostTab

--- a/website/src/components/NewPostTab.tsx
+++ b/website/src/components/NewPostTab.tsx
@@ -1,6 +1,8 @@
-import { useState, type FormEvent } from 'react'
+import { useEffect, useState, type FormEvent } from 'react'
 import { apiClient } from '../api/client'
 import type { ApiError } from '../api/client'
+import { getCurrentUserId } from '../api/session'
+import { uploadImage } from '../api/s3Uploader'
 
 interface NewPostTabProps {
   /** Called after a successful post so the shell can switch back to the Home tab. */
@@ -8,29 +10,52 @@ interface NewPostTabProps {
 }
 
 /**
- * The "Post" tab: create a new post from an image URL and caption. The native
- * apps upload a picked photo to S3 first; the web build has no uploader, so it
- * takes the hosted image URL directly (matching the backend's `image_url`
- * field). Mirrors iOS NewPostView (preview, share button, success/failure).
+ * The "Post" tab: pick a photo and write a caption. The photo is uploaded to S3
+ * (scoped to the signed-in user) and the resulting URL is sent to the backend,
+ * mirroring iOS NewPostView (photo picker, preview, share button, success/
+ * failure handling).
  */
 function NewPostTab({ onPosted }: NewPostTabProps) {
-  const [imageUrl, setImageUrl] = useState('')
+  const [file, setFile] = useState<File | null>(null)
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null)
   const [caption, setCaption] = useState('')
   const [isLoading, setIsLoading] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [successMessage, setSuccessMessage] = useState<string | null>(null)
 
-  const isFormValid = imageUrl.trim().length > 0 && caption.trim().length > 0
+  // Revoke the preview object URL when it changes or the component unmounts.
+  // (The URL is created in handleFileChange, not here, to avoid a synchronous
+  // setState inside the effect.)
+  useEffect(() => {
+    if (!previewUrl) return
+    return () => URL.revokeObjectURL(previewUrl)
+  }, [previewUrl])
+
+  function handleFileChange(next: File | null) {
+    setFile(next)
+    setPreviewUrl(next ? URL.createObjectURL(next) : null)
+  }
+
+  const isFormValid = file !== null && caption.trim().length > 0
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault()
-    if (!isFormValid) return
+    if (!isFormValid || !file) return
+
+    const userId = getCurrentUserId()
+    if (!userId) {
+      setErrorMessage('You must be logged in to post.')
+      return
+    }
+
     setIsLoading(true)
     setErrorMessage(null)
     setSuccessMessage(null)
     try {
-      await apiClient.createPost({ image_url: imageUrl.trim(), caption: caption.trim() })
-      setImageUrl('')
+      const imageUrl = await uploadImage(file, userId)
+      await apiClient.createPost({ image_url: imageUrl, caption: caption.trim() })
+      setFile(null)
+      setPreviewUrl(null)
       setCaption('')
       setSuccessMessage('Your post was shared successfully!')
       onPosted()
@@ -65,24 +90,22 @@ function NewPostTab({ onPosted }: NewPostTabProps) {
       )}
 
       <div className="auth-field">
-        <label className="auth-label" htmlFor="imageUrl">
-          Image URL
+        <label className="auth-label" htmlFor="photo">
+          Photo
         </label>
         <input
-          id="imageUrl"
+          id="photo"
           className="search-bar"
-          type="url"
-          inputMode="url"
-          autoCapitalize="none"
-          placeholder="https://example.com/photo.jpg"
-          value={imageUrl}
-          onChange={e => setImageUrl(e.target.value)}
+          type="file"
+          accept="image/*"
+          aria-label="Choose a photo"
+          onChange={e => handleFileChange(e.target.files?.[0] ?? null)}
           disabled={isLoading}
         />
       </div>
 
-      {imageUrl.trim().length > 0 && (
-        <img className="form-section__preview" src={imageUrl} alt="Selected post preview" />
+      {previewUrl && (
+        <img className="form-section__preview" src={previewUrl} alt="Selected post preview" />
       )}
 
       <div className="auth-field">

--- a/website/src/components/SettingsTab.test.tsx
+++ b/website/src/components/SettingsTab.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { vi, beforeEach, afterEach, test, expect } from 'vitest'
+import SettingsTab from './SettingsTab'
+
+vi.mock('../api/client', () => ({
+  apiClient: {
+    logout: vi.fn(),
+    deleteAccount: vi.fn(),
+    verifyIdentity: vi.fn(),
+    setToken: vi.fn(),
+  },
+}))
+
+import { apiClient } from '../api/client'
+const mockLogout = vi.mocked(apiClient.logout)
+const mockDelete = vi.mocked(apiClient.deleteAccount)
+const mockVerify = vi.mocked(apiClient.verifyIdentity)
+
+function renderTab() {
+  return render(
+    <MemoryRouter initialEntries={['/home']}>
+      <Routes>
+        <Route path="/home" element={<SettingsTab />} />
+        <Route path="/" element={<div>Landing page</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  mockLogout.mockReset().mockResolvedValue({ message: 'ok' })
+  mockDelete.mockReset().mockResolvedValue({ message: 'ok' })
+  mockVerify.mockReset().mockResolvedValue({ message: 'ok' })
+  vi.stubGlobal('localStorage', {
+    getItem: vi.fn(),
+    setItem: vi.fn(),
+    removeItem: vi.fn(),
+    clear: vi.fn(),
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+test('logout requires confirmation then signs out', async () => {
+  renderTab()
+  await userEvent.click(screen.getByRole('button', { name: 'Logout' }))
+  // Confirm dialog appears.
+  await userEvent.click(
+    screen.getByRole('dialog', { name: /log out/i }).querySelector('.modal__confirm')!,
+  )
+  expect(mockLogout).toHaveBeenCalled()
+  expect(await screen.findByText('Landing page')).toBeInTheDocument()
+})
+
+test('delete account requires confirmation then deletes', async () => {
+  renderTab()
+  await userEvent.click(screen.getByRole('button', { name: 'Delete Account' }))
+  await userEvent.click(
+    screen.getByRole('dialog', { name: /delete your account/i }).querySelector('.modal__confirm')!,
+  )
+  expect(mockDelete).toHaveBeenCalled()
+  expect(await screen.findByText('Landing page')).toBeInTheDocument()
+})
+
+test('verify identity submits the date of birth', async () => {
+  renderTab()
+  await userEvent.click(screen.getByRole('button', { name: 'Verify Identity' }))
+  await userEvent.type(screen.getByLabelText('Date of birth'), '1990-01-01')
+  await userEvent.click(screen.getByRole('button', { name: 'Verify' }))
+  expect(mockVerify).toHaveBeenCalledWith('1990-01-01')
+  expect(await screen.findByText('Identity verified successfully!')).toBeInTheDocument()
+})
+
+test('privacy policy can be shown', async () => {
+  renderTab()
+  await userEvent.click(screen.getByRole('button', { name: 'Privacy Policy' }))
+  expect(screen.getByRole('dialog', { name: 'Privacy Policy' })).toBeInTheDocument()
+})

--- a/website/src/components/SettingsTab.tsx
+++ b/website/src/components/SettingsTab.tsx
@@ -1,0 +1,200 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { apiClient } from '../api/client'
+import { clearSession } from '../api/session'
+import { PRIVACY_POLICY_TEXT } from '../pages/RegisterPage'
+
+type ActiveModal = 'logout' | 'delete' | 'verify' | 'privacy' | null
+
+const CONTACT_EMAIL = 'katsonsoftware@gmail.com'
+
+/**
+ * The "Settings" tab: contact info, logout, identity verification, privacy
+ * policy, and account deletion — with confirmation dialogs. Mirrors iOS
+ * SettingsView / SettingsViewModel.
+ */
+function SettingsTab() {
+  const navigate = useNavigate()
+  const [activeModal, setActiveModal] = useState<ActiveModal>(null)
+  const [dateOfBirth, setDateOfBirth] = useState('')
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [infoMessage, setInfoMessage] = useState<string | null>(null)
+
+  const close = () => setActiveModal(null)
+
+  async function handleLogout() {
+    close()
+    try {
+      await apiClient.logout()
+    } catch {
+      // Even if the backend call fails, log out locally (mirrors the native apps).
+    }
+    clearSession()
+    navigate('/')
+  }
+
+  async function handleDelete() {
+    close()
+    try {
+      await apiClient.deleteAccount()
+      clearSession()
+      navigate('/')
+    } catch {
+      setErrorMessage('Failed to delete account. Please try again.')
+    }
+  }
+
+  async function handleVerify() {
+    close()
+    try {
+      await apiClient.verifyIdentity(dateOfBirth)
+      setInfoMessage('Identity verified successfully!')
+    } catch {
+      setErrorMessage('Verification failed. Please check your date of birth.')
+    }
+  }
+
+  return (
+    <div className="settings-list">
+      {errorMessage && (
+        <div className="auth-error" role="alert">
+          <p>{errorMessage}</p>
+          <button
+            type="button"
+            className="auth-error__dismiss"
+            aria-label="Dismiss error"
+            onClick={() => setErrorMessage(null)}
+          >
+            ✕
+          </button>
+        </div>
+      )}
+      {infoMessage && (
+        <div className="auth-success" role="status">
+          {infoMessage}
+        </div>
+      )}
+
+      <div className="settings-group">
+        <span className="settings-group__header">Contact Information</span>
+        <div className="settings-row settings-row--static">{CONTACT_EMAIL}</div>
+      </div>
+
+      <div className="settings-group">
+        <button
+          type="button"
+          className="settings-row settings-row--destructive"
+          onClick={() => setActiveModal('logout')}
+        >
+          Logout
+        </button>
+        <button
+          type="button"
+          className="settings-row settings-row--action"
+          onClick={() => setActiveModal('verify')}
+        >
+          Verify Identity
+        </button>
+        <button
+          type="button"
+          className="settings-row"
+          onClick={() => setActiveModal('privacy')}
+        >
+          Privacy Policy
+        </button>
+      </div>
+
+      <div className="settings-group">
+        <span className="settings-group__header">Account Actions</span>
+        <button
+          type="button"
+          className="settings-row settings-row--destructive"
+          onClick={() => setActiveModal('delete')}
+        >
+          Delete Account
+        </button>
+      </div>
+
+      {activeModal === 'logout' && (
+        <Modal title="Are you sure you want to log out?">
+          <div className="modal__actions">
+            <button type="button" className="modal__cancel" onClick={close}>
+              Cancel
+            </button>
+            <button type="button" className="modal__confirm" onClick={handleLogout}>
+              Logout
+            </button>
+          </div>
+        </Modal>
+      )}
+
+      {activeModal === 'delete' && (
+        <Modal title="Delete Your Account?" body="This action is permanent and cannot be undone.">
+          <div className="modal__actions">
+            <button type="button" className="modal__cancel" onClick={close}>
+              Cancel
+            </button>
+            <button type="button" className="modal__confirm" onClick={handleDelete}>
+              Delete
+            </button>
+          </div>
+        </Modal>
+      )}
+
+      {activeModal === 'verify' && (
+        <Modal title="Verify Identity" body="Please enter your date of birth.">
+          <input
+            className="search-bar"
+            type="date"
+            aria-label="Date of birth"
+            value={dateOfBirth}
+            onChange={e => setDateOfBirth(e.target.value)}
+          />
+          <div className="modal__actions">
+            <button type="button" className="modal__cancel" onClick={close}>
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="modal__confirm"
+              disabled={dateOfBirth.length === 0}
+              onClick={handleVerify}
+            >
+              Verify
+            </button>
+          </div>
+        </Modal>
+      )}
+
+      {activeModal === 'privacy' && (
+        <Modal title="Privacy Policy" body={PRIVACY_POLICY_TEXT}>
+          <div className="modal__actions">
+            <button type="button" className="modal__confirm" onClick={close}>
+              Ok
+            </button>
+          </div>
+        </Modal>
+      )}
+    </div>
+  )
+}
+
+interface ModalProps {
+  title: string
+  body?: string
+  children: React.ReactNode
+}
+
+function Modal({ title, body, children }: ModalProps) {
+  return (
+    <div className="modal-overlay">
+      <div className="modal" role="dialog" aria-modal="true" aria-label={title}>
+        <h2 className="modal__title">{title}</h2>
+        {body && <p className="modal__body">{body}</p>}
+        {children}
+      </div>
+    </div>
+  )
+}
+
+export default SettingsTab

--- a/website/src/components/SettingsTab.tsx
+++ b/website/src/components/SettingsTab.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, type ReactNode } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { apiClient } from '../api/client'
 import { clearSession } from '../api/session'
@@ -182,7 +182,7 @@ function SettingsTab() {
 interface ModalProps {
   title: string
   body?: string
-  children: React.ReactNode
+  children: ReactNode
 }
 
 function Modal({ title, body, children }: ModalProps) {

--- a/website/src/main.tsx
+++ b/website/src/main.tsx
@@ -2,7 +2,15 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import App from './App'
+import { apiClient } from './api/client'
 import './index.css'
+
+// Restore the session token persisted at login so a page reload keeps the user
+// authenticated (the ApiClient otherwise only holds the token in memory).
+const storedToken = localStorage.getItem('session_token')
+if (storedToken) {
+  apiClient.setToken(storedToken)
+}
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/website/src/pages/HomePage.test.tsx
+++ b/website/src/pages/HomePage.test.tsx
@@ -1,7 +1,76 @@
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { vi, beforeEach, afterEach, test, expect } from 'vitest'
 import HomePage from './HomePage'
 
-test('renders Home View placeholder', () => {
-  render(<HomePage />)
-  expect(screen.getByRole('heading', { name: 'Home View' })).toBeInTheDocument()
+vi.mock('../api/client', () => ({
+  apiClient: {
+    isAuthenticated: vi.fn(() => true),
+    getPostsForUser: vi.fn().mockResolvedValue([]),
+    searchUsers: vi.fn().mockResolvedValue([]),
+    getFeed: vi.fn().mockResolvedValue([]),
+    getFollowedFeed: vi.fn().mockResolvedValue([]),
+    logout: vi.fn().mockResolvedValue({ message: 'ok' }),
+    deleteAccount: vi.fn().mockResolvedValue({ message: 'ok' }),
+    verifyIdentity: vi.fn().mockResolvedValue({ message: 'ok' }),
+    setToken: vi.fn(),
+  },
+}))
+
+import { apiClient } from '../api/client'
+const mockIsAuthenticated = vi.mocked(apiClient.isAuthenticated)
+
+function renderHome() {
+  return render(
+    <MemoryRouter initialEntries={['/home']}>
+      <Routes>
+        <Route path="/home" element={<HomePage />} />
+        <Route path="/login" element={<div>Login page</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  mockIsAuthenticated.mockReturnValue(true)
+  vi.stubGlobal('localStorage', {
+    getItem: vi.fn(() => 'ada'),
+    setItem: vi.fn(),
+    removeItem: vi.fn(),
+    clear: vi.fn(),
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+test('renders the Home tab title and bottom navigation', () => {
+  renderHome()
+  expect(screen.getByRole('heading', { name: 'Your Posts' })).toBeInTheDocument()
+  expect(screen.getByRole('button', { name: /Home/ })).toBeInTheDocument()
+  expect(screen.getByRole('button', { name: /Feed/ })).toBeInTheDocument()
+  expect(screen.getByRole('button', { name: /Post/ })).toBeInTheDocument()
+  expect(screen.getByRole('button', { name: /Settings/ })).toBeInTheDocument()
+})
+
+test('switches to the Feed tab', async () => {
+  renderHome()
+  await userEvent.click(screen.getByRole('button', { name: /Feed/ }))
+  expect(screen.getByRole('heading', { name: 'Feed' })).toBeInTheDocument()
+  expect(screen.getByRole('tab', { name: 'For You' })).toBeInTheDocument()
+})
+
+test('switches to the Settings tab', async () => {
+  renderHome()
+  await userEvent.click(screen.getByRole('button', { name: /Settings/ }))
+  expect(screen.getByRole('heading', { name: 'Settings' })).toBeInTheDocument()
+  expect(screen.getByRole('button', { name: 'Logout' })).toBeInTheDocument()
+})
+
+test('redirects to login when not authenticated', () => {
+  mockIsAuthenticated.mockReturnValue(false)
+  renderHome()
+  expect(screen.getByText('Login page')).toBeInTheDocument()
 })

--- a/website/src/pages/HomePage.tsx
+++ b/website/src/pages/HomePage.tsx
@@ -1,7 +1,72 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import MyPostsTab from '../components/MyPostsTab'
+import FeedTab from '../components/FeedTab'
+import NewPostTab from '../components/NewPostTab'
+import SettingsTab from '../components/SettingsTab'
+import { apiClient } from '../api/client'
+import './MainApp.css'
+
+type Tab = 'home' | 'feed' | 'post' | 'settings'
+
+const TAB_TITLES: Record<Tab, string> = {
+  home: 'Your Posts',
+  feed: 'Feed',
+  post: 'Create Post',
+  settings: 'Settings',
+}
+
+const TABS: { id: Tab; label: string; icon: string }[] = [
+  { id: 'home', label: 'Home', icon: '🏠' },
+  { id: 'feed', label: 'Feed', icon: '📰' },
+  { id: 'post', label: 'Post', icon: '➕' },
+  { id: 'settings', label: 'Settings', icon: '⚙️' },
+]
+
+/**
+ * The signed-in app shell: a bottom tab bar switching between the My Posts grid,
+ * the Feed, New Post creation, and Settings. Mirrors the iOS HomeView TabView.
+ */
 function HomePage() {
+  const navigate = useNavigate()
+  const [tab, setTab] = useState<Tab>('home')
+
+  // Guard the authenticated surface: bounce to login if there's no session.
+  useEffect(() => {
+    if (!apiClient.isAuthenticated()) {
+      navigate('/login', { replace: true })
+    }
+  }, [navigate])
+
   return (
-    <div>
-      <h1>Home View</h1>
+    <div className="app-shell">
+      <header className="app-bar">
+        <h1 className="app-bar__title">{TAB_TITLES[tab]}</h1>
+      </header>
+
+      <main className="app-content">
+        {tab === 'home' && <MyPostsTab />}
+        {tab === 'feed' && <FeedTab />}
+        {tab === 'post' && <NewPostTab onPosted={() => setTab('home')} />}
+        {tab === 'settings' && <SettingsTab />}
+      </main>
+
+      <nav className="tab-bar" aria-label="Main navigation">
+        {TABS.map(({ id, label, icon }) => (
+          <button
+            key={id}
+            type="button"
+            className={`tab-bar__item${tab === id ? ' tab-bar__item--active' : ''}`}
+            aria-current={tab === id ? 'page' : undefined}
+            onClick={() => setTab(id)}
+          >
+            <span className="tab-bar__icon" aria-hidden="true">
+              {icon}
+            </span>
+            {label}
+          </button>
+        ))}
+      </nav>
     </div>
   )
 }

--- a/website/src/pages/MainApp.css
+++ b/website/src/pages/MainApp.css
@@ -1,0 +1,696 @@
+/* ============================================================
+   Shared styles for the authenticated app surface:
+   HomePage shell + tabs, PostDetailPage, ProfilePage.
+   Mirrors the dark theme used by the auth pages (LoginPage.css).
+   ============================================================ */
+
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background-color: #000000;
+  color: #ffffff;
+}
+
+/* ---- Top bar ---- */
+
+.app-bar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.85rem 1rem;
+  background: #000000;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.app-bar__title {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 700;
+  flex: 1;
+}
+
+.app-bar__back {
+  background: none;
+  border: none;
+  color: #5ba4dc;
+  font-size: 0.95rem;
+  cursor: pointer;
+  padding: 0;
+}
+
+.app-bar__back:hover {
+  opacity: 0.8;
+}
+
+/* ---- Content area (scrolls above the bottom tab bar) ---- */
+
+.app-content {
+  flex: 1;
+  width: 100%;
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 1rem;
+  box-sizing: border-box;
+  padding-bottom: 5.5rem;
+}
+
+/* ---- Bottom tab bar ---- */
+
+.tab-bar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  background: #0d0d0d;
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+  z-index: 20;
+}
+
+.tab-bar__item {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.2rem;
+  padding: 0.55rem 0 0.7rem;
+  background: none;
+  border: none;
+  color: rgba(255, 255, 255, 0.55);
+  font-size: 0.72rem;
+  cursor: pointer;
+  transition: color 0.15s ease;
+}
+
+.tab-bar__item--active {
+  color: #5ba4dc;
+}
+
+.tab-bar__icon {
+  font-size: 1.25rem;
+  line-height: 1;
+}
+
+/* ---- Search bar ---- */
+
+.search-bar {
+  width: 100%;
+  background: #1a1a1a;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 10px;
+  color: #ffffff;
+  padding: 0.7rem 1rem;
+  font-size: 1rem;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+}
+
+.search-bar:focus {
+  outline: none;
+  border-color: #5ba4dc;
+}
+
+/* ---- Post grid (My Posts, Profile) ---- */
+
+.post-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 3px;
+}
+
+.post-grid__cell {
+  position: relative;
+  aspect-ratio: 1 / 1;
+  background: #1a1a1a;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  overflow: hidden;
+}
+
+.post-grid__cell img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+/* ---- User search results ---- */
+
+.user-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.user-list__item {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.75rem 0.25rem;
+  background: none;
+  border: none;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  color: #ffffff;
+  font-size: 1rem;
+  cursor: pointer;
+  text-align: left;
+}
+
+.user-list__item:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.user-list__avatar {
+  font-size: 1.6rem;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.user-list__name {
+  font-weight: 600;
+}
+
+.verified-badge {
+  color: #5ba4dc;
+}
+
+/* ---- Segmented control (Feed tabs) ---- */
+
+.segmented {
+  display: flex;
+  background: #1a1a1a;
+  border-radius: 10px;
+  padding: 3px;
+  margin-bottom: 1rem;
+}
+
+.segmented__option {
+  flex: 1;
+  background: none;
+  border: none;
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 0.95rem;
+  font-weight: 600;
+  padding: 0.5rem;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.segmented__option--active {
+  background: #5ba4dc;
+  color: #ffffff;
+}
+
+/* ---- Feed list ---- */
+
+.feed-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.feed-post__author {
+  background: none;
+  border: none;
+  color: #ffffff;
+  font-weight: 700;
+  font-size: 1rem;
+  cursor: pointer;
+  padding: 0 0 0.5rem;
+}
+
+.feed-post__author:hover {
+  color: #5ba4dc;
+}
+
+.feed-post__image {
+  width: 100%;
+  border: none;
+  background: #1a1a1a;
+  padding: 0;
+  cursor: pointer;
+  border-radius: 10px;
+  overflow: hidden;
+  display: block;
+}
+
+.feed-post__image img {
+  width: 100%;
+  display: block;
+}
+
+/* ---- Generic helpers ---- */
+
+.muted {
+  color: rgba(255, 255, 255, 0.55);
+  text-align: center;
+  padding: 2rem 0;
+}
+
+.load-more {
+  margin: 1.25rem auto 0;
+  display: block;
+  background: none;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 8px;
+  color: rgba(255, 255, 255, 0.8);
+  padding: 0.55rem 1.25rem;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+.load-more:hover {
+  border-color: #5ba4dc;
+  color: #ffffff;
+}
+
+.center-spinner {
+  display: flex;
+  justify-content: center;
+  padding: 2rem 0;
+}
+
+.spinner {
+  display: inline-block;
+  width: 28px;
+  height: 28px;
+  border: 3px solid rgba(91, 164, 220, 0.3);
+  border-top-color: #5ba4dc;
+  border-radius: 50%;
+  animation: spin 0.75s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* ---- Form (New Post) ---- */
+
+.form-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.form-section .btn {
+  width: 100%;
+}
+
+.auth-success {
+  padding: 0.85rem 1rem;
+  background: rgba(91, 164, 220, 0.15);
+  border: 1px solid rgba(91, 164, 220, 0.4);
+  border-radius: 10px;
+  color: #9ccbee;
+  font-size: 0.9rem;
+}
+
+.form-section__preview {
+  width: 100%;
+  max-height: 320px;
+  object-fit: contain;
+  border-radius: 10px;
+  background: #1a1a1a;
+}
+
+.text-area {
+  background: #1a1a1a;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 10px;
+  color: #ffffff;
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  font-family: inherit;
+  width: 100%;
+  box-sizing: border-box;
+  resize: vertical;
+}
+
+.text-area:focus {
+  outline: none;
+  border-color: #5ba4dc;
+}
+
+/* ---- Settings list ---- */
+
+.settings-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.settings-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.settings-group__header {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.settings-row {
+  background: #1a1a1a;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  color: #ffffff;
+  font-size: 1rem;
+  text-align: left;
+  padding: 0.85rem 1rem;
+  cursor: pointer;
+  width: 100%;
+}
+
+.settings-row:hover {
+  border-color: rgba(255, 255, 255, 0.25);
+}
+
+.settings-row--static {
+  cursor: default;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.settings-row--static:hover {
+  border-color: rgba(255, 255, 255, 0.1);
+}
+
+.settings-row--action {
+  color: #5ba4dc;
+}
+
+.settings-row--destructive {
+  color: #ff6b6b;
+}
+
+/* ---- Modal overlay (shared by Settings dialogs) ---- */
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  z-index: 100;
+}
+
+.modal {
+  background: #1a1a1a;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 16px;
+  padding: 1.75rem;
+  max-width: 480px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.modal__title {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: #ffffff;
+}
+
+.modal__body {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.55;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.modal__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.modal__cancel {
+  background: none;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 8px;
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 0.95rem;
+  padding: 0.55rem 1.2rem;
+  cursor: pointer;
+}
+
+.modal__cancel:hover {
+  border-color: rgba(255, 255, 255, 0.4);
+}
+
+.modal__confirm {
+  background: #5ba4dc;
+  border: none;
+  border-radius: 8px;
+  color: #ffffff;
+  font-size: 0.95rem;
+  font-weight: 600;
+  padding: 0.55rem 1.2rem;
+  cursor: pointer;
+}
+
+.modal__confirm:hover {
+  opacity: 0.85;
+}
+
+.modal__confirm:disabled {
+  background: #444;
+  cursor: not-allowed;
+}
+
+/* ---- Error/dismiss banner (shared with auth pages) ---- */
+
+.auth-error {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.85rem 1rem;
+  background: rgba(220, 50, 50, 0.18);
+  border: 1px solid rgba(220, 50, 50, 0.4);
+  border-radius: 10px;
+  color: #ff6b6b;
+  font-size: 0.9rem;
+}
+
+.auth-error p {
+  margin: 0;
+  flex: 1;
+}
+
+.auth-error__dismiss {
+  background: none;
+  border: none;
+  color: #ff6b6b;
+  cursor: pointer;
+  font-size: 0.85rem;
+  padding: 0;
+  line-height: 1;
+}
+
+.auth-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.auth-label {
+  font-size: 0.875rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+/* ---- Profile header ---- */
+
+.profile-header {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  margin-bottom: 1rem;
+}
+
+.profile-stats {
+  display: flex;
+  justify-content: space-around;
+  text-align: center;
+}
+
+.profile-stat__count {
+  font-size: 1.15rem;
+  font-weight: 700;
+  display: block;
+}
+
+.profile-stat__label {
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.profile-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.btn {
+  flex: 1;
+  padding: 0.6rem;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: opacity 0.15s ease;
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn-primary {
+  background: #5ba4dc;
+  border: 1px solid #5ba4dc;
+  color: #ffffff;
+}
+
+.btn-outline {
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  color: #ffffff;
+}
+
+.btn-danger {
+  background: transparent;
+  border: 1px solid #ff6b6b;
+  color: #ff6b6b;
+}
+
+.btn-danger--filled {
+  background: #ff6b6b;
+  color: #ffffff;
+}
+
+/* ---- Post detail ---- */
+
+.detail-image {
+  width: 100%;
+  border-radius: 12px;
+  background: #1a1a1a;
+  cursor: pointer;
+  display: block;
+}
+
+.detail-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0.75rem 0 0.25rem;
+}
+
+.detail-likes {
+  font-weight: 700;
+}
+
+.heart {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1.1rem;
+  padding: 0;
+  color: #ff5a5f;
+}
+
+.flag-icon {
+  color: #ff6b6b;
+}
+
+.detail-caption {
+  margin: 0 0 1rem;
+  line-height: 1.5;
+}
+
+.detail-caption__author {
+  font-weight: 700;
+  margin-right: 0.4rem;
+}
+
+.comment-form {
+  display: flex;
+  gap: 0.5rem;
+  margin: 1rem 0;
+}
+
+.comment-form input {
+  flex: 1;
+  background: #1a1a1a;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 10px;
+  color: #ffffff;
+  padding: 0.6rem 0.9rem;
+  font-size: 0.95rem;
+}
+
+.comment-form input:focus {
+  outline: none;
+  border-color: #5ba4dc;
+}
+
+.comment-thread {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 0.85rem 0;
+}
+
+.comment-row {
+  display: flex;
+  gap: 0.6rem;
+  cursor: pointer;
+}
+
+.comment-row__avatar {
+  font-size: 1.4rem;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.comment-row__author {
+  font-weight: 700;
+  font-size: 0.9rem;
+  margin-right: 0.35rem;
+}
+
+.comment-row__body {
+  font-size: 0.9rem;
+}
+
+.comment-row__info {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  margin-top: 0.3rem;
+  font-size: 0.78rem;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.comment-replies {
+  margin-left: 2rem;
+}
+
+.comment-reply-btn {
+  background: none;
+  border: none;
+  color: #5ba4dc;
+  font-size: 0.78rem;
+  font-weight: 700;
+  cursor: pointer;
+  padding: 0.25rem 0 0 2rem;
+}

--- a/website/src/pages/PostDetailPage.test.tsx
+++ b/website/src/pages/PostDetailPage.test.tsx
@@ -7,6 +7,7 @@ import type { Comment, PostDetails } from '../api/types'
 
 vi.mock('../api/client', () => ({
   apiClient: {
+    isAuthenticated: vi.fn(() => true),
     getPostDetails: vi.fn(),
     getCommentsForPost: vi.fn(),
     getCommentsForThread: vi.fn(),
@@ -110,4 +111,17 @@ test('still shows the post when only the comments fail to load', async () => {
   expect(await screen.findByText('sunshine')).toBeInTheDocument()
   expect(screen.queryByText('Post not found.')).not.toBeInTheDocument()
   expect(await screen.findByText('Failed to load comments.')).toBeInTheDocument()
+})
+
+test('redirects to login when unauthenticated', () => {
+  vi.mocked(apiClient.isAuthenticated).mockReturnValueOnce(false)
+  render(
+    <MemoryRouter initialEntries={['/post/p1']}>
+      <Routes>
+        <Route path="/post/:postId" element={<PostDetailPage />} />
+        <Route path="/login" element={<div>Login page</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+  expect(screen.getByText('Login page')).toBeInTheDocument()
 })

--- a/website/src/pages/PostDetailPage.test.tsx
+++ b/website/src/pages/PostDetailPage.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { vi, beforeEach, test, expect } from 'vitest'
+import PostDetailPage from './PostDetailPage'
+import type { Comment, PostDetails } from '../api/types'
+
+vi.mock('../api/client', () => ({
+  apiClient: {
+    getPostDetails: vi.fn(),
+    getCommentsForPost: vi.fn(),
+    getCommentsForThread: vi.fn(),
+    likePost: vi.fn(),
+    unlikePost: vi.fn(),
+    reportPost: vi.fn(),
+    commentOnPost: vi.fn(),
+    replyToCommentThread: vi.fn(),
+    likeComment: vi.fn(),
+    unlikeComment: vi.fn(),
+    reportComment: vi.fn(),
+  },
+}))
+
+import { apiClient } from '../api/client'
+const mockGetDetails = vi.mocked(apiClient.getPostDetails)
+const mockGetThreadRefs = vi.mocked(apiClient.getCommentsForPost)
+const mockGetThreadComments = vi.mocked(apiClient.getCommentsForThread)
+const mockLikePost = vi.mocked(apiClient.likePost)
+const mockCommentOnPost = vi.mocked(apiClient.commentOnPost)
+
+const post: PostDetails = {
+  post_identifier: 'p1',
+  image_url: 'http://img/1.jpg',
+  caption: 'sunshine',
+  post_likes: 3,
+  author_username: 'ada',
+}
+
+const comment: Comment = {
+  comment_identifier: 'c1',
+  body: 'love this',
+  author_username: 'bob',
+  creation_time: '2024-01-01T00:00:00.000Z',
+  updated_time: '2024-01-01T00:00:00.000Z',
+  comment_likes: 1,
+}
+
+function renderDetail() {
+  return render(
+    <MemoryRouter initialEntries={['/post/p1']}>
+      <Routes>
+        <Route path="/post/:postId" element={<PostDetailPage />} />
+        <Route path="/profile/:username" element={<div>Profile page</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  mockGetDetails.mockReset().mockResolvedValue(post)
+  mockGetThreadRefs.mockReset().mockResolvedValue([])
+  mockGetThreadComments.mockReset().mockResolvedValue([])
+  mockLikePost.mockReset().mockResolvedValue({ message: 'ok' })
+  mockCommentOnPost.mockReset().mockResolvedValue({
+    comment_thread_identifier: 't1',
+    comment_identifier: 'c9',
+  })
+})
+
+test('renders the post caption and like count', async () => {
+  renderDetail()
+  expect(await screen.findByText('sunshine')).toBeInTheDocument()
+  expect(screen.getByText('3 likes')).toBeInTheDocument()
+})
+
+test('liking the post calls the API and bumps the count optimistically', async () => {
+  renderDetail()
+  await screen.findByText('sunshine')
+  await userEvent.click(screen.getByRole('button', { name: 'Like post' }))
+  expect(screen.getByText('4 likes')).toBeInTheDocument()
+  await waitFor(() => expect(mockLikePost).toHaveBeenCalledWith('p1'))
+})
+
+test('renders comment threads', async () => {
+  mockGetThreadRefs.mockResolvedValue([{ comment_thread_identifier: 't1' }])
+  mockGetThreadComments.mockResolvedValue([comment])
+  renderDetail()
+  expect(await screen.findByText('love this')).toBeInTheDocument()
+  expect(screen.getByText('bob')).toBeInTheDocument()
+})
+
+test('posting a comment calls the API and reloads', async () => {
+  renderDetail()
+  await screen.findByText('sunshine')
+  await userEvent.type(screen.getByLabelText('Add a comment'), 'nice!')
+  await userEvent.click(screen.getByRole('button', { name: 'Post' }))
+  await waitFor(() => expect(mockCommentOnPost).toHaveBeenCalledWith('p1', 'nice!'))
+})
+
+test('shows not-found when the post fails to load', async () => {
+  mockGetDetails.mockRejectedValue(new Error('404'))
+  renderDetail()
+  expect(await screen.findByText('Post not found.')).toBeInTheDocument()
+})

--- a/website/src/pages/PostDetailPage.test.tsx
+++ b/website/src/pages/PostDetailPage.test.tsx
@@ -102,3 +102,12 @@ test('shows not-found when the post fails to load', async () => {
   renderDetail()
   expect(await screen.findByText('Post not found.')).toBeInTheDocument()
 })
+
+test('still shows the post when only the comments fail to load', async () => {
+  mockGetThreadRefs.mockRejectedValue(new Error('network'))
+  renderDetail()
+  // The post itself loaded, so it renders rather than the not-found state.
+  expect(await screen.findByText('sunshine')).toBeInTheDocument()
+  expect(screen.queryByText('Post not found.')).not.toBeInTheDocument()
+  expect(await screen.findByText('Failed to load comments.')).toBeInTheDocument()
+})

--- a/website/src/pages/PostDetailPage.tsx
+++ b/website/src/pages/PostDetailPage.tsx
@@ -30,10 +30,17 @@ type ReportTarget = { type: 'post' } | { type: 'comment'; comment: CommentView }
  *
  * The web API doesn't report whether the current user has liked a post/comment,
  * so like state is tracked locally and applied optimistically.
+ *
+ * The inner view is keyed by postId so navigating to a different post fully
+ * resets its state instead of briefly showing the previous post's data.
  */
 function PostDetailPage() {
-  const navigate = useNavigate()
   const { postId = '' } = useParams<{ postId: string }>()
+  return <PostDetailView key={postId} postId={postId} />
+}
+
+function PostDetailView({ postId }: { postId: string }) {
+  const navigate = useNavigate()
 
   const [post, setPost] = useState<PostDetails | null>(null)
   const [postLikeCount, setPostLikeCount] = useState(0)
@@ -50,8 +57,10 @@ function PostDetailPage() {
   const [reportReason, setReportReason] = useState('')
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
-  // Local like/report state, keyed by id so it survives a reload (which only
-  // returns server-side counts, never per-user like flags).
+  // Local like/report state, kept in refs so the in-app reload after posting a
+  // comment/reply doesn't drop it (the API only returns server-side counts,
+  // never per-user like flags). This is in-memory only and resets on a full
+  // page reload.
   const likedCommentIds = useRef<Set<string>>(new Set())
   const reportedCommentIds = useRef<Set<string>>(new Set())
 
@@ -67,11 +76,21 @@ function PostDetailPage() {
       isReported: reportedCommentIds.current.has(c.comment_identifier),
     })
 
+    // A failure to load the post itself is the only "not found" case. Comment
+    // loading is handled separately so a transient comments error doesn't hide
+    // a post that loaded fine.
+    let details: PostDetails
     try {
-      const details = await apiClient.getPostDetails(postId)
-      setPost(details)
-      setPostLikeCount(details.post_likes)
+      details = await apiClient.getPostDetails(postId)
+    } catch {
+      setNotFound(true)
+      setIsLoading(false)
+      return
+    }
+    setPost(details)
+    setPostLikeCount(details.post_likes)
 
+    try {
       const refs = await apiClient.getCommentsForPost(postId, 0)
       const threadLists = await Promise.all(
         refs.map(async ref => {
@@ -97,7 +116,7 @@ function PostDetailPage() {
         )
       setThreads(built)
     } catch {
-      setNotFound(true)
+      setErrorMessage('Failed to load comments.')
     } finally {
       setIsLoading(false)
     }

--- a/website/src/pages/PostDetailPage.tsx
+++ b/website/src/pages/PostDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { useNavigate, useParams } from 'react-router-dom'
+import { Navigate, useNavigate, useParams } from 'react-router-dom'
 import { apiClient } from '../api/client'
 import type { Comment, PostDetails } from '../api/types'
 import './MainApp.css'
@@ -36,11 +36,25 @@ type ReportTarget = { type: 'post' } | { type: 'comment'; comment: CommentView }
  */
 function PostDetailPage() {
   const { postId = '' } = useParams<{ postId: string }>()
+  // Comments/likes/reports require a session, so require one like HomePage.
+  if (!apiClient.isAuthenticated()) {
+    return <Navigate to="/login" replace />
+  }
   return <PostDetailView key={postId} postId={postId} />
 }
 
 function PostDetailView({ postId }: { postId: string }) {
   const navigate = useNavigate()
+
+  // Track mount state so async loads that resolve after navigating away don't
+  // set state on an unmounted view.
+  const isMounted = useRef(true)
+  useEffect(() => {
+    isMounted.current = true
+    return () => {
+      isMounted.current = false
+    }
+  }, [])
 
   const [post, setPost] = useState<PostDetails | null>(null)
   const [postLikeCount, setPostLikeCount] = useState(0)
@@ -83,10 +97,13 @@ function PostDetailView({ postId }: { postId: string }) {
     try {
       details = await apiClient.getPostDetails(postId)
     } catch {
-      setNotFound(true)
-      setIsLoading(false)
+      if (isMounted.current) {
+        setNotFound(true)
+        setIsLoading(false)
+      }
       return
     }
+    if (!isMounted.current) return
     setPost(details)
     setPostLikeCount(details.post_likes)
 
@@ -101,6 +118,7 @@ function PostDetailView({ postId }: { postId: string }) {
           return { threadId: ref.comment_thread_identifier, comments }
         }),
       )
+      if (!isMounted.current) return
 
       const built: ThreadView[] = threadLists
         .filter(t => t.comments.length > 0)
@@ -115,10 +133,12 @@ function PostDetailView({ postId }: { postId: string }) {
           (a.comments[0]?.createdTime ?? '').localeCompare(b.comments[0]?.createdTime ?? ''),
         )
       setThreads(built)
+      // Clear any stale "failed to load comments" message from a prior attempt.
+      setErrorMessage(null)
     } catch {
-      setErrorMessage('Failed to load comments.')
+      if (isMounted.current) setErrorMessage('Failed to load comments.')
     } finally {
-      setIsLoading(false)
+      if (isMounted.current) setIsLoading(false)
     }
   }, [postId])
 

--- a/website/src/pages/PostDetailPage.tsx
+++ b/website/src/pages/PostDetailPage.tsx
@@ -1,0 +1,520 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { apiClient } from '../api/client'
+import type { Comment, PostDetails } from '../api/types'
+import './MainApp.css'
+
+/** A comment enriched with the local like/report state the API doesn't return. */
+interface CommentView {
+  id: string
+  threadId: string
+  authorUsername: string
+  body: string
+  createdTime: string
+  likeCount: number
+  isLiked: boolean
+  isReported: boolean
+}
+
+interface ThreadView {
+  threadId: string
+  comments: CommentView[]
+}
+
+type ReportTarget = { type: 'post' } | { type: 'comment'; comment: CommentView }
+
+/**
+ * Full post view: image, like count, caption, and threaded comments with
+ * replies. Supports liking/reporting the post and each comment, and adding new
+ * comments or replies. Mirrors iOS PostDetailView / PostDetailViewModel.
+ *
+ * The web API doesn't report whether the current user has liked a post/comment,
+ * so like state is tracked locally and applied optimistically.
+ */
+function PostDetailPage() {
+  const navigate = useNavigate()
+  const { postId = '' } = useParams<{ postId: string }>()
+
+  const [post, setPost] = useState<PostDetails | null>(null)
+  const [postLikeCount, setPostLikeCount] = useState(0)
+  const [postLiked, setPostLiked] = useState(false)
+  const [postReported, setPostReported] = useState(false)
+  const [threads, setThreads] = useState<ThreadView[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [notFound, setNotFound] = useState(false)
+
+  const [newComment, setNewComment] = useState('')
+  const [replyText, setReplyText] = useState('')
+  const [replyTarget, setReplyTarget] = useState<ThreadView | null>(null)
+  const [reportTarget, setReportTarget] = useState<ReportTarget | null>(null)
+  const [reportReason, setReportReason] = useState('')
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  // Local like/report state, keyed by id so it survives a reload (which only
+  // returns server-side counts, never per-user like flags).
+  const likedCommentIds = useRef<Set<string>>(new Set())
+  const reportedCommentIds = useRef<Set<string>>(new Set())
+
+  const loadAll = useCallback(async () => {
+    const toView = (c: Comment, threadId: string): CommentView => ({
+      id: c.comment_identifier,
+      threadId,
+      authorUsername: c.author_username,
+      body: c.body,
+      createdTime: c.creation_time,
+      likeCount: c.comment_likes,
+      isLiked: likedCommentIds.current.has(c.comment_identifier),
+      isReported: reportedCommentIds.current.has(c.comment_identifier),
+    })
+
+    try {
+      const details = await apiClient.getPostDetails(postId)
+      setPost(details)
+      setPostLikeCount(details.post_likes)
+
+      const refs = await apiClient.getCommentsForPost(postId, 0)
+      const threadLists = await Promise.all(
+        refs.map(async ref => {
+          const comments = await apiClient.getCommentsForThread(
+            ref.comment_thread_identifier,
+            0,
+          )
+          return { threadId: ref.comment_thread_identifier, comments }
+        }),
+      )
+
+      const built: ThreadView[] = threadLists
+        .filter(t => t.comments.length > 0)
+        .map(t => ({
+          threadId: t.threadId,
+          comments: t.comments
+            .slice()
+            .sort((a, b) => a.creation_time.localeCompare(b.creation_time))
+            .map(c => toView(c, t.threadId)),
+        }))
+        .sort((a, b) =>
+          (a.comments[0]?.createdTime ?? '').localeCompare(b.comments[0]?.createdTime ?? ''),
+        )
+      setThreads(built)
+    } catch {
+      setNotFound(true)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [postId])
+
+  // Kick the initial load off a microtask so the fetch's setState calls don't
+  // run synchronously inside the effect (React flags that as cascading renders).
+  useEffect(() => {
+    void Promise.resolve().then(loadAll)
+  }, [loadAll])
+
+  // ---- Post actions ----
+
+  async function togglePostLike() {
+    const liking = !postLiked
+    setPostLiked(liking)
+    setPostLikeCount(n => (liking ? n + 1 : Math.max(0, n - 1)))
+    try {
+      if (liking) await apiClient.likePost(postId)
+      else await apiClient.unlikePost(postId)
+    } catch (err) {
+      // Revert on failure.
+      setPostLiked(!liking)
+      setPostLikeCount(n => (liking ? Math.max(0, n - 1) : n + 1))
+      setErrorMessage((err as Error).message ?? 'Action failed.')
+    }
+  }
+
+  // ---- Comment actions ----
+
+  function mutateComment(id: string, fn: (c: CommentView) => CommentView) {
+    setThreads(prev =>
+      prev.map(thread => ({
+        ...thread,
+        comments: thread.comments.map(c => (c.id === id ? fn(c) : c)),
+      })),
+    )
+  }
+
+  async function toggleCommentLike(comment: CommentView) {
+    const liking = !comment.isLiked
+    if (liking) likedCommentIds.current.add(comment.id)
+    else likedCommentIds.current.delete(comment.id)
+    mutateComment(comment.id, c => ({
+      ...c,
+      isLiked: liking,
+      likeCount: liking ? c.likeCount + 1 : Math.max(0, c.likeCount - 1),
+    }))
+    try {
+      if (liking)
+        await apiClient.likeComment(postId, comment.threadId, comment.id)
+      else await apiClient.unlikeComment(postId, comment.threadId, comment.id)
+    } catch (err) {
+      if (liking) likedCommentIds.current.delete(comment.id)
+      else likedCommentIds.current.add(comment.id)
+      mutateComment(comment.id, c => ({
+        ...c,
+        isLiked: !liking,
+        likeCount: liking ? Math.max(0, c.likeCount - 1) : c.likeCount + 1,
+      }))
+      setErrorMessage((err as Error).message ?? 'Action failed.')
+    }
+  }
+
+  async function submitComment() {
+    const text = newComment.trim()
+    if (!text) return
+    try {
+      await apiClient.commentOnPost(postId, text)
+      setNewComment('')
+      await loadAll()
+    } catch (err) {
+      setErrorMessage((err as Error).message ?? 'Failed to post comment.')
+    }
+  }
+
+  async function submitReply() {
+    const text = replyText.trim()
+    if (!text || !replyTarget) return
+    try {
+      await apiClient.replyToCommentThread(postId, replyTarget.threadId, text)
+      setReplyText('')
+      setReplyTarget(null)
+      await loadAll()
+    } catch (err) {
+      setErrorMessage((err as Error).message ?? 'Failed to post reply.')
+    }
+  }
+
+  // ---- Reporting ----
+
+  async function submitReport() {
+    const reason = reportReason.trim()
+    const target = reportTarget
+    if (!reason || !target) return
+    try {
+      if (target.type === 'post') {
+        await apiClient.reportPost(postId, reason)
+        setPostReported(true)
+      } else {
+        await apiClient.reportComment(
+          postId,
+          target.comment.threadId,
+          target.comment.id,
+          reason,
+        )
+        reportedCommentIds.current.add(target.comment.id)
+        mutateComment(target.comment.id, c => ({ ...c, isReported: true }))
+      }
+    } catch (err) {
+      setErrorMessage((err as Error).message ?? 'Failed to report.')
+    } finally {
+      setReportReason('')
+      setReportTarget(null)
+    }
+  }
+
+  if (isLoading && !post) {
+    return (
+      <div className="app-shell">
+        <DetailBar onBack={() => navigate(-1)} />
+        <div className="center-spinner">
+          <span className="spinner" />
+        </div>
+      </div>
+    )
+  }
+
+  if (notFound || !post) {
+    return (
+      <div className="app-shell">
+        <DetailBar onBack={() => navigate(-1)} />
+        <main className="app-content">
+          <p className="muted">Post not found.</p>
+        </main>
+      </div>
+    )
+  }
+
+  return (
+    <div className="app-shell">
+      <DetailBar onBack={() => navigate(-1)} />
+
+      <main className="app-content">
+        {errorMessage && (
+          <div className="auth-error" role="alert">
+            <p>{errorMessage}</p>
+            <button
+              type="button"
+              className="auth-error__dismiss"
+              aria-label="Dismiss error"
+              onClick={() => setErrorMessage(null)}
+            >
+              ✕
+            </button>
+          </div>
+        )}
+
+        <img
+          className="detail-image"
+          src={post.image_url}
+          alt={post.caption}
+          onDoubleClick={togglePostLike}
+        />
+
+        <div className="detail-meta">
+          <button
+            type="button"
+            className="heart"
+            aria-label={postLiked ? 'Unlike post' : 'Like post'}
+            aria-pressed={postLiked}
+            onClick={togglePostLike}
+          >
+            {postLiked ? '♥' : '♡'}
+          </button>
+          <span className="detail-likes">{postLikeCount} likes</span>
+          {postReported && (
+            <span className="flag-icon" aria-label="Reported">
+              ⚑
+            </span>
+          )}
+          <button
+            type="button"
+            className="app-bar__back"
+            style={{ marginLeft: 'auto' }}
+            onClick={() => {
+              setReportReason('')
+              setReportTarget({ type: 'post' })
+            }}
+          >
+            Report
+          </button>
+        </div>
+
+        <p className="detail-caption">
+          <button
+            type="button"
+            className="feed-post__author"
+            style={{ display: 'inline', padding: 0 }}
+            onClick={() => navigate(`/profile/${encodeURIComponent(post.author_username)}`)}
+          >
+            {post.author_username}
+          </button>{' '}
+          {post.caption}
+        </p>
+
+        <div className="comment-form">
+          <input
+            type="text"
+            placeholder="Add a comment..."
+            aria-label="Add a comment"
+            value={newComment}
+            onChange={e => setNewComment(e.target.value)}
+          />
+          <button
+            type="button"
+            className="btn btn-primary"
+            disabled={newComment.trim().length === 0}
+            onClick={submitComment}
+          >
+            Post
+          </button>
+        </div>
+
+        <h2 className="app-bar__title" style={{ fontSize: '1rem' }}>
+          Comments
+        </h2>
+
+        {threads.length === 0 ? (
+          <p className="muted">No comments yet. Be the first!</p>
+        ) : (
+          threads.map(thread => {
+            const [root, ...replies] = thread.comments
+            return (
+              <div key={thread.threadId} className="comment-thread">
+                {root && (
+                  <CommentRow
+                    comment={root}
+                    onToggleLike={() => toggleCommentLike(root)}
+                    onReport={() => {
+                      setReportReason('')
+                      setReportTarget({ type: 'comment', comment: root })
+                    }}
+                    onNavigate={() =>
+                      navigate(`/profile/${encodeURIComponent(root.authorUsername)}`)
+                    }
+                  />
+                )}
+                <button
+                  type="button"
+                  className="comment-reply-btn"
+                  onClick={() => {
+                    setReplyText('')
+                    setReplyTarget(thread)
+                  }}
+                >
+                  Reply
+                </button>
+                {replies.length > 0 && (
+                  <div className="comment-replies">
+                    {replies.map(reply => (
+                      <CommentRow
+                        key={reply.id}
+                        comment={reply}
+                        onToggleLike={() => toggleCommentLike(reply)}
+                        onReport={() => {
+                          setReportReason('')
+                          setReportTarget({ type: 'comment', comment: reply })
+                        }}
+                        onNavigate={() =>
+                          navigate(`/profile/${encodeURIComponent(reply.authorUsername)}`)
+                        }
+                      />
+                    ))}
+                  </div>
+                )}
+              </div>
+            )
+          })
+        )}
+      </main>
+
+      {replyTarget && (
+        <div className="modal-overlay">
+          <div className="modal" role="dialog" aria-modal="true" aria-label="Post reply">
+            <h2 className="modal__title">
+              Replying to {replyTarget.comments[0]?.authorUsername ?? 'comment'}
+            </h2>
+            <textarea
+              className="text-area"
+              rows={4}
+              aria-label="Reply text"
+              value={replyText}
+              onChange={e => setReplyText(e.target.value)}
+            />
+            <div className="modal__actions">
+              <button
+                type="button"
+                className="modal__cancel"
+                onClick={() => {
+                  setReplyTarget(null)
+                  setReplyText('')
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="modal__confirm"
+                disabled={replyText.trim().length === 0}
+                onClick={submitReply}
+              >
+                Send
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {reportTarget && (
+        <div className="modal-overlay">
+          <div className="modal" role="dialog" aria-modal="true" aria-label="Report item">
+            <h2 className="modal__title">Report Item</h2>
+            <input
+              className="search-bar"
+              type="text"
+              placeholder="Reason for reporting..."
+              aria-label="Reason for reporting"
+              value={reportReason}
+              onChange={e => setReportReason(e.target.value)}
+            />
+            <div className="modal__actions">
+              <button
+                type="button"
+                className="modal__cancel"
+                onClick={() => {
+                  setReportTarget(null)
+                  setReportReason('')
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="modal__confirm"
+                disabled={reportReason.trim().length === 0}
+                onClick={submitReport}
+              >
+                Submit Report
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function DetailBar({ onBack }: { onBack: () => void }) {
+  return (
+    <header className="app-bar">
+      <button type="button" className="app-bar__back" onClick={onBack}>
+        ← Back
+      </button>
+      <h1 className="app-bar__title">Post</h1>
+    </header>
+  )
+}
+
+interface CommentRowProps {
+  comment: CommentView
+  onToggleLike: () => void
+  onReport: () => void
+  onNavigate: () => void
+}
+
+function CommentRow({ comment, onToggleLike, onReport, onNavigate }: CommentRowProps) {
+  return (
+    <div className="comment-row">
+      <span className="comment-row__avatar" aria-hidden="true">
+        ◍
+      </span>
+      <div>
+        <span>
+          <button
+            type="button"
+            className="feed-post__author"
+            style={{ display: 'inline', padding: 0 }}
+            onClick={onNavigate}
+          >
+            <span className="comment-row__author">{comment.authorUsername}</span>
+          </button>
+          <span className="comment-row__body">{comment.body}</span>
+        </span>
+        <div className="comment-row__info">
+          <button
+            type="button"
+            className="heart"
+            aria-label={comment.isLiked ? 'Unlike comment' : 'Like comment'}
+            aria-pressed={comment.isLiked}
+            onClick={onToggleLike}
+          >
+            {comment.isLiked ? '♥' : '♡'}
+          </button>
+          <span>{comment.likeCount} likes</span>
+          <button type="button" className="comment-reply-btn" style={{ padding: 0 }} onClick={onReport}>
+            Report
+          </button>
+          {comment.isReported && (
+            <span className="flag-icon" aria-label="Reported">
+              ⚑
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default PostDetailPage

--- a/website/src/pages/ProfilePage.test.tsx
+++ b/website/src/pages/ProfilePage.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { vi, beforeEach, test, expect } from 'vitest'
+import ProfilePage from './ProfilePage'
+import type { ProfileDetails } from '../api/types'
+
+vi.mock('../api/client', () => ({
+  apiClient: {
+    getProfile: vi.fn(),
+    getPostsForUser: vi.fn(),
+    followUser: vi.fn(),
+    unfollowUser: vi.fn(),
+    toggleBlock: vi.fn(),
+  },
+}))
+
+import { apiClient } from '../api/client'
+const mockGetProfile = vi.mocked(apiClient.getProfile)
+const mockGetPosts = vi.mocked(apiClient.getPostsForUser)
+const mockFollow = vi.mocked(apiClient.followUser)
+const mockUnfollow = vi.mocked(apiClient.unfollowUser)
+
+const baseProfile: ProfileDetails = {
+  username: 'bob',
+  post_count: 2,
+  follower_count: 10,
+  following_count: 5,
+  is_following: false,
+  is_blocked: false,
+  identity_is_verified: true,
+  is_adult: true,
+}
+
+function renderProfile() {
+  return render(
+    <MemoryRouter initialEntries={['/profile/bob']}>
+      <Routes>
+        <Route path="/profile/:username" element={<ProfilePage />} />
+        <Route path="/post/:postId" element={<div>Post page</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  mockGetProfile.mockReset().mockResolvedValue(baseProfile)
+  mockGetPosts.mockReset().mockResolvedValue([])
+  mockFollow.mockReset().mockResolvedValue({ message: 'ok' })
+  mockUnfollow.mockReset().mockResolvedValue({ message: 'ok' })
+})
+
+test('renders profile stats and follow button', async () => {
+  renderProfile()
+  expect(await screen.findByText('10')).toBeInTheDocument() // followers
+  expect(screen.getByRole('button', { name: 'Follow' })).toBeInTheDocument()
+  expect(screen.getByRole('button', { name: 'Block' })).toBeInTheDocument()
+})
+
+test('following a user calls the API and updates the button', async () => {
+  renderProfile()
+  const followBtn = await screen.findByRole('button', { name: 'Follow' })
+  await userEvent.click(followBtn)
+  await waitFor(() => expect(mockFollow).toHaveBeenCalledWith('bob'))
+  expect(screen.getByRole('button', { name: 'Following' })).toBeInTheDocument()
+})
+
+test('shows empty state when the user has no posts', async () => {
+  renderProfile()
+  expect(await screen.findByText("bob hasn't posted anything yet.")).toBeInTheDocument()
+})
+
+test('renders the post grid and opens a post', async () => {
+  mockGetPosts.mockResolvedValue([
+    { post_identifier: 'p1', image_url: 'http://img/1.jpg', author_username: 'bob', caption: 'hi' },
+  ])
+  renderProfile()
+  await userEvent.click(await screen.findByRole('button', { name: 'Post by bob' }))
+  expect(screen.getByText('Post page')).toBeInTheDocument()
+})

--- a/website/src/pages/ProfilePage.test.tsx
+++ b/website/src/pages/ProfilePage.test.tsx
@@ -7,6 +7,7 @@ import type { ProfileDetails } from '../api/types'
 
 vi.mock('../api/client', () => ({
   apiClient: {
+    isAuthenticated: vi.fn(() => true),
     getProfile: vi.fn(),
     getPostsForUser: vi.fn(),
     followUser: vi.fn(),
@@ -77,4 +78,23 @@ test('renders the post grid and opens a post', async () => {
   renderProfile()
   await userEvent.click(await screen.findByRole('button', { name: 'Post by bob' }))
   expect(screen.getByText('Post page')).toBeInTheDocument()
+})
+
+test('shows "User not found" when the profile fails to load', async () => {
+  mockGetProfile.mockRejectedValue(new Error('404'))
+  renderProfile()
+  expect(await screen.findByText('User not found.')).toBeInTheDocument()
+})
+
+test('redirects to login when unauthenticated', () => {
+  vi.mocked(apiClient.isAuthenticated).mockReturnValueOnce(false)
+  render(
+    <MemoryRouter initialEntries={['/profile/bob']}>
+      <Routes>
+        <Route path="/profile/:username" element={<ProfilePage />} />
+        <Route path="/login" element={<div>Login page</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+  expect(screen.getByText('Login page')).toBeInTheDocument()
 })

--- a/website/src/pages/ProfilePage.tsx
+++ b/website/src/pages/ProfilePage.tsx
@@ -1,0 +1,197 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { apiClient } from '../api/client'
+import type { FeedPost, ProfileDetails } from '../api/types'
+import './MainApp.css'
+
+/**
+ * A user's profile: stats, follow/block actions, and their post grid. Mirrors
+ * iOS ProfileView / ProfileViewModel (optimistic follow/block, paginated grid).
+ */
+function ProfilePage() {
+  const navigate = useNavigate()
+  const { username = '' } = useParams<{ username: string }>()
+
+  const [profile, setProfile] = useState<ProfileDetails | null>(null)
+  const [isFollowing, setIsFollowing] = useState(false)
+  const [isBlocked, setIsBlocked] = useState(false)
+  const [isBusy, setIsBusy] = useState(false)
+
+  const [posts, setPosts] = useState<FeedPost[]>([])
+  const [page, setPage] = useState(0)
+  const [canLoadMore, setCanLoadMore] = useState(true)
+  // Start loading so the spinner shows on mount without a synchronous setState
+  // inside the fetch effect.
+  const [isLoadingPosts, setIsLoadingPosts] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+    apiClient
+      .getProfile(username)
+      .then(details => {
+        if (cancelled) return
+        setProfile(details)
+        setIsFollowing(details.is_following)
+        setIsBlocked(details.is_blocked)
+      })
+      .catch(() => {
+        /* leave profile null → "not found" message */
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [username])
+
+  const loadPosts = useCallback(
+    async (pageToLoad: number, replace: boolean) => {
+      try {
+        const newPosts = await apiClient.getPostsForUser(username, pageToLoad)
+        if (replace) {
+          setPosts(newPosts)
+          setCanLoadMore(newPosts.length > 0)
+          setPage(newPosts.length > 0 ? 1 : 0)
+        } else if (newPosts.length === 0) {
+          setCanLoadMore(false)
+        } else {
+          setPosts(prev => [...prev, ...newPosts])
+          setPage(prev => prev + 1)
+        }
+      } catch {
+        setCanLoadMore(false)
+      } finally {
+        setIsLoadingPosts(false)
+      }
+    },
+    [username],
+  )
+
+  // Deferred to a microtask so the fetch's setState calls don't run
+  // synchronously inside the effect (React flags that as cascading renders).
+  useEffect(() => {
+    void Promise.resolve().then(() => loadPosts(0, true))
+  }, [loadPosts])
+
+  async function toggleFollow() {
+    if (isBusy) return
+    setIsBusy(true)
+    const wasFollowing = isFollowing
+    try {
+      if (wasFollowing) {
+        await apiClient.unfollowUser(username)
+        setIsFollowing(false)
+        setProfile(p => (p ? { ...p, follower_count: Math.max(0, p.follower_count - 1) } : p))
+      } else {
+        await apiClient.followUser(username)
+        setIsFollowing(true)
+        setProfile(p => (p ? { ...p, follower_count: p.follower_count + 1 } : p))
+      }
+    } catch {
+      /* leave state unchanged on failure */
+    } finally {
+      setIsBusy(false)
+    }
+  }
+
+  async function toggleBlock() {
+    if (isBusy) return
+    setIsBusy(true)
+    const previous = isBlocked
+    // Optimistic update; blocking also severs the follow relationship.
+    setIsBlocked(!previous)
+    if (!previous) setIsFollowing(false)
+    try {
+      await apiClient.toggleBlock(username)
+    } catch {
+      setIsBlocked(previous)
+    } finally {
+      setIsBusy(false)
+    }
+  }
+
+  return (
+    <div className="app-shell">
+      <header className="app-bar">
+        <button type="button" className="app-bar__back" onClick={() => navigate(-1)}>
+          ← Back
+        </button>
+        <h1 className="app-bar__title">{username}</h1>
+      </header>
+
+      <main className="app-content">
+        <div className="profile-header">
+          <div className="profile-stats">
+            <div>
+              <span className="profile-stat__count">{profile?.post_count ?? posts.length}</span>
+              <span className="profile-stat__label">Posts</span>
+            </div>
+            <div>
+              <span className="profile-stat__count">{profile?.follower_count ?? 0}</span>
+              <span className="profile-stat__label">Followers</span>
+            </div>
+            <div>
+              <span className="profile-stat__count">{profile?.following_count ?? 0}</span>
+              <span className="profile-stat__label">Following</span>
+            </div>
+          </div>
+
+          <div className="profile-actions">
+            <button
+              type="button"
+              className={`btn ${isFollowing ? 'btn-outline' : 'btn-primary'}`}
+              disabled={isBusy}
+              onClick={toggleFollow}
+            >
+              {isFollowing ? 'Following' : 'Follow'}
+            </button>
+            <button
+              type="button"
+              className={`btn ${isBlocked ? 'btn-danger--filled' : 'btn-danger'}`}
+              disabled={isBusy}
+              onClick={toggleBlock}
+            >
+              {isBlocked ? 'Unblock' : 'Block'}
+            </button>
+          </div>
+        </div>
+
+        {posts.length === 0 && !isLoadingPosts ? (
+          <p className="muted">{username} hasn't posted anything yet.</p>
+        ) : (
+          <div className="post-grid">
+            {posts.map(post => (
+              <button
+                key={post.post_identifier}
+                type="button"
+                className="post-grid__cell"
+                aria-label={`Post by ${post.author_username}`}
+                onClick={() => navigate(`/post/${post.post_identifier}`)}
+              >
+                <img src={post.image_url} alt={post.caption} />
+              </button>
+            ))}
+          </div>
+        )}
+
+        {isLoadingPosts && (
+          <div className="center-spinner">
+            <span className="spinner" />
+          </div>
+        )}
+        {canLoadMore && !isLoadingPosts && posts.length > 0 && (
+          <button
+            type="button"
+            className="load-more"
+            onClick={() => {
+              setIsLoadingPosts(true)
+              void loadPosts(page, false)
+            }}
+          >
+            Load more
+          </button>
+        )}
+      </main>
+    </div>
+  )
+}
+
+export default ProfilePage

--- a/website/src/pages/ProfilePage.tsx
+++ b/website/src/pages/ProfilePage.tsx
@@ -7,10 +7,17 @@ import './MainApp.css'
 /**
  * A user's profile: stats, follow/block actions, and their post grid. Mirrors
  * iOS ProfileView / ProfileViewModel (optimistic follow/block, paginated grid).
+ *
+ * The inner view is keyed by username so navigating between profiles fully
+ * resets its state instead of briefly showing the previous user's data.
  */
 function ProfilePage() {
-  const navigate = useNavigate()
   const { username = '' } = useParams<{ username: string }>()
+  return <ProfileView key={username} username={username} />
+}
+
+function ProfileView({ username }: { username: string }) {
+  const navigate = useNavigate()
 
   const [profile, setProfile] = useState<ProfileDetails | null>(null)
   const [isFollowing, setIsFollowing] = useState(false)
@@ -86,7 +93,7 @@ function ProfilePage() {
         setProfile(p => (p ? { ...p, follower_count: p.follower_count + 1 } : p))
       }
     } catch {
-      /* leave state unchanged on failure */
+      /* state is only updated after a successful call, so nothing to revert */
     } finally {
       setIsBusy(false)
     }
@@ -95,14 +102,19 @@ function ProfilePage() {
   async function toggleBlock() {
     if (isBusy) return
     setIsBusy(true)
-    const previous = isBlocked
-    // Optimistic update; blocking also severs the follow relationship.
-    setIsBlocked(!previous)
-    if (!previous) setIsFollowing(false)
+    const wasFollowing = isFollowing
     try {
       await apiClient.toggleBlock(username)
+      const nowBlocked = !isBlocked
+      setIsBlocked(nowBlocked)
+      // Blocking severs the follow relationship on the backend; reflect that in
+      // the follow button and the follower count so the stats stay consistent.
+      if (nowBlocked && wasFollowing) {
+        setIsFollowing(false)
+        setProfile(p => (p ? { ...p, follower_count: Math.max(0, p.follower_count - 1) } : p))
+      }
     } catch {
-      setIsBlocked(previous)
+      /* state is only updated after a successful call, so nothing to revert */
     } finally {
       setIsBusy(false)
     }

--- a/website/src/pages/ProfilePage.tsx
+++ b/website/src/pages/ProfilePage.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useState } from 'react'
-import { useNavigate, useParams } from 'react-router-dom'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Navigate, useNavigate, useParams } from 'react-router-dom'
 import { apiClient } from '../api/client'
 import type { FeedPost, ProfileDetails } from '../api/types'
 import './MainApp.css'
@@ -13,13 +13,28 @@ import './MainApp.css'
  */
 function ProfilePage() {
   const { username = '' } = useParams<{ username: string }>()
+  // This view hits authenticated endpoints, so require a session like HomePage.
+  if (!apiClient.isAuthenticated()) {
+    return <Navigate to="/login" replace />
+  }
   return <ProfileView key={username} username={username} />
 }
 
 function ProfileView({ username }: { username: string }) {
   const navigate = useNavigate()
 
+  // Track mount state so async loads that resolve after navigating away don't
+  // set state on an unmounted view.
+  const isMounted = useRef(true)
+  useEffect(() => {
+    isMounted.current = true
+    return () => {
+      isMounted.current = false
+    }
+  }, [])
+
   const [profile, setProfile] = useState<ProfileDetails | null>(null)
+  const [notFound, setNotFound] = useState(false)
   const [isFollowing, setIsFollowing] = useState(false)
   const [isBlocked, setIsBlocked] = useState(false)
   const [isBusy, setIsBusy] = useState(false)
@@ -42,7 +57,8 @@ function ProfileView({ username }: { username: string }) {
         setIsBlocked(details.is_blocked)
       })
       .catch(() => {
-        /* leave profile null → "not found" message */
+        // Couldn't load the profile (e.g. user not found) — show a message.
+        if (!cancelled) setNotFound(true)
       })
     return () => {
       cancelled = true
@@ -53,6 +69,7 @@ function ProfileView({ username }: { username: string }) {
     async (pageToLoad: number, replace: boolean) => {
       try {
         const newPosts = await apiClient.getPostsForUser(username, pageToLoad)
+        if (!isMounted.current) return
         if (replace) {
           setPosts(newPosts)
           setCanLoadMore(newPosts.length > 0)
@@ -64,9 +81,9 @@ function ProfileView({ username }: { username: string }) {
           setPage(prev => prev + 1)
         }
       } catch {
-        setCanLoadMore(false)
+        if (isMounted.current) setCanLoadMore(false)
       } finally {
-        setIsLoadingPosts(false)
+        if (isMounted.current) setIsLoadingPosts(false)
       }
     },
     [username],
@@ -129,6 +146,11 @@ function ProfileView({ username }: { username: string }) {
         <h1 className="app-bar__title">{username}</h1>
       </header>
 
+      {notFound ? (
+        <main className="app-content">
+          <p className="muted">User not found.</p>
+        </main>
+      ) : (
       <main className="app-content">
         <div className="profile-header">
           <div className="profile-stats">
@@ -202,6 +224,7 @@ function ProfileView({ username }: { username: string }) {
           </button>
         )}
       </main>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## What & why

The website had only the auth pages plus a placeholder `HomePage`, while the iOS and Android apps already implement the full signed-in experience. This ports the remaining views to the web, built on top of the existing `apiClient`.

## Changes

**Routing & session**
- New routes `/post/:postId` and `/profile/:username`
- Restore the session token from `localStorage` into `apiClient` on startup so a page reload stays authenticated (it was previously in-memory only)
- Small `api/session.ts` helper (`getCurrentUsername`, `getCurrentUserId`, `clearSession`)

**App shell** (`HomePage.tsx`)
- Replaces the `<h1>Home View</h1>` stub with a bottom-tab shell (Home / Feed / Post / Settings) mirroring the iOS `TabView`, redirecting to `/login` when unauthenticated

**Tabs** (`src/components/`)
- `MyPostsTab` — user's post grid + debounced (500ms, 3-char) user search
- `FeedTab` — For You / Following segmented feeds
- `NewPostTab` — **photo upload**: pick an image, preview it, and on submit upload it to S3 and post the resulting URL
- `SettingsTab` — logout, verify identity, privacy policy, delete account, all with confirmation dialogs

**Pages**
- `PostDetailPage` — image, likes, caption, threaded comments with replies, like/report on post and comments
- `ProfilePage` — stats header, follow/block, post grid, with a "user not found" state

**Photo upload** (`api/s3Uploader.ts`)
- Mirrors the native `S3Uploader`/`AWSManager`: compresses the picked image to JPEG (≤10 MB, lowering quality then downscaling via canvas) and `PutObject`s it to the `goodvibesonly-images` bucket in `us-east-2`, keyed `<userId>/<uuid>.jpeg`, using the same Cognito **unauthenticated** identity pool as iOS/Android.
- Uses `@aws-sdk/client-s3` + `@aws-sdk/credential-provider-cognito-identity` (the dedicated browser-safe Cognito provider; the umbrella `@aws-sdk/credential-providers` pulls in a Node-only IMDS module that can't bundle for the browser).

## Reviewer notes

- The web `PostDetails`/`Comment` types have no per-user `is_liked` flag (unlike iOS), so like state is tracked locally and applied optimistically.
- A browser `PUT` to S3 is subject to **CORS** (the native SDKs are not), so the `goodvibesonly-images` bucket's CORS policy must allow `PUT` from the site's origin for uploads to succeed in the browser.
- ProfilePage/PostDetailPage are keyed by their route param so navigating between profiles/posts fully resets state; both guard against unauthenticated access like `HomePage`.
- Async loads ignore results after unmount (mounted ref) to avoid setting state on unmounted tabs/pages.
- The strict `react-hooks/set-state-in-effect` rule flags fetch-on-mount effects, so those loads are deferred to a microtask (see comments on each mount effect).

## Verification
- `tsc`, `eslint`, and `vite build` all clean
- **98 tests pass** — a test file for every new view, including upload, auth-redirect, and not-found cases