### PR TITLE
Fix follower count not decrementing on block

### DIFF
--- a/android/PositiveOnlySocial/app/src/androidTest/java/com/example/positiveonlysocial/PositiveOnlySocialIntegrationTests.kt
+++ b/android/PositiveOnlySocial/app/src/androidTest/java/com/example/positiveonlysocial/PositiveOnlySocialIntegrationTests.kt
@@ -276,9 +276,9 @@ class PositiveOnlySocialIntegrationTests {
             .onNodeWithTag("tag_Followers", true)
             .assert(hasAnyDescendant(hasText("0")))
 
-        // Follow
-        composeTestRule.onNodeWithText("Follow").performClick()
-        composeTestRule.onNodeWithText("Following").assertExists()
+        // Follow (disambiguate the clickable button from the "Following" stat label)
+        composeTestRule.onNode(hasText("Follow") and hasClickAction()).performClick()
+        composeTestRule.onNode(hasText("Following") and hasClickAction()).assertExists()
 
         // Verify Followers count is 1
         composeTestRule
@@ -286,9 +286,9 @@ class PositiveOnlySocialIntegrationTests {
             .assert(hasAnyDescendant(hasText("1")))
 
 
-        // Unfollow
-        composeTestRule.onNodeWithText("Following").performClick()
-        composeTestRule.onNodeWithText("Follow").assertExists()
+        // Unfollow (target the button, not the "Following" stat label)
+        composeTestRule.onNode(hasText("Following") and hasClickAction()).performClick()
+        composeTestRule.onNode(hasText("Follow") and hasClickAction()).assertExists()
     }
     @Test
     fun testLikeAndUnlikePost() {

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/ProfileViewModel.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/ProfileViewModel.kt
@@ -141,11 +141,13 @@ class ProfileViewModel(
         val currentProfile = _profileDetails.value ?: return
         val isFollowing = currentProfile.isFollowing
 
-        // Optimistic Update
+        // Optimistic Update. Keep _isFollowing in sync with the profile so the
+        // follow button and the follower count never drift apart.
         _profileDetails.value = currentProfile.copy(
             isFollowing = !isFollowing,
             followerCount = if (isFollowing) currentProfile.followerCount - 1 else currentProfile.followerCount + 1
         )
+        _isFollowing.value = !isFollowing
 
         viewModelScope.launch {
             try {
@@ -165,11 +167,13 @@ class ProfileViewModel(
                 if (!response.isSuccessful) {
                     // Revert on failure
                     _profileDetails.value = currentProfile
+                    _isFollowing.value = isFollowing
                     _errorMessage.value = "Failed to update follow status"
                 }
             } catch (e: Exception) {
                 // Revert on error
                 _profileDetails.value = currentProfile
+                _isFollowing.value = isFollowing
                 _errorMessage.value = "Error: ${e.localizedMessage}"
             }
         }
@@ -177,14 +181,20 @@ class ProfileViewModel(
 
     fun toggleBlock(username: String) {
         val currentBlockedStatus = _isBlocked.value
-        
+        val currentProfile = _profileDetails.value
+
         // Optimistic Update
         _isBlocked.value = !currentBlockedStatus
-        
-        // If we allow blocking to unfollow immediately in UI, we should update that too.
-        // Backend handles unfollowing.
-        if (!currentBlockedStatus) { // We are now blocking
-             _isFollowing.value = false
+
+        // Blocking also unfollows on the backend, so mirror that here. Only
+        // decrement the follower count if we were actually following, otherwise
+        // the count drifts (e.g. follow -> block -> follow would count twice).
+        if (!currentBlockedStatus && currentProfile != null && currentProfile.isFollowing) {
+            _profileDetails.value = currentProfile.copy(
+                isFollowing = false,
+                followerCount = currentProfile.followerCount - 1
+            )
+            _isFollowing.value = false
         }
 
         viewModelScope.launch {
@@ -199,15 +209,21 @@ class ProfileViewModel(
                 val response = api.toggleBlock(userSession.sessionToken, username)
 
                 if (!response.isSuccessful) {
-                    // Revert on failure
+                    // Revert on failure, including the optimistic unfollow side-effect.
                     _isBlocked.value = currentBlockedStatus
+                    if (currentProfile != null) {
+                        _profileDetails.value = currentProfile
+                        _isFollowing.value = currentProfile.isFollowing
+                    }
                     _errorMessage.value = "Failed to update block status"
-                    // Potentially revert follow status if we changed it optimistically? 
-                    // Simpler to just fetch profile again on error or success to sync state.
                 }
             } catch (e: Exception) {
-                // Revert on error
+                // Revert on error, including the optimistic unfollow side-effect.
                 _isBlocked.value = currentBlockedStatus
+                if (currentProfile != null) {
+                    _profileDetails.value = currentProfile
+                    _isFollowing.value = currentProfile.isFollowing
+                }
                 _errorMessage.value = "Error: ${e.localizedMessage}"
             }
         }

--- a/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/ProfileViewModelTest.kt
+++ b/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/ProfileViewModelTest.kt
@@ -115,6 +115,34 @@ class ProfileViewModelTest {
     }
 
     @Test
+    fun `follow then block then follow does not double-count followers`() = runTest {
+        val userId = "user1"
+        val mockProfile = ProfileDetailsResponse(userId, 1, 0, 3, isFollowing = false, isBlocked = false)
+        whenever(api.getProfileDetails("token123", userId)).thenReturn(Response.success(mockProfile))
+        whenever(api.getPostsForUser("token123", userId, 0)).thenReturn(Response.success(emptyList()))
+        whenever(api.followUser("token123", userId)).thenReturn(Response.success(GenericResponse("Success", "None")))
+        whenever(api.toggleBlock(any(), any())).thenReturn(Response.success(GenericResponse("Success", "None")))
+
+        viewModel.fetchProfile(userId)
+
+        // Follow -> count goes from 0 to 1
+        viewModel.toggleFollow(userId)
+        assertEquals(1, viewModel.profileDetails.value!!.followerCount)
+        assertTrue(viewModel.isFollowing.value)
+
+        // Block -> backend unfollows, so the count must drop back to 0
+        viewModel.toggleBlock(userId)
+        assertEquals(0, viewModel.profileDetails.value!!.followerCount)
+        assertFalse(viewModel.isFollowing.value)
+
+        // Unblock then follow again -> count is 1, not 2
+        viewModel.toggleBlock(userId)
+        viewModel.toggleFollow(userId)
+        assertEquals(1, viewModel.profileDetails.value!!.followerCount)
+        assertTrue(viewModel.isFollowing.value)
+    }
+
+    @Test
     fun testFetchProfileWithBlockedStatus() = runTest {
         // Arrange
         val userId = "testUser"

--- a/ios/Positive Only Social/Positive Only Social/viewmodels/ProfileViewModel.swift
+++ b/ios/Positive Only Social/Positive Only Social/viewmodels/ProfileViewModel.swift
@@ -156,18 +156,21 @@ class ProfileViewModel: ObservableObject {
         isLoadingProfile = true
         
         let previousBlockState = isBlocked
+        let previousFollowState = isFollowing
         // Optimistic update
         isBlocked.toggle()
-        
-        // Blocking also unfollows in our backend logic
-        if isBlocked { 
-             isFollowing = false 
-             if self.profileDetails != nil {
-                 // self.profileDetails?.followerCount -= 1 // Maybe? Only if we were following. 
-                 // It's safer to just let the profile refresh or ignore count for now.
-             }
+
+        // Blocking also unfollows in our backend logic, so mirror that here.
+        // Only decrement the follower count if we were actually following,
+        // otherwise the count drifts (e.g. follow -> block -> follow would
+        // count the same follow twice).
+        if isBlocked && isFollowing {
+            isFollowing = false
+            if self.profileDetails != nil {
+                self.profileDetails?.followerCount -= 1
+            }
         }
-        
+
         Task {
             do {
                 guard let userSession = try keychainHelper.load(UserSession.self, from: keychainService, account: account) else {
@@ -182,7 +185,13 @@ class ProfileViewModel: ObservableObject {
                 // Success, state already updated.
             } catch {
                 NSLog("%@", "Error toggling block: \(error)")
-                // Revert on error
+                // Revert on error, including the optimistic unfollow side-effect.
+                if isBlocked && !previousBlockState && previousFollowState {
+                    isFollowing = previousFollowState
+                    if self.profileDetails != nil {
+                        self.profileDetails?.followerCount += 1
+                    }
+                }
                 isBlocked = previousBlockState
             }
             isLoadingProfile = false

--- a/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_ProfileViewModel.swift
+++ b/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_ProfileViewModel.swift
@@ -218,5 +218,43 @@ struct Positive_Only_SocialTests_ProfileViewModel {
         // Then: The state is updated
         #expect(sut.isBlocked == false, "Should now be unblocked")
     }
+
+    @Test func testFollowThenBlockThenFollow_DoesNotDoubleCountFollowers() async throws {
+        // Given: A logged-in user and a profile user
+        let (requestingUserToken, requestingUser) = try await registerUser(username: "mainRecounter")
+        let (_, profileUser) = try await registerUser(username: "profileToRecount")
+
+        let account = "mainRecounter_account"
+        try await setupLoggedInUser(user: requestingUser, token: requestingUserToken, account: account)
+
+        let sut = ProfileViewModel(user: profileUser, api: stubAPI, keychainHelper: keychainHelper, account: account)
+
+        // --- 1. Load Initial State (Not Following, Not Blocked) ---
+        sut.fetchProfileDetails()
+        await yield()
+        #expect(sut.isFollowing == false, "Pre-condition: Not following")
+        #expect(sut.profileDetails?.followerCount == 0, "Pre-condition: 0 followers")
+
+        // --- 2. Follow -> count goes to 1 ---
+        sut.toggleFollow()
+        await yield()
+        #expect(sut.isFollowing == true)
+        #expect(sut.profileDetails?.followerCount == 1, "Follower count should be 1 after follow")
+
+        // --- 3. Block -> backend unfollows, so the count must drop back to 0 ---
+        sut.toggleBlock()
+        await yield()
+        #expect(sut.isBlocked == true)
+        #expect(sut.isFollowing == false, "Blocking should unfollow")
+        #expect(sut.profileDetails?.followerCount == 0, "Follower count should drop to 0 after block")
+
+        // --- 4. Unblock then follow again -> count is 1, not 2 ---
+        sut.toggleBlock()
+        await yield()
+        sut.toggleFollow()
+        await yield()
+        #expect(sut.isFollowing == true)
+        #expect(sut.profileDetails?.followerCount == 1, "Following again should not double-count to 2")
+    }
 }
 

--- a/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_ProfileViewModel.swift
+++ b/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_ProfileViewModel.swift
@@ -224,7 +224,7 @@ struct Positive_Only_SocialTests_ProfileViewModel {
         let (requestingUserToken, requestingUser) = try await registerUser(username: "mainRecounter")
         let (_, profileUser) = try await registerUser(username: "profileToRecount")
 
-        let account = "mainRecounter_account"
+        let account = "mainRecounterAccount"
         try await setupLoggedInUser(user: requestingUser, token: requestingUserToken, account: account)
 
         let sut = ProfileViewModel(user: profileUser, api: stubAPI, keychainHelper: keychainHelper, account: account)


### PR DESCRIPTION
## What

Fixes a bug where tapping **Follow → Block → Follow** on a profile left the follower count at **2** instead of **1**.

## Why

The backend `toggle_block` correctly unfollows when you block someone, but both mobile clients use optimistic UI updates that never mirrored that unfollow in the displayed follower count:

- **iOS** (`ProfileViewModel.toggleBlock`): set `isFollowing = false` but the follower-count decrement was commented out. So follow (count→1) → block (count stays 1, `isFollowing` reset to false) → follow again (count→**2**).
- **Android** (`ProfileViewModel.toggleBlock`): never touched `followerCount`, and tracked `_isFollowing` separately from `profileDetails.isFollowing`, letting the follow button and count drift apart.
- **Website**: has no profile/follower UI, so nothing to fix there.

## Changes

- **iOS `toggleBlock`** — decrement `followerCount` and clear `isFollowing` when blocking a user we were following; roll back that side-effect on API error.
- **Android `toggleFollow`** — keep `_isFollowing` in sync with `profileDetails.isFollowing` (optimistic update and revert).
- **Android `toggleBlock`** — decrement `followerCount` and clear follow state when blocking; revert the optimistic unfollow on API failure.

Both decrements only apply when actually following, so blocking a non-followed user won't push the count negative.

## Tests

- Added `follow then block then follow does not double-count followers` (Android) and `testFollowThenBlockThenFollow_DoesNotDoubleCountFollowers` (iOS), both asserting the count ends at **1**.
- Ran the Android suite (`ProfileViewModelTest`) — all tests pass including the new regression test. iOS test mirrors the verified Android logic; the iOS stub unfollows-on-block identically to the backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)