### PR TITLE
Enforce shadow bans and hidden content via a visibility layer (banning chunk 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,30 @@ Social media site that only allows positive or neutral text and image posts. The
 Neutral content is allowed. Content that starts sad but ends on a happy or hopeful note is also allowed.
 
 These will be updated as time goes on.
+
+## Banning
+
+Users who violate the guidelines can be banned. Every ban is a `UserBan`
+record (see `backend/user_system/models.py`) with a type, a reason, an
+optional expiry, and the admin who issued it, so there is an audit trail and
+a future appeals system can reference the specific ban.
+
+There are two kinds of ban:
+
+- **Outright ban** — the user is told. Login is rejected with an
+  `account_banned` error, and any live sessions are terminated the moment the
+  ban is applied. Used for clear guideline violations: a temporary outright
+  ban (set `expires`) is the standard response to a first or minor offense,
+  and a permanent outright ban (no expiry) is for repeat offenders or severe
+  violations (hate speech, harassment of a specific person, illegal content).
+- **Shadow ban** — the user is *not* told. They can log in, post, and comment
+  normally, but their content is invisible to everyone but themselves. Used
+  for suspected spam, bots, and bad-faith actors, where telling the user they
+  are banned would just help them evade it by making a new account. Shadow
+  bans should normally carry an expiry; a permanent shadow ban is reserved
+  for confirmed bots.
+
+Whether a ban is temporary or permanent is controlled by the `expires` field
+and is independent of the ban type. Escalation for ordinary users follows
+the ladder: warning (content hidden by reports) → temporary outright ban →
+permanent outright ban.

--- a/backend/user_system/tests/test_shadow_ban_visibility.py
+++ b/backend/user_system/tests/test_shadow_ban_visibility.py
@@ -1,0 +1,212 @@
+from datetime import timedelta
+
+from django.urls import reverse
+from django.utils import timezone
+
+from .test_parent_case import PositiveOnlySocialTestCase
+from ..constants import BAN_TYPE_SHADOW, Fields
+from ..models import Post, UserBan
+from ..views import get_user_with_username
+
+
+class ShadowBanVisibilityTests(PositiveOnlySocialTestCase):
+    """
+    Tests that content authored by a shadow-banned user (and content hidden
+    by reports) is invisible to everyone except its author.
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        # The poster will be shadow banned; the viewer is an ordinary user.
+        self.poster = self.make_user_with_prefix(prefix='poster')
+        self.viewer = self.make_user_with_prefix(prefix='viewer')
+
+        self.poster_user = get_user_with_username(self.poster['username'])
+        self.viewer_user = get_user_with_username(self.viewer['username'])
+
+        self.poster_header = {'HTTP_AUTHORIZATION': f"Bearer {self.poster[Fields.session_management_token]}"}
+        self.viewer_header = {'HTTP_AUTHORIZATION': f"Bearer {self.viewer[Fields.session_management_token]}"}
+
+        post_data = self._make_post(self.poster[Fields.session_management_token])
+        self.post_identifier = post_data[Fields.post_identifier]
+        self.post = Post.objects.get(post_identifier=self.post_identifier)
+
+    def _shadow_ban_poster(self, expires=None):
+        return UserBan.objects.create(user=self.poster_user, ban_type=BAN_TYPE_SHADOW, expires=expires)
+
+    def _get_feed(self, header):
+        url = reverse('get_posts_in_feed', kwargs={'batch': 0})
+        response = self.client.get(url, **header)
+        self.assertEqual(response.status_code, 200)
+        return response.json()
+
+    def _get_posts_for_user(self, username, header):
+        url = reverse('get_posts_for_user', kwargs={'username': username, 'batch': 0})
+        response = self.client.get(url, **header)
+        self.assertEqual(response.status_code, 200)
+        return response.json()
+
+    def _feed_post_ids(self, header):
+        return [entry[Fields.post_identifier] for entry in self._get_feed(header)]
+
+    # =========================================================================
+    # POSTS
+    # =========================================================================
+
+    def test_shadow_banned_post_not_in_feed(self):
+        self.assertIn(self.post_identifier, self._feed_post_ids(self.viewer_header))
+
+        self._shadow_ban_poster()
+
+        self.assertNotIn(self.post_identifier, self._feed_post_ids(self.viewer_header))
+
+    def test_shadow_banned_user_still_sees_own_posts(self):
+        self._shadow_ban_poster()
+
+        posts = self._get_posts_for_user(self.poster['username'], self.poster_header)
+        self.assertEqual(len(posts), 1)
+        self.assertEqual(posts[0][Fields.post_identifier], self.post_identifier)
+
+    def test_shadow_banned_user_profile_posts_empty_for_others(self):
+        self._shadow_ban_poster()
+
+        posts = self._get_posts_for_user(self.poster['username'], self.viewer_header)
+        self.assertEqual(posts, [])
+
+    def test_shadow_banned_post_not_in_followed_feed(self):
+        follow_url = reverse('follow_user', kwargs={'username_to_follow': self.poster['username']})
+        response = self.client.post(follow_url, **self.viewer_header)
+        self.assertEqual(response.status_code, 200)
+
+        followed_url = reverse('get_posts_for_followed_users', kwargs={'batch': 0})
+        response = self.client.get(followed_url, **self.viewer_header)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()), 1)
+
+        self._shadow_ban_poster()
+
+        response = self.client.get(followed_url, **self.viewer_header)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), [])
+
+    def test_shadow_banned_post_details_hidden_from_others_but_not_author(self):
+        self._shadow_ban_poster()
+
+        url = reverse('get_post_details', kwargs={'post_identifier': self.post_identifier})
+
+        response = self.client.get(url, **self.viewer_header)
+        self.assertEqual(response.status_code, 400)
+
+        response = self.client.get(url, **self.poster_header)
+        self.assertEqual(response.status_code, 200)
+
+    def test_expired_shadow_ban_restores_visibility(self):
+        self._shadow_ban_poster(expires=timezone.now() - timedelta(days=1))
+
+        self.assertIn(self.post_identifier, self._feed_post_ids(self.viewer_header))
+
+    # =========================================================================
+    # HIDDEN CONTENT (report threshold)
+    # =========================================================================
+
+    def test_hidden_post_not_in_feed_but_author_still_sees_it(self):
+        self.post.hidden = True
+        self.post.save()
+
+        self.assertNotIn(self.post_identifier, self._feed_post_ids(self.viewer_header))
+
+        posts = self._get_posts_for_user(self.poster['username'], self.poster_header)
+        self.assertEqual(len(posts), 1)
+
+        details_url = reverse('get_post_details', kwargs={'post_identifier': self.post_identifier})
+        response = self.client.get(details_url, **self.viewer_header)
+        self.assertEqual(response.status_code, 400)
+
+    # =========================================================================
+    # COMMENTS
+    # =========================================================================
+
+    def test_shadow_banned_comment_invisible_to_others_but_not_author(self):
+        # The thread must live on the *viewer's* post: a thread on the
+        # banned user's own post would vanish along with the post itself.
+        post_data = self._make_post(self.viewer[Fields.session_management_token])
+        viewer_post_identifier = post_data[Fields.post_identifier]
+        comment_data = self._comment_on_post(
+            self.viewer[Fields.session_management_token], viewer_post_identifier)
+        thread_identifier = comment_data[Fields.comment_thread_identifier]
+
+        # The poster replies on the viewer's thread and is then shadow banned.
+        self._reply_to_comment_thread(
+            self.poster[Fields.session_management_token], viewer_post_identifier, thread_identifier)
+        self._shadow_ban_poster()
+
+        url = reverse('get_comments_for_thread', kwargs={
+            'comment_thread_identifier': thread_identifier, 'batch': 0})
+
+        response = self.client.get(url, **self.viewer_header)
+        self.assertEqual(response.status_code, 200)
+        authors = [comment[Fields.author_username] for comment in response.json()]
+        self.assertNotIn(self.poster['username'], authors)
+        self.assertIn(self.viewer['username'], authors)
+
+        response = self.client.get(url, **self.poster_header)
+        self.assertEqual(response.status_code, 200)
+        authors = [comment[Fields.author_username] for comment in response.json()]
+        self.assertIn(self.poster['username'], authors)
+
+    def test_thread_with_only_shadow_banned_comments_excluded(self):
+        # The viewer makes a post; the (about to be banned) poster starts the
+        # only thread on it.
+        post_data = self._make_post(self.viewer[Fields.session_management_token])
+        viewer_post_identifier = post_data[Fields.post_identifier]
+        self._comment_on_post(
+            self.poster[Fields.session_management_token], viewer_post_identifier)
+
+        url = reverse('get_comments_for_post', kwargs={
+            'post_identifier': viewer_post_identifier, 'batch': 0})
+
+        response = self.client.get(url, **self.viewer_header)
+        self.assertEqual(len(response.json()), 1)
+
+        self._shadow_ban_poster()
+
+        response = self.client.get(url, **self.viewer_header)
+        self.assertEqual(response.json(), [])
+
+        # The banned user still sees their own thread.
+        response = self.client.get(url, **self.poster_header)
+        self.assertEqual(len(response.json()), 1)
+
+    # =========================================================================
+    # SEARCH & PROFILE
+    # =========================================================================
+
+    def test_shadow_banned_user_excluded_from_search(self):
+        fragment = self.poster['username'][:10]
+        url = reverse('get_users_matching_fragment', kwargs={'username_fragment': fragment})
+
+        response = self.client.get(url, **self.viewer_header)
+        self.assertEqual(response.status_code, 200)
+        usernames = [user[Fields.username] for user in response.json()]
+        self.assertIn(self.poster['username'], usernames)
+
+        self._shadow_ban_poster()
+
+        response = self.client.get(url, **self.viewer_header)
+        self.assertEqual(response.status_code, 200)
+        usernames = [user[Fields.username] for user in response.json()]
+        self.assertNotIn(self.poster['username'], usernames)
+
+    def test_profile_post_count_reflects_visibility(self):
+        self._shadow_ban_poster()
+
+        url = reverse('get_profile_details', kwargs={'username': self.poster['username']})
+
+        response = self.client.get(url, **self.viewer_header)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()[Fields.post_count], 0)
+
+        response = self.client.get(url, **self.poster_header)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()[Fields.post_count], 1)

--- a/backend/user_system/views.py
+++ b/backend/user_system/views.py
@@ -30,6 +30,7 @@ from .input_validator import is_valid_pattern
 from .models import LoginCookie, Session, Post, CommentThread, PositiveOnlySocialUser, Comment, UserBlock, UserBan
 from .utils import convert_to_bool, generate_login_cookie_token, generate_management_token, generate_series_identifier, \
     get_batch, get_compressed_image_url
+from .visibility import can_view_post, searchable_users, visible_comment_threads, visible_comments, visible_posts
 
 image_classifier_class = image_classifier
 text_classifier_class = text_classifier
@@ -895,6 +896,8 @@ def get_posts_in_feed(request, batch):
     blocking_users = request.user.blocked_by.all()
     relevant_posts = relevant_posts.exclude(author__in=blocked_users).exclude(author__in=blocking_users)
 
+    relevant_posts = visible_posts(relevant_posts, request.user)
+
     if relevant_posts.count() > 0:
         batched_posts = get_batch(batch, POST_BATCH_SIZE, relevant_posts)
         posts_data = [
@@ -930,7 +933,9 @@ def get_posts_for_followed_users(request, batch):
     if not followed_users.exists():
         return log_and_return_json("get_posts_for_followed_users", [], safe=False)
 
-    posts_queryset = Post.objects.filter(author__in=followed_users).order_by('-creation_time')
+    posts_queryset = visible_posts(
+        Post.objects.filter(author__in=followed_users), request.user
+    ).order_by('-creation_time')
     posts_batch = get_batch(batch, POST_BATCH_SIZE, posts_queryset)
 
     posts_data = [
@@ -967,7 +972,9 @@ def get_posts_for_user(request, username, batch):
         logger.info(f"Get posts for user: Blocking relationship exists for user_id: {request.user.id} and target_user_id: {target_user.id}")
         return log_and_return_json("get_posts_for_user", [], safe=False)
 
-    relevant_posts = feed_algorithm_class.get_posts_weighted_for_user(target_user, Post)
+    relevant_posts = visible_posts(
+        feed_algorithm_class.get_posts_weighted_for_user(target_user, Post), request.user
+    )
 
     if relevant_posts.count() > 0:
         batched_posts = get_batch(batch, POST_BATCH_SIZE, relevant_posts)
@@ -994,7 +1001,7 @@ def get_post_details(request, post_identifier):
         return log_and_return_json("get_post_details", {'error': "Invalid post identifier"}, status=400)
 
     post = get_post_with_identifier(post_identifier)
-    if post is not None:
+    if post is not None and can_view_post(post, request.user):
         total_likes = post.postlike_set.count()
         post_data = {
             Fields.post_identifier: post.post_identifier,
@@ -1273,11 +1280,11 @@ def get_comments_for_post(request, post_identifier, batch):
         return log_and_return_json("get_comments_for_post", {'error': "Invalid batch parameter"}, status=400)
 
     post = get_post_with_identifier(post_identifier)
-    if not post:
-        logger.warning(f"Get comments for post failed: Post {post_identifier} not found")
+    if not post or not can_view_post(post, request.user):
+        logger.warning(f"Get comments for post failed: Post {post_identifier} not found or not visible")
         return log_and_return_json("get_comments_for_post", {'error': "No post with that identifier"}, status=400)
 
-    comment_threads = post.commentthread_set.all()
+    comment_threads = visible_comment_threads(post.commentthread_set.all(), request.user)
 
     relevant_comment_threads = feed_algorithm_class.get_comment_threads_weighted_for_post(comment_threads)
 
@@ -1300,11 +1307,11 @@ def get_comments_for_thread(request, comment_thread_identifier, batch):
         return log_and_return_json("get_comments_for_thread", {'error': "Invalid batch parameter"}, status=400)
 
     comment_thread = get_comment_thread_with_identifier(comment_thread_identifier)
-    if not comment_thread:
-        logger.warning(f"Get comments for thread failed: Thread {comment_thread_identifier} not found")
+    if not comment_thread or not can_view_post(comment_thread.post, request.user):
+        logger.warning(f"Get comments for thread failed: Thread {comment_thread_identifier} not found or not visible")
         return log_and_return_json("get_comments_for_thread", {'error': "No comment thread with that identifier"}, status=400)
 
-    comments = comment_thread.comment_set.all().order_by('creation_time')
+    comments = visible_comments(comment_thread.comment_set.all(), request.user).order_by('creation_time')
     relevant_comments = feed_algorithm_class.get_comments_weighted_for_thread(comments)
 
     if not relevant_comments.count() > 0:
@@ -1358,7 +1365,7 @@ def get_users_matching_fragment(request, username_fragment):
     # So if I blocked someone, I can still search them.
     # But if someone blocked me, I cannot search them.
     users_who_blocked_me = request.user.blocked_by.all()
-    users = users.exclude(pk__in=users_who_blocked_me)[:10]
+    users = searchable_users(users.exclude(pk__in=users_who_blocked_me))[:10]
 
     users_data = [
         {
@@ -1466,7 +1473,9 @@ def get_profile_details(request, username):
         logger.warning(f"Get profile details failed: User with username fragment not found")
         return log_and_return_json("get_profile_details", {'error': "User not found"}, status=400)
 
-    post_count = profile_user.post_set.count()
+    # Count only the posts the requesting user is allowed to see, so a
+    # shadow-banned profile shows no posts to others (but all to its owner).
+    post_count = visible_posts(profile_user.post_set.all(), request.user).count()
 
     # Assuming UserFollow model or a ManyToMany 'followers' field
     # This logic depends heavily on your model structure.

--- a/backend/user_system/visibility.py
+++ b/backend/user_system/visibility.py
@@ -34,8 +34,9 @@ def visible_comment_threads(threads, viewer):
     via a subquery on thread ids rather than joining through comments so the
     like-count annotations applied later are not inflated by duplicate rows.
     """
-    visible_thread_ids = visible_comments(Comment.objects.all(), viewer).values_list(
-        'comment_thread_id', flat=True)
+    visible_thread_ids = visible_comments(
+        Comment.objects.filter(comment_thread__in=threads), viewer
+    ).values_list('comment_thread_id', flat=True).distinct()
     return threads.filter(pk__in=visible_thread_ids)
 
 

--- a/backend/user_system/visibility.py
+++ b/backend/user_system/visibility.py
@@ -1,0 +1,53 @@
+from django.db.models import Q
+
+from .constants import BAN_TYPE_SHADOW
+from .models import Comment, UserBan
+
+
+def _shadow_banned_user_ids():
+    """User ids with a shadow ban currently in effect, usable as a subquery."""
+    return UserBan.objects.active().filter(ban_type=BAN_TYPE_SHADOW).values_list('user_id', flat=True)
+
+
+def visible_posts(posts, viewer):
+    """
+    Posts the viewer is allowed to see. A viewer always sees their own posts,
+    so a shadow ban (and report-hiding) stays invisible to the author;
+    everyone else only sees posts that are not hidden and whose author is not
+    shadow banned.
+    """
+    return posts.filter(
+        Q(author=viewer) | (Q(hidden=False) & ~Q(author__in=_shadow_banned_user_ids()))
+    )
+
+
+def visible_comments(comments, viewer):
+    """Same visibility rule as visible_posts, for comments."""
+    return comments.filter(
+        Q(author=viewer) | (Q(hidden=False) & ~Q(author__in=_shadow_banned_user_ids()))
+    )
+
+
+def visible_comment_threads(threads, viewer):
+    """
+    Threads that contain at least one comment visible to the viewer. Filters
+    via a subquery on thread ids rather than joining through comments so the
+    like-count annotations applied later are not inflated by duplicate rows.
+    """
+    visible_thread_ids = visible_comments(Comment.objects.all(), viewer).values_list(
+        'comment_thread_id', flat=True)
+    return threads.filter(pk__in=visible_thread_ids)
+
+
+def can_view_post(post, viewer):
+    """Visibility check for a single already-fetched post."""
+    if post.author == viewer:
+        return True
+    if post.hidden:
+        return False
+    return not UserBan.objects.active().filter(user=post.author, ban_type=BAN_TYPE_SHADOW).exists()
+
+
+def searchable_users(users):
+    """Excludes shadow-banned users from user search results."""
+    return users.exclude(pk__in=_shadow_banned_user_ids())


### PR DESCRIPTION
## Summary
- Adds `backend/user_system/visibility.py` with a single visibility rule: a viewer always sees their own content; everyone else only sees content that is not `hidden` and whose author has no active shadow ban (`UserBan.objects.active()`, so expiry is respected).
- Applies it to every read endpoint: main feed, followed feed, profile posts, post details, comments for post (threads with no visible comments disappear), comments for thread, user search, and profile post counts.
- Also fixes a latent gap: posts/comments hidden by the report threshold were never filtered out of any read endpoint before this.
- Documents the ban policy in the README: outright bans are told to the user (first/minor offense → temporary, repeat/severe → permanent); shadow bans are for spam/bots/bad-faith actors and normally carry an expiry.

Chunk 2 of #16, building on the `UserBan` model from #222.

## Test plan
- 11 new tests in `test_shadow_ban_visibility.py` covering feeds, post details, comments, threads, search, profile counts, author self-visibility, hidden content, and ban expiry.
- Full backend suite: 232 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)