### PR TITLE
Ownership-aware Report/Delete menu (can't report own post/comment)

### DIFF
--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -157,6 +157,7 @@ jobs:
                   "Positive Only SocialUITests/Positive_Only_SocialUITests/testVerifyIdentity"
                   "Positive Only SocialUITests/Positive_Only_SocialUITests/testLikeAndUnlikeCommentOnPostAndThread"
                   "Positive Only SocialUITests/Positive_Only_SocialUITests/testReportPost"
+                  "Positive Only SocialUITests/Positive_Only_SocialUITests/testDeleteOwnPost"
                 )
                 # "Positive Only Social" (default) plan covers both unit and UI tests
                 XCTESTRUN=$(find build/Build/Products -name "*.xctestrun" | grep -v "Unit Tests" | head -1)
@@ -164,6 +165,7 @@ jobs:
               UI_Tests_Delta)
                 TESTS=(
                   "Positive Only SocialUITests/Positive_Only_SocialUITests/testReportComment"
+                  "Positive Only SocialUITests/Positive_Only_SocialUITests/testDeleteOwnComment"
                   "Positive Only SocialUITests/Positive_Only_SocialUITests/testLaunchPerformance"
                   "Positive Only SocialUITests/Positive_Only_SocialUITests/testBlockAndUnblockUser"
                 )

--- a/android/PositiveOnlySocial/app/src/androidTest/java/com/example/positiveonlysocial/PositiveOnlySocialIntegrationTests.kt
+++ b/android/PositiveOnlySocial/app/src/androidTest/java/com/example/positiveonlysocial/PositiveOnlySocialIntegrationTests.kt
@@ -178,6 +178,13 @@ class PositiveOnlySocialIntegrationTests {
             com.example.positiveonlysocial.di.DependencyProvider.api.makePost(token, request)
         }
 
+    private fun makeCommentViaApi(username: String, password: String, postId: String, body: String) =
+        kotlinx.coroutines.runBlocking {
+            val token = loginUserViaApi(username, password)
+            val request = com.example.positiveonlysocial.data.model.CommentRequest(body)
+            com.example.positiveonlysocial.di.DependencyProvider.api.commentOnPost(token, postId, request)
+        }
+
     // MARK: Tests
 
     @Test
@@ -492,44 +499,93 @@ class PositiveOnlySocialIntegrationTests {
         composeTestRule.onNodeWithText("Feed").performClick()
         composeTestRule.onAllNodesWithContentDescription("Post Image").onFirst().performClick()
         
-        // Long press to report
+        // Long press opens the action menu; this is another user's post, so it
+        // offers Report (not Delete).
         composeTestRule.onNodeWithContentDescription("Post Image").performTouchInput { longClick() }
-        
+        composeTestRule.onNodeWithText("Report Post").performClick()
+
         // Report Dialog
-        composeTestRule.onNodeWithText("Report").assertExists()
         composeTestRule.onNodeWithText("Reason for reporting...").performTextInput("Report post")
         composeTestRule.onNodeWithText("Submit").performClick()
-        
+
         // Verify reported icon
         composeTestRule.onNodeWithContentDescription("Reported").assertExists()
     }
 
     @Test
     fun testReportComment() {
-        // Setup
+        // Setup: testUser owns both the post and the comment, so otherTestUser
+        // (the viewer) can report the comment — you can't report your own.
         registerUserViaApi(testUsername, strongPassword)
         val postResponse = makePostViaApi(testUsername, strongPassword, "Some Post Caption")
         val postId = postResponse.body()?.postIdentifier ?: throw IllegalStateException("Failed to create post")
-        
+        makeCommentViaApi(testUsername, strongPassword, postId, "Comment to Report")
+
         loginUser(otherTestUsername, strongPassword, rememberMe = false, registerToo = true)
-        
+
         composeTestRule.onNodeWithText("Feed").performClick()
         composeTestRule.onAllNodesWithContentDescription("Post Image").onFirst().performClick()
-        
-        // Make comment
-        composeTestRule.onNodeWithText("Add a comment...").performTextInput("Comment to Report")
-        composeTestRule.onNodeWithText("Post").performClick()
-        
-        // Long press comment
+
+        // Long press the other user's comment; the menu offers Report.
         composeTestRule.onNodeWithText("Comment to Report").performTouchInput { longClick() }
-        
+        composeTestRule.onNodeWithText("Report Comment").performClick()
+
         // Report Dialog
-        composeTestRule.onNodeWithText("Report").assertExists()
         composeTestRule.onNodeWithText("Reason for reporting...").performTextInput("Report comment")
         composeTestRule.onNodeWithText("Submit").performClick()
 
         // Verify reported icon
         composeTestRule.onNodeWithContentDescription("Reported").assertExists()
+    }
+
+    @Test
+    fun testDeleteOwnPost() {
+        // The viewer owns the post, so long-press offers Delete (not Report).
+        registerUserViaApi(testUsername, strongPassword)
+        makePostViaApi(testUsername, strongPassword, "Post to Delete")
+
+        loginUser(testUsername, strongPassword, rememberMe = false)
+
+        composeTestRule.onNodeWithText("Feed").performClick()
+        composeTestRule.onAllNodesWithContentDescription("Post Image").onFirst().performClick()
+
+        composeTestRule.onNodeWithContentDescription("Post Image").performTouchInput { longClick() }
+
+        // It's the user's own post: Delete is offered, Report is not.
+        composeTestRule.onNodeWithText("Report Post").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Delete Post").performClick()
+
+        // Deleting pops the Post Detail screen back to the feed.
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodesWithText("Add a comment...").fetchSemanticsNodes().isEmpty()
+        }
+        assertOnFeedView()
+    }
+
+    @Test
+    fun testDeleteOwnComment() {
+        // The viewer owns the comment, so long-press offers Delete (not Report).
+        registerUserViaApi(testUsername, strongPassword)
+        val postResponse = makePostViaApi(testUsername, strongPassword, "Some Post Caption")
+        val postId = postResponse.body()?.postIdentifier ?: throw IllegalStateException("Failed to create post")
+        makeCommentViaApi(testUsername, strongPassword, postId, "Comment to Delete")
+
+        loginUser(testUsername, strongPassword, rememberMe = false)
+
+        composeTestRule.onNodeWithText("Feed").performClick()
+        composeTestRule.onAllNodesWithContentDescription("Post Image").onFirst().performClick()
+
+        composeTestRule.onNodeWithText("Comment to Delete").performTouchInput { longClick() }
+
+        // It's the user's own comment: Delete is offered, Report is not.
+        composeTestRule.onNodeWithText("Report Comment").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Delete Comment").performClick()
+
+        // The comment is removed from the thread.
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodesWithText("Comment to Delete").fetchSemanticsNodes().isEmpty()
+        }
+        composeTestRule.onNodeWithText("Comment to Delete").assertDoesNotExist()
     }
     @Test
     fun testVerifyIdentity() {

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/PostDetailViewModel.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/PostDetailViewModel.kt
@@ -52,6 +52,26 @@ class PostDetailViewModel(
     private val _commentToReport = MutableStateFlow<CommentViewData?>(null)
     val commentToReport: StateFlow<CommentViewData?> = _commentToReport.asStateFlow()
 
+    // Drives the long-press action menu for the post. The menu offers either
+    // "Report" (others' posts) or "Delete" (the user's own post) — never both,
+    // so you can't report your own content.
+    private val _showActionSheetForPost = MutableStateFlow(false)
+    val showActionSheetForPost: StateFlow<Boolean> = _showActionSheetForPost.asStateFlow()
+
+    // The comment whose long-press action menu is showing, if any.
+    private val _commentForAction = MutableStateFlow<CommentViewData?>(null)
+    val commentForAction: StateFlow<CommentViewData?> = _commentForAction.asStateFlow()
+
+    // Set once the post has been deleted so the screen can pop back — the post
+    // no longer exists to display.
+    private val _postWasDeleted = MutableStateFlow(false)
+    val postWasDeleted: StateFlow<Boolean> = _postWasDeleted.asStateFlow()
+
+    // Ids of comments the user has reported this session, so the reported flag
+    // stays shown after a successful report (the backend doesn't echo it back).
+    private val _reportedCommentIds = MutableStateFlow<Set<String>>(emptySet())
+    val reportedCommentIds: StateFlow<Set<String>> = _reportedCommentIds.asStateFlow()
+
     private val _newCommentText = MutableStateFlow("")
     val newCommentText: StateFlow<String> = _newCommentText.asStateFlow()
 
@@ -84,6 +104,14 @@ class PostDetailViewModel(
 
     fun setCommentToReport(comment: CommentViewData?) {
         _commentToReport.value = comment
+    }
+
+    fun setShowActionSheetForPost(show: Boolean) {
+        _showActionSheetForPost.value = show
+    }
+
+    fun setCommentForAction(comment: CommentViewData?) {
+        _commentForAction.value = comment
     }
 
     fun dismissAlert() {
@@ -271,6 +299,58 @@ class PostDetailViewModel(
         }
     }
 
+    /**
+     * Deletes the user's own post, then signals the screen to pop back since the
+     * post no longer exists. Only reachable from the action menu on an own post.
+     */
+    fun deletePost() {
+        viewModelScope.launch {
+            try {
+                val userSession = keychainHelper.load(UserSession::class.java, service, account)
+                if (userSession == null) {
+                    Log.e(TAG, "No active session found — cannot perform action")
+                    _alertMessage.value = "Not logged in."
+                    return@launch
+                }
+                val response = api.deletePost(userSession.sessionToken, postIdentifier)
+                if (response.isSuccessful) {
+                    _postWasDeleted.value = true
+                } else {
+                    _alertMessage.value = "Failed to delete post: ${response.message()}"
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to delete post", e)
+                _alertMessage.value = "Error: ${e.localizedMessage}"
+            }
+        }
+    }
+
+    /**
+     * Deletes one of the user's own comments, then reloads so it disappears from
+     * the thread. Only reachable from the action menu on an own comment.
+     */
+    fun deleteComment(comment: CommentViewData, threadId: String) {
+        viewModelScope.launch {
+            try {
+                val userSession = keychainHelper.load(UserSession::class.java, service, account)
+                if (userSession == null) {
+                    Log.e(TAG, "No active session found — cannot perform action")
+                    _alertMessage.value = "Not logged in."
+                    return@launch
+                }
+                val response = api.deleteComment(userSession.sessionToken, postIdentifier, threadId, comment.id)
+                if (response.isSuccessful) {
+                    loadAllData()
+                } else {
+                    _alertMessage.value = "Failed to delete comment: ${response.message()}"
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to delete comment", e)
+                _alertMessage.value = "Error: ${e.localizedMessage}"
+            }
+        }
+    }
+
     fun likeComment(comment: CommentViewData, threadId: String) {
         // The backend rejects liking your own comment; ignore the request.
         if (isOwnComment(comment)) return
@@ -328,6 +408,7 @@ class PostDetailViewModel(
                 }
                 val response = api.reportComment(userSession.sessionToken, postIdentifier, threadId, comment.id, ReportRequest(reason))
                 if (response.isSuccessful) {
+                    _reportedCommentIds.value = _reportedCommentIds.value + comment.id
                     _alertMessage.value = "Comment reported successfully."
                 } else {
                     _alertMessage.value = "Failed to report comment: ${response.message()}"

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/PostDetailScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/PostDetailScreen.kt
@@ -64,6 +64,18 @@ fun PostDetailScreen(
         val commentToReport by viewModel.commentToReport.collectAsState()
         val threadToReplyTo by viewModel.threadToReplyTo.collectAsState()
 
+        // Long-press action menus (Report vs Delete, depending on ownership).
+        val showActionSheetForPost by viewModel.showActionSheetForPost.collectAsState()
+        val commentForAction by viewModel.commentForAction.collectAsState()
+        val postWasDeleted by viewModel.postWasDeleted.collectAsState()
+
+        // The post was deleted out from under this screen; pop back to the feed.
+        LaunchedEffect(postWasDeleted) {
+            if (postWasDeleted) {
+                navController.popBackStack()
+            }
+        }
+
         if (alertMessage != null) {
             AlertDialog(
                 onDismissRequest = { viewModel.dismissAlert() },
@@ -74,6 +86,31 @@ fun PostDetailScreen(
                         Text("OK")
                     }
                 }
+            )
+        }
+
+        // The post's long-press action menu: Delete on the user's own post,
+        // Report on everyone else's — so you can never report your own post.
+        if (showActionSheetForPost) {
+            val isOwnPost = postDetail?.authorUsername == currentUsername
+            ActionSheetDialog(
+                isOwn = isOwnPost,
+                itemLabel = "Post",
+                onDismiss = { viewModel.setShowActionSheetForPost(false) },
+                onReport = { viewModel.setShowReportSheetForPost(true) },
+                onDelete = { viewModel.deletePost() }
+            )
+        }
+
+        // The comment's long-press action menu mirrors the post's.
+        commentForAction?.let { comment ->
+            val isOwnComment = comment.authorUsername == currentUsername
+            ActionSheetDialog(
+                isOwn = isOwnComment,
+                itemLabel = "Comment",
+                onDismiss = { viewModel.setCommentForAction(null) },
+                onReport = { viewModel.setCommentToReport(comment) },
+                onDelete = { viewModel.deleteComment(comment, comment.threadId) }
             )
         }
 
@@ -137,7 +174,7 @@ fun PostDetailScreen(
                                         if (post.isLiked) viewModel.unlikePost() else viewModel.likePost()
                                     },
                                     onLongClick = {
-                                       viewModel.setShowReportSheetForPost(true)
+                                       viewModel.setShowActionSheetForPost(true)
                                     },
                                     onClick = {}
                                 ),
@@ -211,14 +248,16 @@ fun PostDetailScreen(
 
 @Composable
 fun CommentThreadView(thread: CommentThreadViewData, viewModel: PostDetailViewModel, currentUsername: String?) {
+    val reportedCommentIds by viewModel.reportedCommentIds.collectAsState()
     Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
         thread.comments.firstOrNull()?.let { rootComment ->
             CommentRow(
                 comment = rootComment,
                 isOwn = rootComment.authorUsername == currentUsername,
+                isReported = reportedCommentIds.contains(rootComment.id),
                 onLike = { viewModel.likeComment(rootComment, rootComment.threadId) },
                 onUnlike = { viewModel.unlikeComment(rootComment, rootComment.threadId) },
-                onReport = { viewModel.setCommentToReport(rootComment) }
+                onLongPress = { viewModel.setCommentForAction(rootComment) }
             )
             
             // Reply Input for Thread
@@ -235,9 +274,10 @@ fun CommentThreadView(thread: CommentThreadViewData, viewModel: PostDetailViewMo
                     CommentRow(
                         comment = reply,
                         isOwn = reply.authorUsername == currentUsername,
+                        isReported = reportedCommentIds.contains(reply.id),
                         onLike = { viewModel.likeComment(reply, reply.threadId) },
                         onUnlike = { viewModel.unlikeComment(reply, reply.threadId) },
-                        onReport = { viewModel.setCommentToReport(reply) }
+                        onLongPress = { viewModel.setCommentForAction(reply) }
                     )
                 }
             }
@@ -250,12 +290,11 @@ fun CommentThreadView(thread: CommentThreadViewData, viewModel: PostDetailViewMo
 fun CommentRow(
     comment: CommentViewData,
     isOwn: Boolean,
+    isReported: Boolean,
     onLike: () -> Unit,
     onUnlike: () -> Unit,
-    onReport: () -> Unit
+    onLongPress: () -> Unit
 ) {
-    var isReported by remember { mutableStateOf(false) }
-
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -269,8 +308,8 @@ fun CommentRow(
                     if (comment.isLiked) onUnlike() else onLike()
                 },
                 onLongClick = {
-                    isReported = true
-                    onReport()
+                    // Open the action menu (Report or Delete, by ownership).
+                    onLongPress()
                 },
                 onClick = {}
             ),
@@ -319,6 +358,42 @@ fun CommentRow(
             }
         }
     }
+}
+
+/**
+ * The mini action menu shown on long-press. Offers a single action — Delete for
+ * the user's own content, Report for everyone else's — so you can never report
+ * your own post or comment. More options can be added here later.
+ */
+@Composable
+fun ActionSheetDialog(
+    isOwn: Boolean,
+    itemLabel: String,
+    onDismiss: () -> Unit,
+    onReport: () -> Unit,
+    onDelete: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(itemLabel) },
+        text = {
+            if (isOwn) {
+                TextButton(onClick = { onDelete(); onDismiss() }) {
+                    Text("Delete $itemLabel")
+                }
+            } else {
+                TextButton(onClick = { onReport(); onDismiss() }) {
+                    Text("Report $itemLabel")
+                }
+            }
+        },
+        confirmButton = {},
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel")
+            }
+        }
+    )
 }
 
 @Composable

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/PostDetailScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/PostDetailScreen.kt
@@ -376,7 +376,9 @@ fun ActionSheetDialog(
     AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text(itemLabel) },
-        text = {
+        // The primary action lives in the confirmButton slot so it's laid out and
+        // announced as the dialog's main action; more options can be added later.
+        confirmButton = {
             if (isOwn) {
                 TextButton(onClick = { onDelete(); onDismiss() }) {
                     Text("Delete $itemLabel")
@@ -387,7 +389,6 @@ fun ActionSheetDialog(
                 }
             }
         },
-        confirmButton = {},
         dismissButton = {
             TextButton(onClick = onDismiss) {
                 Text("Cancel")

--- a/ios/Positive Only Social/Positive Only Social/PostDetailView.swift
+++ b/ios/Positive Only Social/Positive Only Social/PostDetailView.swift
@@ -13,6 +13,9 @@ struct PostDetailView: View {
     // Use @StateObject to create and own the ViewModel
     @StateObject private var viewModel: PostDetailViewModel
 
+    // Used to pop this view once the user deletes the post being shown.
+    @Environment(\.dismiss) private var dismiss
+
     // Public init
     init(postIdentifier: String, api: Networking, keychainHelper: KeychainHelperProtocol) {
         _viewModel = StateObject(wrappedValue: PostDetailViewModel(postIdentifier: postIdentifier, api: api, keychainHelper: keychainHelper))
@@ -57,7 +60,7 @@ struct PostDetailView: View {
                         }
                     }
                     .onLongPressGesture {
-                        viewModel.showReportSheetForPost = true
+                        viewModel.showActionSheetForPost = true
                     }
 
                     // --- POST DETAILS (CAPTION, LIKES) ---
@@ -130,6 +133,45 @@ struct PostDetailView: View {
             // Pull-to-refresh: reload the post details and comments from the backend.
             await viewModel.refresh()
         }
+        // --- Action menus (long-press) ---
+        // The post's menu offers Delete on the user's own post and Report on
+        // everyone else's — so you can never report your own post.
+        .confirmationDialog("Post", isPresented: $viewModel.showActionSheetForPost, titleVisibility: .hidden) {
+            if viewModel.isOwnPost {
+                Button("Delete Post", role: .destructive) {
+                    viewModel.deletePost()
+                }
+                .accessibilityIdentifier("DeletePostActionButton")
+            } else {
+                Button("Report Post") {
+                    viewModel.showReportSheetForPost = true
+                }
+                .accessibilityIdentifier("ReportPostActionButton")
+            }
+        }
+        // The comment menu mirrors the post menu: Delete for the user's own
+        // comments, Report for everyone else's.
+        .confirmationDialog(
+            "Comment",
+            isPresented: Binding(
+                get: { viewModel.commentForAction != nil },
+                set: { if !$0 { viewModel.commentForAction = nil } }
+            ),
+            titleVisibility: .hidden,
+            presenting: viewModel.commentForAction
+        ) { comment in
+            if viewModel.isOwnComment(comment) {
+                Button("Delete Comment", role: .destructive) {
+                    viewModel.deleteComment(comment)
+                }
+                .accessibilityIdentifier("DeleteCommentActionButton")
+            } else {
+                Button("Report Comment") {
+                    viewModel.commentToReport = comment
+                }
+                .accessibilityIdentifier("ReportCommentActionButton")
+            }
+        }
         // --- Modals and Sheets ---
         .sheet(isPresented: $viewModel.showReportSheetForPost) {
             ReportView { reason in
@@ -156,6 +198,10 @@ struct PostDetailView: View {
                 }
             )
         })
+        .onChange(of: viewModel.postWasDeleted) { wasDeleted in
+            // The post was deleted out from under this view; pop back to the feed.
+            if wasDeleted { dismiss() }
+        }
         .environmentObject(viewModel) // Pass VM to subviews
     }
 
@@ -202,8 +248,8 @@ struct PostDetailView: View {
         // Actions passed from the parent
         let onLike: () -> Void
         let onUnlike: () -> Void
-        let onReport: () -> Void
-        
+        let onLongPress: () -> Void
+
         var body: some View {
             HStack(alignment: .top, spacing: 10) {
                 // Placeholder for profile picture
@@ -271,7 +317,7 @@ struct PostDetailView: View {
                 }
             }
             .onLongPressGesture {
-                onReport()
+                onLongPress()
             }
             .accessibilityElement(children: .contain)
             .accessibilityIdentifier("CommentStack")
@@ -296,8 +342,8 @@ struct PostDetailView: View {
                                    onUnlike: { // --- ADDED ---
                                        viewModel.unlikeComment(rootComment)
                                    },
-                                   onReport: {
-                                       viewModel.commentToReport = rootComment
+                                   onLongPress: {
+                                       viewModel.commentForAction = rootComment
                                    })
                     Section {
                         HStack {
@@ -332,8 +378,8 @@ struct PostDetailView: View {
                                            onUnlike: { // --- ADDED ---
                                                viewModel.unlikeComment(reply)
                                            },
-                                           onReport: {
-                                               viewModel.commentToReport = reply
+                                           onLongPress: {
+                                               viewModel.commentForAction = reply
                                            })
                         }
                     }

--- a/ios/Positive Only Social/Positive Only Social/viewmodels/PostDetailViewModel.swift
+++ b/ios/Positive Only Social/Positive Only Social/viewmodels/PostDetailViewModel.swift
@@ -23,6 +23,19 @@ final class PostDetailViewModel: ObservableObject {
     // State for presentation
     @Published var showReportSheetForPost = false
     @Published var commentToReport: CommentViewData? // Use item-based sheet
+
+    /// Drives the long-press action menu for the post. The menu offers either
+    /// "Report" (others' posts) or "Delete" (the user's own post) — never both,
+    /// so you can't report your own content.
+    @Published var showActionSheetForPost = false
+
+    /// The comment whose long-press action menu is showing, if any. Like the
+    /// post action menu, it offers "Report" or "Delete" depending on ownership.
+    @Published var commentForAction: CommentViewData?
+
+    /// Set once the post has been deleted so the view can pop back — the post no
+    /// longer exists to display.
+    @Published var postWasDeleted = false
     
     /// The text for creating a brand new comment thread
     @Published var newCommentText: String = ""
@@ -268,6 +281,54 @@ final class PostDetailViewModel: ObservableObject {
         }
     }
     
+    /// Deletes the user's own post, then signals the view to pop back since the
+    /// post no longer exists. Only reachable from the action menu on an own post.
+    func deletePost() {
+        NSLog("%@", "ACTION: Delete post \(postIdentifier)")
+        Task {
+            do {
+                guard let userSession = try keychainHelper.load(UserSession.self, from: keychainService, account: account) else {
+                    NSLog("%@", "No active session — cannot delete post")
+                    self.alertMessage = "Session not found."
+                    return
+                }
+                let token = userSession.sessionToken
+                _ = try await api.deletePost(sessionManagementToken: token, postIdentifier: postIdentifier)
+                await MainActor.run {
+                    self.postWasDeleted = true
+                }
+            } catch {
+                NSLog("%@", "Failed to delete post: \(error)")
+                await MainActor.run {
+                    self.alertMessage = "Failed to delete post: \(error.localizedDescription)"
+                }
+            }
+        }
+    }
+
+    /// Deletes one of the user's own comments, then reloads so it disappears from
+    /// the thread. Only reachable from the action menu on an own comment.
+    func deleteComment(_ comment: CommentViewData) {
+        NSLog("%@", "ACTION: Delete comment \(comment.id)")
+        Task {
+            do {
+                guard let userSession = try keychainHelper.load(UserSession.self, from: keychainService, account: account) else {
+                    NSLog("%@", "No active session — cannot delete comment")
+                    self.alertMessage = "Session not found."
+                    return
+                }
+                let token = userSession.sessionToken
+                _ = try await api.deleteComment(sessionManagementToken: token, postIdentifier: postIdentifier, commentThreadIdentifier: comment.threadId, commentIdentifier: comment.id)
+                self.loadAllData()
+            } catch {
+                NSLog("%@", "Failed to delete comment: \(error)")
+                await MainActor.run {
+                    self.alertMessage = "Failed to delete comment: \(error.localizedDescription)"
+                }
+            }
+        }
+    }
+
     func likeComment(_ comment: CommentViewData) {
         // The backend rejects liking your own comment; don't optimistically like it.
         guard !isOwnComment(comment) else { return }

--- a/ios/Positive Only Social/Positive Only SocialUITests/Positive_Only_SocialUITests.swift
+++ b/ios/Positive Only Social/Positive Only SocialUITests/Positive_Only_SocialUITests.swift
@@ -1301,7 +1301,13 @@ final class Positive_Only_SocialUITests: XCTestCase {
         // 2 second press
         XCTAssertTrue(postImage.waitForExistence(timeout: TestConstants.shortTimeout))
         postImage.press(forDuration: 2)
-        
+
+        // The long-press now opens an action menu; choose "Report Post" (this
+        // post belongs to another user, so the menu offers Report, not Delete).
+        let reportPostAction = app.buttons["Report Post"]
+        XCTAssertTrue(reportPostAction.waitForExistence(timeout: TestConstants.shortTimeout))
+        reportPostAction.tap()
+
         let reasonTextField = app.textFields["ProvideAReasonTextField"]
         XCTAssertTrue(reasonTextField.waitForExistence(timeout: TestConstants.shortTimeout))
         reasonTextField.tap()
@@ -1326,7 +1332,93 @@ final class Positive_Only_SocialUITests: XCTestCase {
         
         assertOnHomeView(app: app)
     }
-    
+
+    /// Long-pressing your own post offers Delete (not Report); deleting it pops
+    /// back to the feed and the post is gone.
+    @MainActor
+    func testDeleteOwnPost() throws {
+
+        try ifOnHomeDeleteAccount(app: app)
+
+        try loginUser(app: app, username: testUsername, password: strongPassword, rememberMe: false)
+
+        try makePost(app: app, postText: "Post To Delete")
+
+        let feedTab = app.buttons["Feed"]
+        XCTAssertTrue(feedTab.waitForExistence(timeout: TestConstants.shortTimeout))
+        feedTab.tap()
+
+        assertOnFeedView(app: app)
+
+        let firstPostElement = app.buttons.matching(identifier: "ForYouPostImage").element(boundBy: 0)
+        XCTAssertTrue(firstPostElement.waitForExistence(timeout: TestConstants.shortTimeout))
+        firstPostElement.tap()
+
+        assertOnPostDetailView(app: app)
+
+        let postImage = app.buttons["PostImage"]
+        XCTAssertTrue(postImage.waitForExistence(timeout: TestConstants.shortTimeout))
+        postImage.press(forDuration: 2)
+
+        // It's the user's own post, so the action menu offers Delete, not Report.
+        XCTAssertFalse(app.buttons["Report Post"].exists, "Should not be able to report your own post")
+        let deletePostAction = app.buttons["Delete Post"]
+        XCTAssertTrue(deletePostAction.waitForExistence(timeout: TestConstants.shortTimeout))
+        deletePostAction.tap()
+
+        // Deleting pops the Post Detail view back to the feed.
+        assertOnFeedView(app: app)
+        XCTAssertFalse(app.textFields["AddACommentTextFieldToPost"].exists, "Post Detail view should have been dismissed after deleting the post")
+
+        let homeButton = app.buttons["Home"]
+        XCTAssertTrue(homeButton.waitForExistence(timeout: TestConstants.shortTimeout))
+        homeButton.tap()
+
+        assertOnHomeView(app: app)
+    }
+
+    /// Long-pressing your own comment offers Delete (not Report); deleting it
+    /// removes it from the thread.
+    @MainActor
+    func testDeleteOwnComment() throws {
+
+        try ifOnHomeDeleteAccount(app: app)
+
+        try loginUser(app: app, username: testUsername, password: strongPassword, rememberMe: false)
+
+        try makePost(app: app, postText: "Some Post Caption")
+
+        // Comment on the user's own post, ending on the Post Detail view.
+        makeCommentOnPost(app: app, commentText: "Comment To Delete")
+
+        let commentStack = app.buttons.matching(identifier: "CommentStack").element(boundBy: 0)
+        XCTAssertTrue(commentStack.waitForExistence(timeout: TestConstants.shortTimeout))
+        commentStack.press(forDuration: 2)
+
+        // It's the user's own comment, so the menu offers Delete, not Report.
+        XCTAssertFalse(app.buttons["Report Comment"].exists, "Should not be able to report your own comment")
+        let deleteCommentAction = app.buttons["Delete Comment"]
+        XCTAssertTrue(deleteCommentAction.waitForExistence(timeout: TestConstants.shortTimeout))
+        deleteCommentAction.tap()
+
+        // The comment is removed from the thread.
+        let commentElements = app.staticTexts.matching(identifier: "CommentText")
+        expectation(for: NSPredicate(format: "count == 0"), evaluatedWith: commentElements, handler: nil)
+        waitForExpectations(timeout: TestConstants.timeout, handler: nil)
+        XCTAssertEqual(commentElements.count, 0, "Expected the deleted comment to be gone")
+
+        let backButton = app.navigationBars.firstMatch.buttons.element(boundBy: 0)
+        XCTAssertTrue(backButton.waitForExistence(timeout: TestConstants.shortTimeout))
+        backButton.tap()
+
+        let homeButton = app.buttons["Home"]
+        if homeButton.exists {
+            homeButton.tap()
+        }
+
+        assertOnHomeView(app: app)
+    }
+
     @MainActor
     func testReportComment() throws {
         
@@ -1389,7 +1481,13 @@ final class Positive_Only_SocialUITests: XCTestCase {
         // 2 second press
         XCTAssertTrue(commentStack.waitForExistence(timeout: TestConstants.shortTimeout))
         commentStack.press(forDuration: 2)
-        
+
+        // The long-press opens an action menu; choose "Report Comment" (this
+        // comment belongs to another user, so the menu offers Report).
+        let reportCommentAction = app.buttons["Report Comment"]
+        XCTAssertTrue(reportCommentAction.waitForExistence(timeout: TestConstants.shortTimeout))
+        reportCommentAction.tap()
+
         let reasonTextField = app.textFields["ProvideAReasonTextField"]
         XCTAssertTrue(reasonTextField.waitForExistence(timeout: TestConstants.shortTimeout))
         reasonTextField.tap()
@@ -1408,7 +1506,11 @@ final class Positive_Only_SocialUITests: XCTestCase {
         // 2 second press
         XCTAssertTrue(commentStack2.waitForExistence(timeout: TestConstants.shortTimeout))
         commentStack2.press(forDuration: 2)
-        
+
+        let reportCommentAction2 = app.buttons["Report Comment"]
+        XCTAssertTrue(reportCommentAction2.waitForExistence(timeout: TestConstants.shortTimeout))
+        reportCommentAction2.tap()
+
         let reasonTextField2 = app.textFields["ProvideAReasonTextField"]
         XCTAssertTrue(reasonTextField2.waitForExistence(timeout: TestConstants.shortTimeout))
         reasonTextField2.tap()

--- a/ios/Positive Only Social/Positive Only SocialUITests/Positive_Only_SocialUITests.swift
+++ b/ios/Positive Only Social/Positive Only SocialUITests/Positive_Only_SocialUITests.swift
@@ -1302,12 +1302,12 @@ final class Positive_Only_SocialUITests: XCTestCase {
         XCTAssertTrue(postImage.waitForExistence(timeout: TestConstants.shortTimeout))
         postImage.press(forDuration: 2)
 
-        // The long-press now opens an action menu; choose "Report Post" (this
+        // The long-press now opens an action menu; choose Report Post (this
         // post belongs to another user, so the menu offers Report, not Delete).
-        // SwiftUI exposes the dialog button as a nested duplicate with the same
-        // label, so take firstMatch to avoid an ambiguous "multiple matching
-        // elements" failure on tap().
-        let reportPostAction = app.buttons["Report Post"].firstMatch
+        // Query by accessibilityIdentifier; SwiftUI exposes the dialog button as
+        // a nested duplicate with the same identifier, so take firstMatch to
+        // avoid an ambiguous "multiple matching elements" failure on tap().
+        let reportPostAction = app.buttons["ReportPostActionButton"].firstMatch
         XCTAssertTrue(reportPostAction.waitForExistence(timeout: TestConstants.shortTimeout))
         reportPostAction.tap()
 
@@ -1364,10 +1364,10 @@ final class Positive_Only_SocialUITests: XCTestCase {
         postImage.press(forDuration: 2)
 
         // It's the user's own post, so the action menu offers Delete, not Report.
-        XCTAssertFalse(app.buttons["Report Post"].exists, "Should not be able to report your own post")
+        XCTAssertFalse(app.buttons["ReportPostActionButton"].exists, "Should not be able to report your own post")
         // firstMatch: the dialog button is exposed as a nested duplicate with the
-        // same label, so a bare query matches multiple and tap() is ambiguous.
-        let deletePostAction = app.buttons["Delete Post"].firstMatch
+        // same identifier, so a bare query matches multiple and tap() is ambiguous.
+        let deletePostAction = app.buttons["DeletePostActionButton"].firstMatch
         XCTAssertTrue(deletePostAction.waitForExistence(timeout: TestConstants.shortTimeout))
         deletePostAction.tap()
 
@@ -1401,10 +1401,10 @@ final class Positive_Only_SocialUITests: XCTestCase {
         commentStack.press(forDuration: 2)
 
         // It's the user's own comment, so the menu offers Delete, not Report.
-        XCTAssertFalse(app.buttons["Report Comment"].exists, "Should not be able to report your own comment")
+        XCTAssertFalse(app.buttons["ReportCommentActionButton"].exists, "Should not be able to report your own comment")
         // firstMatch: the dialog button is exposed as a nested duplicate with the
-        // same label, so a bare query matches multiple and tap() is ambiguous.
-        let deleteCommentAction = app.buttons["Delete Comment"].firstMatch
+        // same identifier, so a bare query matches multiple and tap() is ambiguous.
+        let deleteCommentAction = app.buttons["DeleteCommentActionButton"].firstMatch
         XCTAssertTrue(deleteCommentAction.waitForExistence(timeout: TestConstants.shortTimeout))
         deleteCommentAction.tap()
 
@@ -1489,11 +1489,11 @@ final class Positive_Only_SocialUITests: XCTestCase {
         XCTAssertTrue(commentStack.waitForExistence(timeout: TestConstants.shortTimeout))
         commentStack.press(forDuration: 2)
 
-        // The long-press opens an action menu; choose "Report Comment" (this
+        // The long-press opens an action menu; choose Report Comment (this
         // comment belongs to another user, so the menu offers Report).
         // firstMatch: the dialog button is exposed as a nested duplicate with the
-        // same label, so a bare query matches multiple and tap() is ambiguous.
-        let reportCommentAction = app.buttons["Report Comment"].firstMatch
+        // same identifier, so a bare query matches multiple and tap() is ambiguous.
+        let reportCommentAction = app.buttons["ReportCommentActionButton"].firstMatch
         XCTAssertTrue(reportCommentAction.waitForExistence(timeout: TestConstants.shortTimeout))
         reportCommentAction.tap()
 
@@ -1516,7 +1516,7 @@ final class Positive_Only_SocialUITests: XCTestCase {
         XCTAssertTrue(commentStack2.waitForExistence(timeout: TestConstants.shortTimeout))
         commentStack2.press(forDuration: 2)
 
-        let reportCommentAction2 = app.buttons["Report Comment"].firstMatch
+        let reportCommentAction2 = app.buttons["ReportCommentActionButton"].firstMatch
         XCTAssertTrue(reportCommentAction2.waitForExistence(timeout: TestConstants.shortTimeout))
         reportCommentAction2.tap()
 

--- a/ios/Positive Only Social/Positive Only SocialUITests/Positive_Only_SocialUITests.swift
+++ b/ios/Positive Only Social/Positive Only SocialUITests/Positive_Only_SocialUITests.swift
@@ -1304,7 +1304,10 @@ final class Positive_Only_SocialUITests: XCTestCase {
 
         // The long-press now opens an action menu; choose "Report Post" (this
         // post belongs to another user, so the menu offers Report, not Delete).
-        let reportPostAction = app.buttons["Report Post"]
+        // SwiftUI exposes the dialog button as a nested duplicate with the same
+        // label, so take firstMatch to avoid an ambiguous "multiple matching
+        // elements" failure on tap().
+        let reportPostAction = app.buttons["Report Post"].firstMatch
         XCTAssertTrue(reportPostAction.waitForExistence(timeout: TestConstants.shortTimeout))
         reportPostAction.tap()
 
@@ -1362,7 +1365,9 @@ final class Positive_Only_SocialUITests: XCTestCase {
 
         // It's the user's own post, so the action menu offers Delete, not Report.
         XCTAssertFalse(app.buttons["Report Post"].exists, "Should not be able to report your own post")
-        let deletePostAction = app.buttons["Delete Post"]
+        // firstMatch: the dialog button is exposed as a nested duplicate with the
+        // same label, so a bare query matches multiple and tap() is ambiguous.
+        let deletePostAction = app.buttons["Delete Post"].firstMatch
         XCTAssertTrue(deletePostAction.waitForExistence(timeout: TestConstants.shortTimeout))
         deletePostAction.tap()
 
@@ -1397,7 +1402,9 @@ final class Positive_Only_SocialUITests: XCTestCase {
 
         // It's the user's own comment, so the menu offers Delete, not Report.
         XCTAssertFalse(app.buttons["Report Comment"].exists, "Should not be able to report your own comment")
-        let deleteCommentAction = app.buttons["Delete Comment"]
+        // firstMatch: the dialog button is exposed as a nested duplicate with the
+        // same label, so a bare query matches multiple and tap() is ambiguous.
+        let deleteCommentAction = app.buttons["Delete Comment"].firstMatch
         XCTAssertTrue(deleteCommentAction.waitForExistence(timeout: TestConstants.shortTimeout))
         deleteCommentAction.tap()
 
@@ -1484,7 +1491,9 @@ final class Positive_Only_SocialUITests: XCTestCase {
 
         // The long-press opens an action menu; choose "Report Comment" (this
         // comment belongs to another user, so the menu offers Report).
-        let reportCommentAction = app.buttons["Report Comment"]
+        // firstMatch: the dialog button is exposed as a nested duplicate with the
+        // same label, so a bare query matches multiple and tap() is ambiguous.
+        let reportCommentAction = app.buttons["Report Comment"].firstMatch
         XCTAssertTrue(reportCommentAction.waitForExistence(timeout: TestConstants.shortTimeout))
         reportCommentAction.tap()
 
@@ -1507,7 +1516,7 @@ final class Positive_Only_SocialUITests: XCTestCase {
         XCTAssertTrue(commentStack2.waitForExistence(timeout: TestConstants.shortTimeout))
         commentStack2.press(forDuration: 2)
 
-        let reportCommentAction2 = app.buttons["Report Comment"]
+        let reportCommentAction2 = app.buttons["Report Comment"].firstMatch
         XCTAssertTrue(reportCommentAction2.waitForExistence(timeout: TestConstants.shortTimeout))
         reportCommentAction2.tap()
 

--- a/website/src/pages/PostDetailPage.test.tsx
+++ b/website/src/pages/PostDetailPage.test.tsx
@@ -209,7 +209,8 @@ test('own post shows Delete instead of Report, and deleting navigates away', asy
 
   await userEvent.click(screen.getByRole('button', { name: 'Delete' }))
   // Confirm in the modal.
-  await userEvent.click(screen.getByRole('dialog', { name: 'Delete item' }).querySelector('.modal__confirm')!)
+  const deleteDialog = screen.getByRole('dialog', { name: 'Delete item' })
+  await userEvent.click(within(deleteDialog).getByRole('button', { name: 'Delete' }))
   await waitFor(() => expect(mockDeletePost).toHaveBeenCalledWith('p1'))
 })
 
@@ -237,7 +238,8 @@ test('own comment shows Delete instead of Report, and deleting reloads', async (
   expect(within(commentRow).queryByRole('button', { name: 'Report' })).not.toBeInTheDocument()
 
   await userEvent.click(within(commentRow).getByRole('button', { name: 'Delete' }))
-  await userEvent.click(screen.getByRole('dialog', { name: 'Delete item' }).querySelector('.modal__confirm')!)
+  const deleteDialog = screen.getByRole('dialog', { name: 'Delete item' })
+  await userEvent.click(within(deleteDialog).getByRole('button', { name: 'Delete' }))
   await waitFor(() => expect(mockDeleteComment).toHaveBeenCalledWith('p1', 't1', 'c1'))
 })
 

--- a/website/src/pages/PostDetailPage.test.tsx
+++ b/website/src/pages/PostDetailPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import { vi, beforeEach, afterEach, test, expect } from 'vitest'
@@ -14,11 +14,13 @@ vi.mock('../api/client', () => ({
     likePost: vi.fn(),
     unlikePost: vi.fn(),
     reportPost: vi.fn(),
+    deletePost: vi.fn(),
     commentOnPost: vi.fn(),
     replyToCommentThread: vi.fn(),
     likeComment: vi.fn(),
     unlikeComment: vi.fn(),
     reportComment: vi.fn(),
+    deleteComment: vi.fn(),
   },
 }))
 
@@ -28,6 +30,8 @@ const mockGetThreadRefs = vi.mocked(apiClient.getCommentsForPost)
 const mockGetThreadComments = vi.mocked(apiClient.getCommentsForThread)
 const mockLikePost = vi.mocked(apiClient.likePost)
 const mockCommentOnPost = vi.mocked(apiClient.commentOnPost)
+const mockDeletePost = vi.mocked(apiClient.deletePost)
+const mockDeleteComment = vi.mocked(apiClient.deleteComment)
 
 const post: PostDetails = {
   post_identifier: 'p1',
@@ -76,6 +80,8 @@ beforeEach(() => {
     comment_thread_identifier: 't1',
     comment_identifier: 'c9',
   })
+  mockDeletePost.mockReset().mockResolvedValue({ message: 'ok' })
+  mockDeleteComment.mockReset().mockResolvedValue({ message: 'ok' })
 })
 
 afterEach(() => {
@@ -191,6 +197,48 @@ test('still shows the post when only the comments fail to load', async () => {
   expect(await screen.findByText('sunshine')).toBeInTheDocument()
   expect(screen.queryByText('Post not found.')).not.toBeInTheDocument()
   expect(await screen.findByText('Failed to load comments.')).toBeInTheDocument()
+})
+
+test('own post shows Delete instead of Report, and deleting navigates away', async () => {
+  // The signed-in user authored the post, so they can't report it.
+  localStorage.setItem('username', 'ada')
+  renderDetail()
+  await screen.findByText('sunshine')
+  // No Report control on your own post (issue: can't report your own post).
+  expect(screen.queryByRole('button', { name: 'Report' })).not.toBeInTheDocument()
+
+  await userEvent.click(screen.getByRole('button', { name: 'Delete' }))
+  // Confirm in the modal.
+  await userEvent.click(screen.getByRole('dialog', { name: 'Delete item' }).querySelector('.modal__confirm')!)
+  await waitFor(() => expect(mockDeletePost).toHaveBeenCalledWith('p1'))
+})
+
+test('other users’ post still shows Report, not Delete', async () => {
+  // The post is by 'ada'; the signed-in user is someone else.
+  localStorage.setItem('username', 'someone-else')
+  renderDetail()
+  await screen.findByText('sunshine')
+  expect(screen.getByRole('button', { name: 'Report' })).toBeInTheDocument()
+  expect(screen.queryByRole('button', { name: 'Delete' })).not.toBeInTheDocument()
+})
+
+test('own comment shows Delete instead of Report, and deleting reloads', async () => {
+  // The signed-in user authored the comment (bob), so they can't report it.
+  // The post is by 'ada', so it keeps its own Report control.
+  localStorage.setItem('username', 'bob')
+  mockGetThreadRefs.mockResolvedValue([{ comment_thread_identifier: 't1' }])
+  mockGetThreadComments.mockResolvedValue([comment])
+  renderDetail()
+  await screen.findByText('love this')
+
+  // Scope to the comment row: it offers Delete, not Report.
+  const commentRow = screen.getByText('love this').closest('.comment-row') as HTMLElement
+  expect(within(commentRow).getByRole('button', { name: 'Delete' })).toBeInTheDocument()
+  expect(within(commentRow).queryByRole('button', { name: 'Report' })).not.toBeInTheDocument()
+
+  await userEvent.click(within(commentRow).getByRole('button', { name: 'Delete' }))
+  await userEvent.click(screen.getByRole('dialog', { name: 'Delete item' }).querySelector('.modal__confirm')!)
+  await waitFor(() => expect(mockDeleteComment).toHaveBeenCalledWith('p1', 't1', 'c1'))
 })
 
 test('redirects to login when unauthenticated', () => {

--- a/website/src/pages/PostDetailPage.test.tsx
+++ b/website/src/pages/PostDetailPage.test.tsx
@@ -56,6 +56,7 @@ function renderDetail() {
       <Routes>
         <Route path="/post/:postId" element={<PostDetailPage />} />
         <Route path="/profile/:username" element={<div>Profile page</div>} />
+        <Route path="/home" element={<div>Feed page</div>} />
       </Routes>
     </MemoryRouter>,
   )
@@ -212,6 +213,8 @@ test('own post shows Delete instead of Report, and deleting navigates away', asy
   const deleteDialog = screen.getByRole('dialog', { name: 'Delete item' })
   await userEvent.click(within(deleteDialog).getByRole('button', { name: 'Delete' }))
   await waitFor(() => expect(mockDeletePost).toHaveBeenCalledWith('p1'))
+  // ...and we land on the feed, not the landing page.
+  expect(await screen.findByText('Feed page')).toBeInTheDocument()
 })
 
 test('other users’ post still shows Report, not Delete', async () => {

--- a/website/src/pages/PostDetailPage.tsx
+++ b/website/src/pages/PostDetailPage.tsx
@@ -323,7 +323,7 @@ function PostDetailView({ postId }: { postId: string }) {
         await apiClient.deletePost(postId)
         // The post no longer exists; leave the detail view for the feed.
         // (the finally block clears deleteTarget)
-        navigate('/')
+        navigate('/home')
         return
       }
       await apiClient.deleteComment(postId, target.comment.threadId, target.comment.id)

--- a/website/src/pages/PostDetailPage.tsx
+++ b/website/src/pages/PostDetailPage.tsx
@@ -26,6 +26,7 @@ interface ThreadView {
 }
 
 type ReportTarget = { type: 'post' } | { type: 'comment'; comment: CommentView }
+type DeleteTarget = { type: 'post' } | { type: 'comment'; comment: CommentView }
 
 /**
  * Full post view: image, like count, caption, and threaded comments with
@@ -78,6 +79,7 @@ function PostDetailView({ postId }: { postId: string }) {
   const [replyTarget, setReplyTarget] = useState<ThreadView | null>(null)
   const [reportTarget, setReportTarget] = useState<ReportTarget | null>(null)
   const [reportReason, setReportReason] = useState('')
+  const [deleteTarget, setDeleteTarget] = useState<DeleteTarget | null>(null)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
   // Local like/report state, kept in refs so the in-app reload after posting a
@@ -311,6 +313,29 @@ function PostDetailView({ postId }: { postId: string }) {
     }
   }
 
+  // ---- Deleting (own content only) ----
+
+  async function submitDelete() {
+    const target = deleteTarget
+    if (!target) return
+    try {
+      if (target.type === 'post') {
+        await apiClient.deletePost(postId)
+        // The post no longer exists; leave the detail view for the feed.
+        setDeleteTarget(null)
+        navigate('/')
+        return
+      }
+      await apiClient.deleteComment(postId, target.comment.threadId, target.comment.id)
+      // Reload so the deleted comment disappears from its thread.
+      await loadAll()
+    } catch (err) {
+      setErrorMessage((err as Error).message ?? 'Failed to delete.')
+    } finally {
+      setDeleteTarget(null)
+    }
+  }
+
   if (isLoading && !post) {
     return (
       <div className="app-shell">
@@ -377,17 +402,29 @@ function PostDetailView({ postId }: { postId: string }) {
               ⚑
             </span>
           )}
-          <button
-            type="button"
-            className="app-bar__back"
-            style={{ marginLeft: 'auto' }}
-            onClick={() => {
-              setReportReason('')
-              setReportTarget({ type: 'post' })
-            }}
-          >
-            Report
-          </button>
+          {/* You can't report your own post — own posts offer Delete instead. */}
+          {isOwnPost ? (
+            <button
+              type="button"
+              className="app-bar__back"
+              style={{ marginLeft: 'auto' }}
+              onClick={() => setDeleteTarget({ type: 'post' })}
+            >
+              Delete
+            </button>
+          ) : (
+            <button
+              type="button"
+              className="app-bar__back"
+              style={{ marginLeft: 'auto' }}
+              onClick={() => {
+                setReportReason('')
+                setReportTarget({ type: 'post' })
+              }}
+            >
+              Report
+            </button>
+          )}
         </div>
 
         <p className="detail-caption">
@@ -449,6 +486,7 @@ function PostDetailView({ postId }: { postId: string }) {
                       setReportReason('')
                       setReportTarget({ type: 'comment', comment: root })
                     }}
+                    onDelete={() => setDeleteTarget({ type: 'comment', comment: root })}
                     onNavigate={() =>
                       navigate(`/profile/${encodeURIComponent(root.authorUsername)}`)
                     }
@@ -475,6 +513,7 @@ function PostDetailView({ postId }: { postId: string }) {
                           setReportReason('')
                           setReportTarget({ type: 'comment', comment: reply })
                         }}
+                        onDelete={() => setDeleteTarget({ type: 'comment', comment: reply })}
                         onNavigate={() =>
                           navigate(`/profile/${encodeURIComponent(reply.authorUsername)}`)
                         }
@@ -560,6 +599,29 @@ function PostDetailView({ postId }: { postId: string }) {
           </div>
         </div>
       )}
+
+      {deleteTarget && (
+        <div className="modal-overlay">
+          <div className="modal" role="dialog" aria-modal="true" aria-label="Delete item">
+            <h2 className="modal__title">
+              Delete {deleteTarget.type === 'post' ? 'Post' : 'Comment'}?
+            </h2>
+            <p className="muted">This can’t be undone.</p>
+            <div className="modal__actions">
+              <button
+                type="button"
+                className="modal__cancel"
+                onClick={() => setDeleteTarget(null)}
+              >
+                Cancel
+              </button>
+              <button type="button" className="modal__confirm" onClick={submitDelete}>
+                Delete
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   )
 }
@@ -579,10 +641,11 @@ interface CommentRowProps {
   comment: CommentView
   onToggleLike: () => void
   onReport: () => void
+  onDelete: () => void
   onNavigate: () => void
 }
 
-function CommentRow({ comment, onToggleLike, onReport, onNavigate }: CommentRowProps) {
+function CommentRow({ comment, onToggleLike, onReport, onDelete, onNavigate }: CommentRowProps) {
   return (
     <div className="comment-row">
       <span className="comment-row__avatar" aria-hidden="true">
@@ -613,9 +676,16 @@ function CommentRow({ comment, onToggleLike, onReport, onNavigate }: CommentRowP
             </button>
           )}
           <span>{comment.likeCount} likes</span>
-          <button type="button" className="comment-reply-btn" style={{ padding: 0 }} onClick={onReport}>
-            Report
-          </button>
+          {/* You can't report your own comment — own comments offer Delete. */}
+          {comment.isOwn ? (
+            <button type="button" className="comment-reply-btn" style={{ padding: 0 }} onClick={onDelete}>
+              Delete
+            </button>
+          ) : (
+            <button type="button" className="comment-reply-btn" style={{ padding: 0 }} onClick={onReport}>
+              Report
+            </button>
+          )}
           {comment.isReported && (
             <span className="flag-icon" aria-label="Reported">
               ⚑

--- a/website/src/pages/PostDetailPage.tsx
+++ b/website/src/pages/PostDetailPage.tsx
@@ -322,7 +322,7 @@ function PostDetailView({ postId }: { postId: string }) {
       if (target.type === 'post') {
         await apiClient.deletePost(postId)
         // The post no longer exists; leave the detail view for the feed.
-        setDeleteTarget(null)
+        // (the finally block clears deleteTarget)
         navigate('/')
         return
       }


### PR DESCRIPTION
Fixes #207 and #208.

## What & why

Long-pressing a post or comment (clicking the options control on web) used to jump straight to the report dialog — including on your own content. Now it opens a small **action menu** that offers a single, ownership-dependent action:

- **Report** — only on other people's posts/comments.
- **Delete** — only on your own.

This means you can no longer report your own post or comment (#207: "the dialog shouldn't even show up"), and there's now a clear way to delete your own (#208). The menu currently holds one option but is structured so more can be added later, as the issue anticipates.

The `deletePost` / `deleteComment` endpoints already existed on all three clients and their stubs, so this is UI / view-model wiring only.

## Changes by platform

**Website** (`PostDetailPage.tsx`)
- Post action and comment-row action render **Delete** vs **Report** by ownership.
- Added a delete-confirmation modal + `submitDelete`: deleting a post navigates back to the feed; deleting a comment reloads the thread.

**iOS** (`PostDetailView.swift`, `PostDetailViewModel.swift`)
- Long-press opens a `confirmationDialog` offering Delete or Report instead of going straight to the report sheet.
- Added `deletePost()` / `deleteComment()` and a `postWasDeleted` signal the view observes to `dismiss()` back to the feed.

**Android** (`PostDetailScreen.kt`, `PostDetailViewModel.kt`)
- New `ActionSheetDialog` on long-press with the single applicable action.
- Added `deletePost` / `deleteComment`, a `postWasDeleted` flow that `popBackStack`s, and a `reportedCommentIds` flow so the reported flag now appears on an actual successful report rather than immediately on long-press.

## Testing

- **Web**: full suite green — **119 passing**, including 3 new tests (own post → Delete + navigate away; others' post → Report only; own comment → Delete + reload). Typecheck and lint clean.
- **iOS / Android**: existing report tests updated to tap through the new menu; `testReportComment` restructured so the reported comment is authored by a *different* user (you can no longer report your own); added `testDeleteOwnPost` / `testDeleteOwnComment`.

## Reviewer notes

- I could **not** compile the iOS/Android changes locally — no JDK or Xcode toolchain in this environment — so those were verified by review only. The web changes are fully test-verified.
- The "post deleted" mobile tests assert the **detail screen was dismissed** rather than that the post vanished from the feed list, since the feed view is cached and isn't guaranteed to refresh on pop-back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)