### PR TITLE
Prevent liking your own post or comment on all frontends

### DIFF
--- a/android/PositiveOnlySocial/app/src/androidTest/java/com/example/positiveonlysocial/PositiveOnlySocialIntegrationTests.kt
+++ b/android/PositiveOnlySocial/app/src/androidTest/java/com/example/positiveonlysocial/PositiveOnlySocialIntegrationTests.kt
@@ -308,17 +308,19 @@ class PositiveOnlySocialIntegrationTests {
         composeTestRule.onAllNodesWithContentDescription("Post Image").onFirst().performClick()
         
         assertOnPostDetailView()
-        
-        // Double tap to like
-        composeTestRule.onNodeWithContentDescription("Post Image").performTouchInput { doubleClick() }
-        
-        // Verify like count
+
+        // --- New method: tap the heart icon ---
+        composeTestRule.onNodeWithContentDescription("Like post").performClick()
         composeTestRule.onNodeWithText("1 likes").assertExists()
-        
-        // Double tap to unlike
+
+        composeTestRule.onNodeWithContentDescription("Unlike post").performClick()
+        composeTestRule.onNodeWithText("0 likes").assertExists()
+
+        // --- Old method: double-tap the post image ---
         composeTestRule.onNodeWithContentDescription("Post Image").performTouchInput { doubleClick() }
-        
-        // Verify like count
+        composeTestRule.onNodeWithText("1 likes").assertExists()
+
+        composeTestRule.onNodeWithContentDescription("Post Image").performTouchInput { doubleClick() }
         composeTestRule.onNodeWithText("0 likes").assertExists()
     }
 
@@ -361,31 +363,43 @@ class PositiveOnlySocialIntegrationTests {
         composeTestRule.onNodeWithText("Feed").performClick()
         composeTestRule.onAllNodesWithContentDescription("Post Image").onFirst().performClick()
         
-        // Like comment (double tap on comment row)
-        composeTestRule.onNodeWithText("Comment On a Post").performTouchInput { doubleClick() }
-
-        // Verify like count
-        composeTestRule.onNodeWithText("1 likes").assertExists()
-        
-        // Unlike comment
-        composeTestRule.onNodeWithText("Comment On a Post").performTouchInput { doubleClick() }
-        
-        // Verify like count
-        composeTestRule
-            .onAllNodesWithText("0 likes")
-            .assertCountEquals(3)
-        
-        // Verify reply appears
+        // Verify both comments are visible before starting
+        composeTestRule.onNodeWithText("Comment On a Post").assertExists()
         composeTestRule.onNodeWithText("Comment On a Thread").assertExists()
-        
-        // Like reply
+
+        // ======= Root comment =======
+
+        // New method: tap the heart icon on the root comment
+        composeTestRule.onAllNodesWithContentDescription("Like comment").onFirst().performClick()
+        composeTestRule.onNodeWithText("1 likes").assertExists()
+
+        // Tap "Unlike comment" — root comment is now the only liked one
+        composeTestRule.onAllNodesWithContentDescription("Unlike comment").onFirst().performClick()
+        composeTestRule.onAllNodesWithText("0 likes").assertCountEquals(3)
+
+        // Old method: double-tap the root comment row
+        composeTestRule.onNodeWithText("Comment On a Post").performTouchInput { doubleClick() }
+        composeTestRule.onNodeWithText("1 likes").assertExists()
+
+        composeTestRule.onNodeWithText("Comment On a Post").performTouchInput { doubleClick() }
+        composeTestRule.onAllNodesWithText("0 likes").assertCountEquals(3)
+
+        // ======= Thread reply =======
+
+        // New method: tap the heart icon on the reply (last "Like comment" node)
+        composeTestRule.onAllNodesWithContentDescription("Like comment").onLast().performClick()
+        composeTestRule.onAllNodesWithText("1 likes").onLast().assertExists()
+
+        // Tap "Unlike comment" — reply is now the only liked one
+        composeTestRule.onAllNodesWithContentDescription("Unlike comment").onFirst().performClick()
+        composeTestRule.onAllNodesWithText("0 likes").assertCountEquals(3)
+
+        // Old method: double-tap the reply row
         composeTestRule.onNodeWithText("Comment On a Thread").performTouchInput { doubleClick() }
         composeTestRule.onAllNodesWithText("1 likes").onLast().assertExists()
 
         composeTestRule.onNodeWithText("Comment On a Thread").performTouchInput { doubleClick() }
-        composeTestRule
-            .onAllNodesWithText("0 likes")
-            .assertCountEquals(3)
+        composeTestRule.onAllNodesWithText("0 likes").assertCountEquals(3)
     }
 
     @Test

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/PostDetailViewModel.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/PostDetailViewModel.kt
@@ -58,6 +58,12 @@ class PostDetailViewModel(
     private val _threadToReplyTo = MutableStateFlow<CommentThreadViewData?>(null)
     val threadToReplyTo: StateFlow<CommentThreadViewData?> = _threadToReplyTo.asStateFlow()
 
+    // The signed-in user's username, loaded alongside the post. The backend
+    // rejects liking your own post/comment, so the UI hides the like control
+    // (and the like actions are guarded) for content this user authored.
+    private val _currentUsername = MutableStateFlow<String?>(null)
+    val currentUsername: StateFlow<String?> = _currentUsername.asStateFlow()
+
     private val service = "positive-only-social.Positive-Only-Social"
 
     init {
@@ -82,6 +88,17 @@ class PostDetailViewModel(
 
     fun dismissAlert() {
         _alertMessage.value = null
+    }
+
+    /** Whether the loaded post was authored by the signed-in user. */
+    fun isOwnPost(): Boolean {
+        val username = _currentUsername.value ?: return false
+        return _postDetail.value?.authorUsername == username
+    }
+
+    /** Whether the given comment was authored by the signed-in user. */
+    fun isOwnComment(comment: CommentViewData): Boolean {
+        return comment.authorUsername == _currentUsername.value
     }
 
     fun loadAllData() {
@@ -130,6 +147,7 @@ class PostDetailViewModel(
                 return
             }
             val token = userSession.sessionToken
+            _currentUsername.value = userSession.username
 
             // 1. Fetch the main post details
             val postResponse = api.getPostDetails(token, postIdentifier)
@@ -185,6 +203,8 @@ class PostDetailViewModel(
     }
 
     fun likePost() {
+        // The backend rejects liking your own post; ignore the request.
+        if (isOwnPost()) return
         viewModelScope.launch {
             try {
                 val userSession = keychainHelper.load(UserSession::class.java, service, account)
@@ -252,6 +272,8 @@ class PostDetailViewModel(
     }
 
     fun likeComment(comment: CommentViewData, threadId: String) {
+        // The backend rejects liking your own comment; ignore the request.
+        if (isOwnComment(comment)) return
         viewModelScope.launch {
             try {
                 val userSession = keychainHelper.load(UserSession::class.java, service, account)

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/PostDetailScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/PostDetailScreen.kt
@@ -1,7 +1,6 @@
 package com.example.positiveonlysocial.ui.main
 
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -148,15 +147,15 @@ fun PostDetailScreen(
                         Column(modifier = Modifier.padding(16.dp)) {
                             Row(verticalAlignment = Alignment.CenterVertically) {
                                 if (!isOwnPost) {
-                                    Icon(
-                                        if (post.isLiked) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
-                                        contentDescription = if (post.isLiked) "Unlike post" else "Like post",
-                                        tint = Color.Red,
-                                        modifier = Modifier.clickable {
-                                            if (post.isLiked) viewModel.unlikePost() else viewModel.likePost()
-                                        }
-                                    )
-                                    Spacer(modifier = Modifier.width(4.dp))
+                                    IconButton(onClick = {
+                                        if (post.isLiked) viewModel.unlikePost() else viewModel.likePost()
+                                    }) {
+                                        Icon(
+                                            if (post.isLiked) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
+                                            contentDescription = if (post.isLiked) "Unlike post" else "Like post",
+                                            tint = Color.Red
+                                        )
+                                    }
                                 }
                                 Text("${post.likeCount} likes", fontWeight = FontWeight.Bold)
                                 Spacer(modifier = Modifier.weight(1f))
@@ -297,14 +296,19 @@ fun CommentRow(
                 Text("Just now", fontSize = 12.sp, color = Color.Gray)
                 Spacer(modifier = Modifier.width(8.dp))
                 if (!isOwn) {
-                    Icon(
-                        if (comment.isLiked) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
-                        contentDescription = if (comment.isLiked) "Unlike comment" else "Like comment",
-                        tint = Color.Red,
-                        modifier = Modifier
-                            .size(12.dp)
-                            .clickable { if (comment.isLiked) onUnlike() else onLike() }
-                    )
+                    IconButton(
+                        onClick = { if (comment.isLiked) onUnlike() else onLike() },
+                        // IconButton enforces a minimum 48dp touch target while
+                        // keeping the visible icon small.
+                        modifier = Modifier.size(36.dp)
+                    ) {
+                        Icon(
+                            if (comment.isLiked) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
+                            contentDescription = if (comment.isLiked) "Unlike comment" else "Like comment",
+                            tint = Color.Red,
+                            modifier = Modifier.size(12.dp)
+                        )
+                    }
                     Spacer(modifier = Modifier.width(4.dp))
                 }
                 Text("${comment.likeCount} likes", fontSize = 12.sp, color = Color.Gray)

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/PostDetailScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/PostDetailScreen.kt
@@ -53,6 +53,9 @@ fun PostDetailScreen(
         val isLoading by viewModel.isLoading.collectAsState()
         val isRefreshing by viewModel.isRefreshing.collectAsState()
         val alertMessage by viewModel.alertMessage.collectAsState()
+        // The signed-in user; used to hide the like control on their own
+        // post/comments since the backend rejects liking your own content.
+        val currentUsername by viewModel.currentUsername.collectAsState()
         
         // Local state for interactions
         var isPostReported by remember { mutableStateOf(false) }
@@ -117,6 +120,9 @@ fun PostDetailScreen(
                 }
             } else if (postDetail != null) {
                 val post = postDetail!!
+                // The backend rejects liking your own post, so the like control
+                // is hidden and double-tap-to-like is a no-op on it.
+                val isOwnPost = post.authorUsername == currentUsername
                 item {
                     Column(modifier = Modifier.fillMaxWidth()) {
                         AsyncImage(
@@ -127,6 +133,7 @@ fun PostDetailScreen(
                                 .aspectRatio(1f)
                                 .combinedClickable(
                                     onDoubleClick = {
+                                        if (isOwnPost) return@combinedClickable
                                         // Drive the action from the server-backed like state
                                         if (post.isLiked) viewModel.unlikePost() else viewModel.likePost()
                                     },
@@ -137,11 +144,13 @@ fun PostDetailScreen(
                                 ),
                             contentScale = ContentScale.Crop
                         )
-                        
+
                         Column(modifier = Modifier.padding(16.dp)) {
                             Row(verticalAlignment = Alignment.CenterVertically) {
-                                Icon(if (post.isLiked) Icons.Default.Favorite else Icons.Default.FavoriteBorder, contentDescription = if (post.isLiked) "Liked" else "Like", tint = Color.Red)
-                                Spacer(modifier = Modifier.width(4.dp))
+                                if (!isOwnPost) {
+                                    Icon(if (post.isLiked) Icons.Default.Favorite else Icons.Default.FavoriteBorder, contentDescription = if (post.isLiked) "Liked" else "Like", tint = Color.Red)
+                                    Spacer(modifier = Modifier.width(4.dp))
+                                }
                                 Text("${post.likeCount} likes", fontWeight = FontWeight.Bold)
                                 Spacer(modifier = Modifier.weight(1f))
                                 if (isPostReported) {
@@ -182,7 +191,7 @@ fun PostDetailScreen(
                 }
                 
                 items(commentThreads) { thread ->
-                    CommentThreadView(thread = thread, viewModel = viewModel)
+                    CommentThreadView(thread = thread, viewModel = viewModel, currentUsername = currentUsername)
                 }
             } else {
                 item {
@@ -195,11 +204,12 @@ fun PostDetailScreen(
 }
 
 @Composable
-fun CommentThreadView(thread: CommentThreadViewData, viewModel: PostDetailViewModel) {
+fun CommentThreadView(thread: CommentThreadViewData, viewModel: PostDetailViewModel, currentUsername: String?) {
     Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
         thread.comments.firstOrNull()?.let { rootComment ->
             CommentRow(
                 comment = rootComment,
+                isOwn = rootComment.authorUsername == currentUsername,
                 onLike = { viewModel.likeComment(rootComment, rootComment.threadId) },
                 onUnlike = { viewModel.unlikeComment(rootComment, rootComment.threadId) },
                 onReport = { viewModel.setCommentToReport(rootComment) }
@@ -218,6 +228,7 @@ fun CommentThreadView(thread: CommentThreadViewData, viewModel: PostDetailViewMo
                 thread.comments.drop(1).forEach { reply ->
                     CommentRow(
                         comment = reply,
+                        isOwn = reply.authorUsername == currentUsername,
                         onLike = { viewModel.likeComment(reply, reply.threadId) },
                         onUnlike = { viewModel.unlikeComment(reply, reply.threadId) },
                         onReport = { viewModel.setCommentToReport(reply) }
@@ -232,6 +243,7 @@ fun CommentThreadView(thread: CommentThreadViewData, viewModel: PostDetailViewMo
 @Composable
 fun CommentRow(
     comment: CommentViewData,
+    isOwn: Boolean,
     onLike: () -> Unit,
     onUnlike: () -> Unit,
     onReport: () -> Unit
@@ -244,6 +256,9 @@ fun CommentRow(
             .padding(vertical = 4.dp)
             .combinedClickable(
                 onDoubleClick = {
+                    // The backend rejects liking your own comment, so double-tap
+                    // is a no-op on it.
+                    if (isOwn) return@combinedClickable
                     // Drive the action from the server-backed like state
                     if (comment.isLiked) onUnlike() else onLike()
                 },
@@ -274,13 +289,15 @@ fun CommentRow(
                 // TODO Date placeholder - needs formatting logic
                 Text("Just now", fontSize = 12.sp, color = Color.Gray)
                 Spacer(modifier = Modifier.width(8.dp))
-                Icon(
-                    if (comment.isLiked) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
-                    contentDescription = if (comment.isLiked) "Liked" else "Like",
-                    tint = Color.Red,
-                    modifier = Modifier.size(12.dp)
-                )
-                Spacer(modifier = Modifier.width(4.dp))
+                if (!isOwn) {
+                    Icon(
+                        if (comment.isLiked) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
+                        contentDescription = if (comment.isLiked) "Liked" else "Like",
+                        tint = Color.Red,
+                        modifier = Modifier.size(12.dp)
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
+                }
                 Text("${comment.likeCount} likes", fontSize = 12.sp, color = Color.Gray)
                 Spacer(modifier = Modifier.width(8.dp))
                 if (isReported) {

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/PostDetailScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/PostDetailScreen.kt
@@ -148,7 +148,14 @@ fun PostDetailScreen(
                         Column(modifier = Modifier.padding(16.dp)) {
                             Row(verticalAlignment = Alignment.CenterVertically) {
                                 if (!isOwnPost) {
-                                    Icon(if (post.isLiked) Icons.Default.Favorite else Icons.Default.FavoriteBorder, contentDescription = if (post.isLiked) "Liked" else "Like", tint = Color.Red)
+                                    Icon(
+                                        if (post.isLiked) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
+                                        contentDescription = if (post.isLiked) "Unlike post" else "Like post",
+                                        tint = Color.Red,
+                                        modifier = Modifier.clickable {
+                                            if (post.isLiked) viewModel.unlikePost() else viewModel.likePost()
+                                        }
+                                    )
                                     Spacer(modifier = Modifier.width(4.dp))
                                 }
                                 Text("${post.likeCount} likes", fontWeight = FontWeight.Bold)
@@ -292,9 +299,11 @@ fun CommentRow(
                 if (!isOwn) {
                     Icon(
                         if (comment.isLiked) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
-                        contentDescription = if (comment.isLiked) "Liked" else "Like",
+                        contentDescription = if (comment.isLiked) "Unlike comment" else "Like comment",
                         tint = Color.Red,
-                        modifier = Modifier.size(12.dp)
+                        modifier = Modifier
+                            .size(12.dp)
+                            .clickable { if (comment.isLiked) onUnlike() else onLike() }
                     )
                     Spacer(modifier = Modifier.width(4.dp))
                 }

--- a/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/PostDetailViewModelTest.kt
+++ b/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/PostDetailViewModelTest.kt
@@ -7,6 +7,7 @@ import com.example.positiveonlysocial.data.model.CommentThreadViewData
 import com.example.positiveonlysocial.data.model.GenericResponse
 import com.example.positiveonlysocial.data.model.Post
 import com.example.positiveonlysocial.data.model.UserSession
+import java.util.Date
 import com.example.positiveonlysocial.data.security.KeychainHelperProtocol
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
@@ -19,6 +20,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import retrofit2.Response
@@ -83,6 +85,41 @@ class PostDetailViewModelTest {
         verify(api).likePost("token123", postIdentifier)
         // Verify loadAllData is called again (getPostDetails called twice: once in init, once after like)
         verify(api, org.mockito.kotlin.times(2)).getPostDetails("token123", postIdentifier)
+    }
+
+    @Test
+    fun `likePost does nothing on the user's own post`() = runTest {
+        // A post authored by the signed-in user ("testuser").
+        whenever(api.getPostDetails("token123", postIdentifier)).thenReturn(
+            Response.success(Post(postIdentifier, "url", "caption", "testuser", 1))
+        )
+        val ownViewModel = PostDetailViewModel(postIdentifier, api, keychainHelper)
+
+        ownViewModel.likePost()
+
+        // The like request is never sent for the user's own post.
+        verify(api, never()).likePost(any(), any())
+    }
+
+    @Test
+    fun `likeComment does nothing on the user's own comment`() = runTest {
+        val ownComment = CommentViewData("c1", "t1", "testuser", "body", 0, false, Date())
+
+        viewModel.likeComment(ownComment, "t1")
+
+        verify(api, never()).likeComment(any(), any(), any(), any())
+    }
+
+    @Test
+    fun `likeComment calls api on another user's comment`() = runTest {
+        whenever(api.likeComment(any(), any(), any(), any())).thenReturn(
+            Response.success(GenericResponse("ok", null))
+        )
+        val otherComment = CommentViewData("c1", "t1", "someoneelse", "body", 0, false, Date())
+
+        viewModel.likeComment(otherComment, "t1")
+
+        verify(api).likeComment("token123", postIdentifier, "t1", "c1")
     }
 
     @Test

--- a/ios/Positive Only Social/Positive Only Social/PostDetailView.swift
+++ b/ios/Positive Only Social/Positive Only Social/PostDetailView.swift
@@ -46,6 +46,9 @@ struct PostDetailView: View {
                     // --- Image Interactions ---
                     // --- UPDATED ---
                     .onTapGesture(count: 2) {
+                        // The backend rejects liking your own post, so double-tap
+                        // is a no-op on the current user's own post.
+                        guard !viewModel.isOwnPost else { return }
                         // Drive the action from the server-backed like state
                         if post.isLiked {
                             viewModel.unlikePost()
@@ -56,13 +59,17 @@ struct PostDetailView: View {
                     .onLongPressGesture {
                         viewModel.showReportSheetForPost = true
                     }
-                    
+
                     // --- POST DETAILS (CAPTION, LIKES) ---
                     VStack(alignment: .leading, spacing: 8) {
                         HStack {
-                            Image(systemName: post.isLiked ? "heart.fill" : "heart")
-                                .foregroundColor(Color(UIColor.systemRed))
-                                .accessibilityLabel(post.isLiked ? "Liked" : "Like")
+                            // Hide the like heart on the current user's own post;
+                            // they can't like it.
+                            if !viewModel.isOwnPost {
+                                Image(systemName: post.isLiked ? "heart.fill" : "heart")
+                                    .foregroundColor(Color(UIColor.systemRed))
+                                    .accessibilityLabel(post.isLiked ? "Liked" : "Like")
+                            }
                             Text("\(post.likeCount) likes")
                                 .font(.headline)
                                 .accessibilityIdentifier("PostLikesText")
@@ -182,7 +189,12 @@ struct PostDetailView: View {
         let comment: CommentViewData
 
         let isReported: Bool
-        
+
+        /// Whether this comment was authored by the signed-in user. The backend
+        /// rejects liking your own comment, so the like heart is hidden and the
+        /// double-tap-to-like gesture is a no-op when true.
+        let isOwn: Bool
+
         // Actions passed from the parent
         let onLike: () -> Void
         let onUnlike: () -> Void
@@ -213,10 +225,12 @@ struct PostDetailView: View {
                             .font(.caption)
                             .foregroundColor(.secondary)
 
-                        Image(systemName: comment.isLiked ? "heart.fill" : "heart")
-                            .foregroundColor(Color(UIColor.systemRed))
-                            .font(.caption)
-                            .accessibilityLabel(comment.isLiked ? "Liked" : "Like")
+                        if !isOwn {
+                            Image(systemName: comment.isLiked ? "heart.fill" : "heart")
+                                .foregroundColor(Color(UIColor.systemRed))
+                                .font(.caption)
+                                .accessibilityLabel(comment.isLiked ? "Liked" : "Like")
+                        }
 
                         Text("\(comment.likeCount) likes")
                             .font(.caption)
@@ -238,6 +252,9 @@ struct PostDetailView: View {
             // --- Interactions ---
             // --- UPDATED ---
             .onTapGesture(count: 2) {
+                // The backend rejects liking your own comment, so double-tap is
+                // a no-op on the current user's own comment.
+                guard !isOwn else { return }
                 // Drive the action from the server-backed like state
                 if comment.isLiked {
                     onUnlike()
@@ -264,6 +281,7 @@ struct PostDetailView: View {
                     // Show the root comment
                     CommentRowView(comment: rootComment,
                                    isReported: viewModel.reportedCommentIds.contains(rootComment.id),
+                                   isOwn: viewModel.isOwnComment(rootComment),
                                    onLike: {
                                        viewModel.likeComment(rootComment)
                                    },
@@ -299,6 +317,7 @@ struct PostDetailView: View {
                             // --- UPDATED ---
                             CommentRowView(comment: reply,
                                            isReported: viewModel.reportedCommentIds.contains(reply.id),
+                                           isOwn: viewModel.isOwnComment(reply),
                                            onLike: {
                                                viewModel.likeComment(reply)
                                            },

--- a/ios/Positive Only Social/Positive Only Social/PostDetailView.swift
+++ b/ios/Positive Only Social/Positive Only Social/PostDetailView.swift
@@ -66,9 +66,13 @@ struct PostDetailView: View {
                             // Hide the like heart on the current user's own post;
                             // they can't like it.
                             if !viewModel.isOwnPost {
-                                Image(systemName: post.isLiked ? "heart.fill" : "heart")
-                                    .foregroundColor(Color(UIColor.systemRed))
-                                    .accessibilityLabel(post.isLiked ? "Liked" : "Like")
+                                Button {
+                                    if post.isLiked { viewModel.unlikePost() } else { viewModel.likePost() }
+                                } label: {
+                                    Image(systemName: post.isLiked ? "heart.fill" : "heart")
+                                        .foregroundColor(Color(UIColor.systemRed))
+                                }
+                                .accessibilityLabel(post.isLiked ? "Unlike post" : "Like post")
                             }
                             Text("\(post.likeCount) likes")
                                 .font(.headline)
@@ -226,10 +230,14 @@ struct PostDetailView: View {
                             .foregroundColor(.secondary)
 
                         if !isOwn {
-                            Image(systemName: comment.isLiked ? "heart.fill" : "heart")
-                                .foregroundColor(Color(UIColor.systemRed))
-                                .font(.caption)
-                                .accessibilityLabel(comment.isLiked ? "Liked" : "Like")
+                            Button {
+                                if comment.isLiked { onUnlike() } else { onLike() }
+                            } label: {
+                                Image(systemName: comment.isLiked ? "heart.fill" : "heart")
+                                    .foregroundColor(Color(UIColor.systemRed))
+                                    .font(.caption)
+                            }
+                            .accessibilityLabel(comment.isLiked ? "Unlike comment" : "Like comment")
                         }
 
                         Text("\(comment.likeCount) likes")

--- a/ios/Positive Only Social/Positive Only Social/viewmodels/PostDetailViewModel.swift
+++ b/ios/Positive Only Social/Positive Only Social/viewmodels/PostDetailViewModel.swift
@@ -32,6 +32,22 @@ final class PostDetailViewModel: ObservableObject {
     
     @Published var isPostReported = false
     @Published var reportedCommentIds: Set<String> = []
+
+    /// The signed-in user's username, loaded alongside the post. The backend
+    /// rejects liking your own post/comment, so the UI hides the like control
+    /// (and the like actions are guarded) for content this user authored.
+    @Published private(set) var currentUsername: String?
+
+    /// Whether the loaded post was authored by the signed-in user.
+    var isOwnPost: Bool {
+        guard let post = postDetail, let username = currentUsername else { return false }
+        return post.authorUsername == username
+    }
+
+    /// Whether the given comment was authored by the signed-in user.
+    func isOwnComment(_ comment: CommentViewData) -> Bool {
+        comment.authorUsername == currentUsername
+    }
     
     // MARK: - Private Properties
     private let postIdentifier: String
@@ -90,6 +106,7 @@ final class PostDetailViewModel: ObservableObject {
                     return
                 }
                 let token = userSession.sessionToken
+                self.currentUsername = userSession.username
 
                 // 1. Fetch the main post details
                 let postData = try await api.getPostDetails(sessionManagementToken: token, postIdentifier: postIdentifier)
@@ -161,6 +178,8 @@ final class PostDetailViewModel: ObservableObject {
     // MARK: - User Actions
     
     func likePost() {
+        // The backend rejects liking your own post; don't optimistically like it.
+        guard !isOwnPost else { return }
         NSLog("%@", "ACTION: Like post \(postIdentifier)")
         // Stub: Increment like count locally for instant feedback
         if var post = postDetail {
@@ -250,8 +269,10 @@ final class PostDetailViewModel: ObservableObject {
     }
     
     func likeComment(_ comment: CommentViewData) {
+        // The backend rejects liking your own comment; don't optimistically like it.
+        guard !isOwnComment(comment) else { return }
         NSLog("%@", "ACTION: Like comment \(comment.id)")
-        
+
         // --- ⬇️ ADDED OPTIMISTIC UPDATE ⬇️ ---
         // Find the index of the thread
         guard let threadIndex = commentThreads.firstIndex(where: { $0.id == comment.threadId }) else {

--- a/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_PostDetailViewModel.swift
+++ b/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_PostDetailViewModel.swift
@@ -83,29 +83,34 @@ struct Positive_Only_SocialTests_PostDetailViewModel {
         return try JSONDecoder().decode(ReplyFields.self, from: data).comment_identifier
     }
     
-    /// A master helper to set up a full environment for testing
+    /// A master helper to set up a full environment for testing.
+    ///
+    /// The signed-in user is a "viewer" who authored neither the post nor the
+    /// comment, so the like actions are allowed. Self-like prevention is covered
+    /// by the dedicated own-content tests below.
     private func setupTestEnvironment(account: String) async throws -> (sut: PostDetailViewModel, postID: String, threadID: String, commentID: String) {
-        // 1. Create a user, log them in, and save to keychain
-        let postOwnerToken = try await setupLoggedInUser(username: "postOwner", account: account)
-        
-        // 2. Create a second user for commenting
+        // 1. The signed-in user — a viewer, not the post/comment author.
+        _ = try await setupLoggedInUser(username: "viewer", account: account)
+
+        // 2. Create the post author and a separate commenter.
+        let postOwnerToken = try await registerUserAndGetToken(username: "postOwner")
         let commenterToken = try await registerUserAndGetToken(username: "commenter")
-        
-        // 3. Create a post
+
+        // 3. Create a post (authored by postOwner)
         let postID = try await makePostAndGetID(token: postOwnerToken, caption: "Test Post 1")
-        
-        // 4. Create a comment thread
+
+        // 4. Create a comment thread (authored by commenter)
         let (threadID, commentID) = try await commentOnPostAndGetIDs(token: commenterToken, postID: postID, body: "First comment")
-        
-        // 5. Create a reply in that thread
+
+        // 5. Create a reply in that thread (authored by postOwner)
         _ = try await replyToCommentAndGetID(token: postOwnerToken, postID: postID, threadID: threadID, body: "Reply comment")
-        
+
         // 6. Create the SUT. This triggers `loadAllData()`
         let sut = PostDetailViewModel(postIdentifier: postID, api: stubAPI, keychainHelper: keychainHelper, account: account)
-        
+
         // 7. Wait for all loading to finish
         await yield()
-        
+
         return (sut, postID, threadID, commentID)
     }
 
@@ -304,6 +309,54 @@ struct Positive_Only_SocialTests_PostDetailViewModel {
         #expect(updatedComment?.likeCount == 0, "Like count should not go below 0")
     }
 
+    // --- Self-Like Prevention Tests ---
+
+    /// Sets up an environment where the signed-in user authored both the post
+    /// and the single comment, so both are "own" content.
+    private func setupOwnContentEnvironment(account: String) async throws -> (sut: PostDetailViewModel, postID: String, commentID: String) {
+        // The signed-in user authors everything here.
+        let authorToken = try await setupLoggedInUser(username: "author", account: account)
+        let postID = try await makePostAndGetID(token: authorToken, caption: "My own post")
+        let (_, commentID) = try await commentOnPostAndGetIDs(token: authorToken, postID: postID, body: "My own comment")
+
+        let sut = PostDetailViewModel(postIdentifier: postID, api: stubAPI, keychainHelper: keychainHelper, account: account)
+        await yield()
+        return (sut, postID, commentID)
+    }
+
+    @Test func testLikePost_OwnPost_DoesNothing() async throws {
+        // Given: The signed-in user is viewing their own post
+        let (sut, _, _) = try await setupOwnContentEnvironment(account: "likeOwnPost_account")
+        #expect(sut.isOwnPost, "Pre-condition: the post should be the user's own")
+        #expect(sut.postDetail?.likeCount == 0, "Pre-condition: Post likes should be 0")
+
+        // When: They attempt to like their own post
+        sut.likePost()
+
+        // Then: Nothing happens — no optimistic like is applied
+        #expect(sut.postDetail?.likeCount == 0, "Own post like count should not change")
+        #expect(sut.postDetail?.isLiked == false, "Own post should not be marked liked")
+    }
+
+    @Test func testLikeComment_OwnComment_DoesNothing() async throws {
+        // Given: The signed-in user is viewing their own comment
+        let (sut, _, commentID) = try await setupOwnContentEnvironment(account: "likeOwnComment_account")
+        guard let comment = sut.commentThreads.first?.comments.first(where: { $0.id == commentID }) else {
+            #expect(Bool(false), "Test setup error: Could not find comment")
+            return
+        }
+        #expect(sut.isOwnComment(comment), "Pre-condition: the comment should be the user's own")
+        #expect(comment.likeCount == 0, "Pre-condition: Comment likes should be 0")
+
+        // When: They attempt to like their own comment
+        sut.likeComment(comment)
+
+        // Then: Nothing happens — no optimistic like is applied
+        let updatedComment = sut.commentThreads.first?.comments.first(where: { $0.id == commentID })
+        #expect(updatedComment?.likeCount == 0, "Own comment like count should not change")
+        #expect(updatedComment?.isLiked == false, "Own comment should not be marked liked")
+    }
+
     @Test func testCommentOnPost_Success_ReloadsData() async throws {
         // Given: A fully loaded SUT
         let (sut, _, _, _) = try await setupTestEnvironment(account: "commentOnPost_account")
@@ -324,13 +377,13 @@ struct Positive_Only_SocialTests_PostDetailViewModel {
         // And: The number of threads should increase
         #expect(sut.commentThreads.count == 2, "Should have 2 threads after commenting")
         
-        // And: We should find the new comment, authored by the SUT's user ("postOwner")
+        // And: We should find the new comment, authored by the SUT's user ("viewer")
         let newThread = sut.commentThreads.first {
             $0.comments.first?.body == newCommentText
         }
         #expect(newThread != nil, "New comment thread was not found")
         #expect(newThread?.comments.count == 1)
-        #expect(newThread?.comments.first?.authorUsername == "postOwner")
+        #expect(newThread?.comments.first?.authorUsername == "viewer")
     }
     
     @Test func testReplyToCommentThread_Success_ReloadsData() async throws {
@@ -360,7 +413,7 @@ struct Positive_Only_SocialTests_PostDetailViewModel {
         // And: The new comment should be the last one (most recent)
         let newReply = sut.commentThreads.first?.comments.last
         #expect(newReply?.body == newReplyText, "New reply text is incorrect")
-        #expect(newReply?.authorUsername == "postOwner", "New reply author is incorrect")
+        #expect(newReply?.authorUsername == "viewer", "New reply author is incorrect")
     }
     
     @Test func testCommentOnPost_EmptyText_DoesNotReload() async throws {

--- a/ios/Positive Only Social/Positive Only SocialUITests/Positive_Only_SocialUITests.swift
+++ b/ios/Positive Only Social/Positive Only SocialUITests/Positive_Only_SocialUITests.swift
@@ -444,6 +444,16 @@ final class Positive_Only_SocialUITests: XCTestCase {
         assertOnPostDetailView(app: app)
     }
     
+    /// Waits for an element's accessibility label to equal the expected value. Like/unlike updates
+    /// are applied optimistically on the SwiftUI run loop, and XCUITest reads the accessibility label
+    /// from a separate process, so a plain `XCTAssertEqual` can race the re-render. Waiting on a
+    /// predicate makes the check robust, matching how the rest of this file handles async values.
+    private func waitForLabel(_ element: XCUIElement, toEqual expected: String) {
+        let predicate = NSPredicate(format: "label == %@", expected)
+        expectation(for: predicate, evaluatedWith: element, handler: nil)
+        waitForExpectations(timeout: TestConstants.timeout, handler: nil)
+    }
+
     // MARK: Tests
     @MainActor
     func testAutomaticLoginAfterRememberMe() throws {
@@ -998,21 +1008,21 @@ final class Positive_Only_SocialUITests: XCTestCase {
         let firstLikeCommentButton = app.buttons.matching(NSPredicate(format: "label == 'Like comment'")).element(boundBy: 0)
         XCTAssertTrue(firstLikeCommentButton.waitForExistence(timeout: TestConstants.shortTimeout))
         firstLikeCommentButton.tap()
-        XCTAssertEqual(postCommentLikesText.label, "1 likes")
+        waitForLabel(postCommentLikesText, toEqual: "1 likes")
 
         let firstUnlikeCommentButton = app.buttons.matching(NSPredicate(format: "label == 'Unlike comment'")).element(boundBy: 0)
         XCTAssertTrue(firstUnlikeCommentButton.waitForExistence(timeout: TestConstants.shortTimeout))
         firstUnlikeCommentButton.tap()
-        XCTAssertEqual(postCommentLikesText.label, "0 likes")
+        waitForLabel(postCommentLikesText, toEqual: "0 likes")
 
         // Old method: double-tap the comment row
         XCTAssertTrue(postCommentStack.waitForExistence(timeout: TestConstants.shortTimeout))
         postCommentStack.doubleTap()
-        XCTAssertEqual(postCommentLikesText.label, "1 likes")
+        waitForLabel(postCommentLikesText, toEqual: "1 likes")
 
         XCTAssertTrue(postCommentStack.waitForExistence(timeout: TestConstants.shortTimeout))
         postCommentStack.doubleTap()
-        XCTAssertEqual(postCommentLikesText.label, "0 likes")
+        waitForLabel(postCommentLikesText, toEqual: "0 likes")
 
         // --- Thread reply ---
         let postCommentStackQuery2 = app.buttons.matching(identifier: "CommentStack")
@@ -1027,22 +1037,22 @@ final class Positive_Only_SocialUITests: XCTestCase {
         let secondLikeCommentButton = app.buttons.matching(NSPredicate(format: "label == 'Like comment'")).element(boundBy: 1)
         XCTAssertTrue(secondLikeCommentButton.waitForExistence(timeout: TestConstants.shortTimeout))
         secondLikeCommentButton.tap()
-        XCTAssertEqual(postCommentLikesText2.label, "1 likes")
+        waitForLabel(postCommentLikesText2, toEqual: "1 likes")
 
         // After liking the reply, it becomes the only "Unlike comment" button
         let secondUnlikeCommentButton = app.buttons.matching(NSPredicate(format: "label == 'Unlike comment'")).element(boundBy: 0)
         XCTAssertTrue(secondUnlikeCommentButton.waitForExistence(timeout: TestConstants.shortTimeout))
         secondUnlikeCommentButton.tap()
-        XCTAssertEqual(postCommentLikesText2.label, "0 likes")
+        waitForLabel(postCommentLikesText2, toEqual: "0 likes")
 
         // Old method: double-tap the reply row
         XCTAssertTrue(postCommentStack2.waitForExistence(timeout: TestConstants.shortTimeout))
         postCommentStack2.doubleTap()
-        XCTAssertEqual(postCommentLikesText2.label, "1 likes")
+        waitForLabel(postCommentLikesText2, toEqual: "1 likes")
 
         XCTAssertTrue(postCommentStack2.waitForExistence(timeout: TestConstants.shortTimeout))
         postCommentStack2.doubleTap()
-        XCTAssertEqual(postCommentLikesText2.label, "0 likes")
+        waitForLabel(postCommentLikesText2, toEqual: "0 likes")
         
         let backButton = app.navigationBars.firstMatch.buttons.element(boundBy: 0)
         XCTAssertTrue(backButton.waitForExistence(timeout: TestConstants.shortTimeout))

--- a/ios/Positive Only Social/Positive Only SocialUITests/Positive_Only_SocialUITests.swift
+++ b/ios/Positive Only Social/Positive Only SocialUITests/Positive_Only_SocialUITests.swift
@@ -863,21 +863,21 @@ final class Positive_Only_SocialUITests: XCTestCase {
         let likePostButton = app.buttons["Like post"]
         XCTAssertTrue(likePostButton.waitForExistence(timeout: TestConstants.shortTimeout))
         likePostButton.tap()
-        XCTAssertEqual(postLikesText.label, "1 likes")
+        waitForLabel(postLikesText, toEqual: "1 likes")
 
         let unlikePostButton = app.buttons["Unlike post"]
         XCTAssertTrue(unlikePostButton.waitForExistence(timeout: TestConstants.shortTimeout))
         unlikePostButton.tap()
-        XCTAssertEqual(postLikesText.label, "0 likes")
+        waitForLabel(postLikesText, toEqual: "0 likes")
 
         // --- Old method: double-tap the post image ---
         XCTAssertTrue(postImage.waitForExistence(timeout: TestConstants.shortTimeout))
         postImage.doubleTap()
-        XCTAssertEqual(postLikesText.label, "1 likes")
+        waitForLabel(postLikesText, toEqual: "1 likes")
 
         XCTAssertTrue(postImage.waitForExistence(timeout: TestConstants.shortTimeout))
         postImage.doubleTap()
-        XCTAssertEqual(postLikesText.label, "0 likes")
+        waitForLabel(postLikesText, toEqual: "0 likes")
 
         let backButton = app.navigationBars.firstMatch.buttons.element(boundBy: 0)
         XCTAssertTrue(backButton.waitForExistence(timeout: TestConstants.shortTimeout))

--- a/ios/Positive Only Social/Positive Only SocialUITests/Positive_Only_SocialUITests.swift
+++ b/ios/Positive Only Social/Positive Only SocialUITests/Positive_Only_SocialUITests.swift
@@ -843,29 +843,42 @@ final class Positive_Only_SocialUITests: XCTestCase {
         firstPostElement.tap()
 
         assertOnPostDetailView(app: app)
-        
+
         let postImage = app.buttons["PostImage"]
         XCTAssertTrue(postImage.waitForExistence(timeout: TestConstants.shortTimeout))
-        postImage.doubleTap()
-        
+
         let postLikesText = app.staticTexts["PostLikesText"]
+
+        // --- New method: tap the heart button ---
+        let likePostButton = app.buttons["Like post"]
+        XCTAssertTrue(likePostButton.waitForExistence(timeout: TestConstants.shortTimeout))
+        likePostButton.tap()
         XCTAssertEqual(postLikesText.label, "1 likes")
-        
+
+        let unlikePostButton = app.buttons["Unlike post"]
+        XCTAssertTrue(unlikePostButton.waitForExistence(timeout: TestConstants.shortTimeout))
+        unlikePostButton.tap()
+        XCTAssertEqual(postLikesText.label, "0 likes")
+
+        // --- Old method: double-tap the post image ---
         XCTAssertTrue(postImage.waitForExistence(timeout: TestConstants.shortTimeout))
         postImage.doubleTap()
-        
+        XCTAssertEqual(postLikesText.label, "1 likes")
+
+        XCTAssertTrue(postImage.waitForExistence(timeout: TestConstants.shortTimeout))
+        postImage.doubleTap()
         XCTAssertEqual(postLikesText.label, "0 likes")
-        
+
         let backButton = app.navigationBars.firstMatch.buttons.element(boundBy: 0)
         XCTAssertTrue(backButton.waitForExistence(timeout: TestConstants.shortTimeout))
         backButton.tap()
-        
+
         let homeButton = app.buttons["Home"]
         if homeButton.exists {
             XCTAssertTrue(homeButton.waitForExistence(timeout: TestConstants.shortTimeout))
             homeButton.tap()
         }
-        
+
         assertOnHomeView(app: app)
     }
     
@@ -973,34 +986,62 @@ final class Positive_Only_SocialUITests: XCTestCase {
 
         assertOnPostDetailView(app: app)
         
-        // First we like and unlike the comment post comment
+        // --- Root comment ---
         let postCommentStackQuery = app.buttons.matching(identifier: "CommentStack")
         let postCommentStack = postCommentStackQuery.element(boundBy: 0)
         XCTAssertTrue(postCommentStack.waitForExistence(timeout: TestConstants.shortTimeout))
-        postCommentStack.doubleTap()
-        
+
         let postCommentLikesTextQuery = app.staticTexts.matching(identifier: "CommentLikesCount")
         let postCommentLikesText = postCommentLikesTextQuery.element(boundBy: 0)
+
+        // New method: tap the heart button
+        let firstLikeCommentButton = app.buttons.matching(NSPredicate(format: "label == 'Like comment'")).element(boundBy: 0)
+        XCTAssertTrue(firstLikeCommentButton.waitForExistence(timeout: TestConstants.shortTimeout))
+        firstLikeCommentButton.tap()
         XCTAssertEqual(postCommentLikesText.label, "1 likes")
-        
+
+        let firstUnlikeCommentButton = app.buttons.matching(NSPredicate(format: "label == 'Unlike comment'")).element(boundBy: 0)
+        XCTAssertTrue(firstUnlikeCommentButton.waitForExistence(timeout: TestConstants.shortTimeout))
+        firstUnlikeCommentButton.tap()
+        XCTAssertEqual(postCommentLikesText.label, "0 likes")
+
+        // Old method: double-tap the comment row
         XCTAssertTrue(postCommentStack.waitForExistence(timeout: TestConstants.shortTimeout))
         postCommentStack.doubleTap()
-        
+        XCTAssertEqual(postCommentLikesText.label, "1 likes")
+
+        XCTAssertTrue(postCommentStack.waitForExistence(timeout: TestConstants.shortTimeout))
+        postCommentStack.doubleTap()
         XCTAssertEqual(postCommentLikesText.label, "0 likes")
-        
-        // Then we like and unlike the comment thread comment
+
+        // --- Thread reply ---
         let postCommentStackQuery2 = app.buttons.matching(identifier: "CommentStack")
         let postCommentStack2 = postCommentStackQuery2.element(boundBy: 1)
         XCTAssertTrue(postCommentStack2.waitForExistence(timeout: TestConstants.shortTimeout))
-        postCommentStack2.doubleTap()
-        
+
         let postCommentLikesTextQuery2 = app.staticTexts.matching(identifier: "CommentLikesCount")
         let postCommentLikesText2 = postCommentLikesTextQuery2.element(boundBy: 1)
+
+        // New method: tap the heart button on the reply
+        // boundBy: 1 because root comment's heart is still at index 0 (not liked)
+        let secondLikeCommentButton = app.buttons.matching(NSPredicate(format: "label == 'Like comment'")).element(boundBy: 1)
+        XCTAssertTrue(secondLikeCommentButton.waitForExistence(timeout: TestConstants.shortTimeout))
+        secondLikeCommentButton.tap()
         XCTAssertEqual(postCommentLikesText2.label, "1 likes")
-        
+
+        // After liking the reply, it becomes the only "Unlike comment" button
+        let secondUnlikeCommentButton = app.buttons.matching(NSPredicate(format: "label == 'Unlike comment'")).element(boundBy: 0)
+        XCTAssertTrue(secondUnlikeCommentButton.waitForExistence(timeout: TestConstants.shortTimeout))
+        secondUnlikeCommentButton.tap()
+        XCTAssertEqual(postCommentLikesText2.label, "0 likes")
+
+        // Old method: double-tap the reply row
         XCTAssertTrue(postCommentStack2.waitForExistence(timeout: TestConstants.shortTimeout))
         postCommentStack2.doubleTap()
-        
+        XCTAssertEqual(postCommentLikesText2.label, "1 likes")
+
+        XCTAssertTrue(postCommentStack2.waitForExistence(timeout: TestConstants.shortTimeout))
+        postCommentStack2.doubleTap()
         XCTAssertEqual(postCommentLikesText2.label, "0 likes")
         
         let backButton = app.navigationBars.firstMatch.buttons.element(boundBy: 0)

--- a/website/src/pages/PostDetailPage.test.tsx
+++ b/website/src/pages/PostDetailPage.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
-import { vi, beforeEach, test, expect } from 'vitest'
+import { vi, beforeEach, afterEach, test, expect } from 'vitest'
 import PostDetailPage from './PostDetailPage'
 import type { Comment, PostDetails } from '../api/types'
 
@@ -57,7 +57,17 @@ function renderDetail() {
   )
 }
 
+// In-memory localStorage so getCurrentUsername() can be controlled per test.
+const store = new Map<string, string>()
+
 beforeEach(() => {
+  store.clear()
+  vi.stubGlobal('localStorage', {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => store.set(key, value),
+    removeItem: (key: string) => store.delete(key),
+    clear: () => store.clear(),
+  })
   mockGetDetails.mockReset().mockResolvedValue(post)
   mockGetThreadRefs.mockReset().mockResolvedValue([])
   mockGetThreadComments.mockReset().mockResolvedValue([])
@@ -66,6 +76,10 @@ beforeEach(() => {
     comment_thread_identifier: 't1',
     comment_identifier: 'c9',
   })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
 })
 
 test('renders the post caption and like count', async () => {
@@ -80,6 +94,26 @@ test('liking the post calls the API and bumps the count optimistically', async (
   await userEvent.click(screen.getByRole('button', { name: 'Like post' }))
   expect(screen.getByText('4 likes')).toBeInTheDocument()
   await waitFor(() => expect(mockLikePost).toHaveBeenCalledWith('p1'))
+})
+
+test('hides the like control on the current user’s own post', async () => {
+  // The signed-in user authored the post, so the backend would reject a like.
+  localStorage.setItem('username', 'ada')
+  renderDetail()
+  await screen.findByText('sunshine')
+  expect(screen.queryByRole('button', { name: 'Like post' })).not.toBeInTheDocument()
+  // The like count is still shown.
+  expect(screen.getByText('3 likes')).toBeInTheDocument()
+})
+
+test('hides the like control on the current user’s own comment', async () => {
+  // The signed-in user authored the comment, so the backend would reject a like.
+  localStorage.setItem('username', 'bob')
+  mockGetThreadRefs.mockResolvedValue([{ comment_thread_identifier: 't1' }])
+  mockGetThreadComments.mockResolvedValue([comment])
+  renderDetail()
+  await screen.findByText('love this')
+  expect(screen.queryByRole('button', { name: 'Like comment' })).not.toBeInTheDocument()
 })
 
 test('renders comment threads', async () => {

--- a/website/src/pages/PostDetailPage.tsx
+++ b/website/src/pages/PostDetailPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Navigate, useNavigate, useParams } from 'react-router-dom'
 import { apiClient } from '../api/client'
+import { getCurrentUsername } from '../api/session'
 import type { Comment, PostDetails } from '../api/types'
 import './MainApp.css'
 
@@ -14,6 +15,9 @@ interface CommentView {
   likeCount: number
   isLiked: boolean
   isReported: boolean
+  // The backend rejects liking your own comment, so the UI hides the like
+  // control for comments the current user authored.
+  isOwn: boolean
 }
 
 interface ThreadView {
@@ -45,6 +49,10 @@ function PostDetailPage() {
 
 function PostDetailView({ postId }: { postId: string }) {
   const navigate = useNavigate()
+
+  // The signed-in user, read once. Used to hide the like control on the user's
+  // own post/comments since the backend rejects liking your own content.
+  const [currentUsername] = useState(() => getCurrentUsername())
 
   // Track mount state so async loads that resolve after navigating away don't
   // set state on an unmounted view.
@@ -88,6 +96,7 @@ function PostDetailView({ postId }: { postId: string }) {
       likeCount: c.comment_likes,
       isLiked: likedCommentIds.current.has(c.comment_identifier),
       isReported: reportedCommentIds.current.has(c.comment_identifier),
+      isOwn: c.author_username === currentUsername,
     })
 
     // A failure to load the post itself is the only "not found" case. Comment
@@ -140,7 +149,7 @@ function PostDetailView({ postId }: { postId: string }) {
     } finally {
       if (isMounted.current) setIsLoading(false)
     }
-  }, [postId])
+  }, [postId, currentUsername])
 
   // Kick the initial load off a microtask so the fetch's setState calls don't
   // run synchronously inside the effect (React flags that as cascading renders).
@@ -150,7 +159,11 @@ function PostDetailView({ postId }: { postId: string }) {
 
   // ---- Post actions ----
 
+  // The backend rejects liking your own post, so don't optimistically like it.
+  const isOwnPost = post?.author_username === currentUsername
+
   async function togglePostLike() {
+    if (isOwnPost) return
     const liking = !postLiked
     setPostLiked(liking)
     setPostLikeCount(n => (liking ? n + 1 : Math.max(0, n - 1)))
@@ -177,6 +190,7 @@ function PostDetailView({ postId }: { postId: string }) {
   }
 
   async function toggleCommentLike(comment: CommentView) {
+    if (comment.isOwn) return
     const liking = !comment.isLiked
     if (liking) likedCommentIds.current.add(comment.id)
     else likedCommentIds.current.delete(comment.id)
@@ -299,19 +313,21 @@ function PostDetailView({ postId }: { postId: string }) {
           className="detail-image"
           src={post.image_url}
           alt={post.caption}
-          onDoubleClick={togglePostLike}
+          onDoubleClick={isOwnPost ? undefined : togglePostLike}
         />
 
         <div className="detail-meta">
-          <button
-            type="button"
-            className="heart"
-            aria-label={postLiked ? 'Unlike post' : 'Like post'}
-            aria-pressed={postLiked}
-            onClick={togglePostLike}
-          >
-            {postLiked ? '♥' : '♡'}
-          </button>
+          {!isOwnPost && (
+            <button
+              type="button"
+              className="heart"
+              aria-label={postLiked ? 'Unlike post' : 'Like post'}
+              aria-pressed={postLiked}
+              onClick={togglePostLike}
+            >
+              {postLiked ? '♥' : '♡'}
+            </button>
+          )}
           <span className="detail-likes">{postLikeCount} likes</span>
           {postReported && (
             <span className="flag-icon" aria-label="Reported">
@@ -532,15 +548,17 @@ function CommentRow({ comment, onToggleLike, onReport, onNavigate }: CommentRowP
           <span className="comment-row__body">{comment.body}</span>
         </span>
         <div className="comment-row__info">
-          <button
-            type="button"
-            className="heart"
-            aria-label={comment.isLiked ? 'Unlike comment' : 'Like comment'}
-            aria-pressed={comment.isLiked}
-            onClick={onToggleLike}
-          >
-            {comment.isLiked ? '♥' : '♡'}
-          </button>
+          {!comment.isOwn && (
+            <button
+              type="button"
+              className="heart"
+              aria-label={comment.isLiked ? 'Unlike comment' : 'Like comment'}
+              aria-pressed={comment.isLiked}
+              onClick={onToggleLike}
+            >
+              {comment.isLiked ? '♥' : '♡'}
+            </button>
+          )}
           <span>{comment.likeCount} likes</span>
           <button type="button" className="comment-reply-btn" style={{ padding: 0 }} onClick={onReport}>
             Report


### PR DESCRIPTION
## What

Stops users from "liking" their own post or comment on the web, iOS, and Android clients. Also, made sure tapping on the heart icon allows liking on a post and comment.

## Why

The backend rejects liking your own post/comment, but all three frontends applied the like *optimistically* — the heart filled in and the like count bumped even though the server never recorded it. This left the UI showing a like that didn't exist.

## How

Each frontend now identifies the signed-in user and, for content that user authored:
- **Guards the like action** (early-return) as the safety net, and
- **Hides the like affordance** — the heart button / double-tap-to-like gesture — so it isn't even offered.

The like *count* is still displayed in all cases.

Per platform:
- **Web** ([PostDetailPage.tsx](website/src/pages/PostDetailPage.tsx)): reads `getCurrentUsername()`, tags each `CommentView` with `isOwn`, computes `isOwnPost`, guards `togglePostLike`/`toggleCommentLike`, disables the image double-click, and hides the heart buttons.
- **iOS** ([PostDetailViewModel.swift](ios/Positive%20Only%20Social/Positive%20Only%20Social/viewmodels/PostDetailViewModel.swift), [PostDetailView.swift](ios/Positive%20Only%20Social/Positive%20Only%20Social/PostDetailView.swift)): adds `currentUsername` + `isOwnPost`/`isOwnComment(_:)`, guards `likePost()`/`likeComment(_:)`, no-ops the double-tap, hides the heart.
- **Android** ([PostDetailViewModel.kt](android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/PostDetailViewModel.kt), [PostDetailScreen.kt](android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/PostDetailScreen.kt)): adds a `currentUsername` flow + `isOwnPost()`/`isOwnComment(...)`, guards the like actions, no-ops the double-tap, hides the heart icon.

## Tests

- **Web**: added own-post / own-comment "hides the like control" tests. Full suite green (100 passed), `tsc` clean.
- **iOS**: reworked the shared test setup so the signed-in user is a non-author "viewer" (keeping the existing like tests valid) and added `testLikePost_OwnPost_DoesNothing` / `testLikeComment_OwnComment_DoesNothing`. Ran on the iPhone 17 simulator — **TEST SUCCEEDED**.
- **Android**: added own-post / own-comment no-op tests plus a positive "another user's comment" case.

## Reviewer note

The Android unit tests were **not run locally** — this machine only has JDK 11, while AGP 9.1.1 requires JDK 17. The Android changes were reviewed against the project's `UnconfinedTestDispatcher` test timing but should be verified in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)