### PR TITLE
Use probability thresholds with AI cascade for content classification

### DIFF
--- a/backend/user_system/classifiers/classifier_constants.py
+++ b/backend/user_system/classifiers/classifier_constants.py
@@ -8,6 +8,14 @@ GEMINI_MODEL = 'gemini-2.5-flash'
 CLAUDE_MODEL = 'claude-haiku-4-5-20251001'
 OPENAI_MODEL = 'gpt-4o-mini'
 
+# Probability zones for classification scores (probability that content is
+# positive/acceptable). Scores at or below REJECT_THRESHOLD are rejected with
+# no possibility of appeal. Scores at or above ALLOW_THRESHOLD are always
+# allowed. Anything strictly between the two is the "middle zone": escalated
+# to additional AIs and, if still not allowed, rejected but appealable.
+REJECT_THRESHOLD = 0.3
+ALLOW_THRESHOLD = 0.7
+
 _CONTENT_RULES = (
     "1. No swear words\n"
     "2. No nudity\n"
@@ -24,19 +32,25 @@ _CONTENT_ALLOWANCES = (
     "Content that begins sad but ends on a happy or hopeful note is also acceptable.\n"
 )
 
+_PROBABILITY_INSTRUCTION = (
+    "Answer with only a single number between 0.00 and 1.00 representing the "
+    "probability that the content is acceptable, where 1.00 means clearly "
+    "acceptable and 0.00 means clearly unacceptable.\n"
+)
+
 TEXT_CLASSIFIER_PROMPT = (
-    "Is the following text positive, neutral, or otherwise acceptable? "
+    "How likely is the following text to be positive, neutral, or otherwise acceptable? "
     "Text is acceptable if it follows these rules:\n"
     + _CONTENT_RULES
     + _CONTENT_ALLOWANCES
-    + 'Answer with only "True" or "False".\n\n'
-    "Text: \"{text}\""
+    + _PROBABILITY_INSTRUCTION
+    + "\nText: \"{text}\""
 )
 
 IMAGE_CLASSIFIER_PROMPT = (
-    "Is this image positive, neutral, or otherwise acceptable? "
+    "How likely is this image to be positive, neutral, or otherwise acceptable? "
     "An image is acceptable if it follows these rules:\n"
     + _CONTENT_RULES
     + _CONTENT_ALLOWANCES
-    + 'Answer with only "True" or "False".'
+    + _PROBABILITY_INSTRUCTION
 )

--- a/backend/user_system/classifiers/classifier_utils.py
+++ b/backend/user_system/classifiers/classifier_utils.py
@@ -1,18 +1,27 @@
 import os
+import re
 import random
 import logging
 import base64
 from io import BytesIO
+from dataclasses import dataclass, field
 from google import genai
 import anthropic
 import openai as openai_lib
-from .classifier_constants import GEMINI_MODEL, CLAUDE_MODEL, OPENAI_MODEL
+from .classifier_constants import (
+    GEMINI_MODEL, CLAUDE_MODEL, OPENAI_MODEL,
+    REJECT_THRESHOLD, ALLOW_THRESHOLD,
+)
 
 logger = logging.getLogger(__name__)
 
 API_GEMINI = 'gemini'
 API_CLAUDE = 'claude'
 API_OPENAI = 'openai'
+
+ZONE_REJECT = 'reject'
+ZONE_MIDDLE = 'middle'
+ZONE_ALLOW = 'allow'
 
 ENV_KEY_TO_API = {
     'GEMINI_API_KEY': API_GEMINI,
@@ -25,31 +34,91 @@ def get_available_apis():
     return [api for env_var, api in ENV_KEY_TO_API.items() if os.environ.get(env_var)]
 
 
-def classify_with_voting(available_apis, call_fn):
+@dataclass
+class ClassificationResult:
+    """Outcome of a probability-threshold classification.
+
+    Truthy when the content is allowed, so existing `if not is_text_positive(...)`
+    call sites keep working. `appealable` only matters when `allowed` is False;
+    the appeal system itself is a future feature.
     """
-    Picks 2 random APIs and uses majority vote; a 3rd breaks ties if available.
-    Falls back to False with 0 APIs, or uses the sole API with 1.
+    allowed: bool
+    appealable: bool = False
+    scores: list = field(default_factory=list)
+
+    def __bool__(self):
+        return self.allowed
+
+
+def get_zone(score):
+    if score <= REJECT_THRESHOLD:
+        return ZONE_REJECT
+    if score >= ALLOW_THRESHOLD:
+        return ZONE_ALLOW
+    return ZONE_MIDDLE
+
+
+def parse_probability(text):
+    """Extracts a probability in [0, 1] from a model response, or None."""
+    match = re.search(r'\d+(?:\.\d+)?|\.\d+', str(text))
+    if not match:
+        logger.warning("Could not parse probability from model response: %r", text)
+        return None
+    probability = float(match.group())
+    if not 0.0 <= probability <= 1.0:
+        logger.warning("Parsed probability out of range: %s", probability)
+        return None
+    return probability
+
+
+def classify_with_thresholds(available_apis, call_fn):
+    """
+    Cascades through up to 3 AIs using probability zones.
+
+    - First AI: allow zone -> allowed; reject zone -> rejected, not appealable;
+      middle zone -> ask a second AI.
+    - Second AI: allow zone -> allowed; middle or reject zone -> ask a third AI.
+    - Third AI: allow zone -> allowed; reject zone -> rejected, not appealable;
+      middle zone -> rejected but appealable.
+    - If the cascade needs another AI and none is available, the content is
+      rejected; it is appealable only if the last score was in the middle zone.
+
+    APIs are consulted in random order. An API that errors or returns an
+    unparseable score is skipped as if unavailable. With no usable scores at
+    all the content is rejected and not appealable.
     """
     if not available_apis:
-        return False
+        return ClassificationResult(allowed=False)
 
-    if len(available_apis) == 1:
-        return call_fn(available_apis[0])
+    order = random.sample(available_apis, len(available_apis))
+    scores = []
 
-    chosen = random.sample(available_apis, 2)
-    remaining = [a for a in available_apis if a not in chosen]
+    for api_name in order:
+        score = call_fn(api_name)
+        if score is None:
+            logger.warning("API %s returned no usable score; skipping it.", api_name)
+            continue
 
-    result_a = call_fn(chosen[0])
-    result_b = call_fn(chosen[1])
+        scores.append(score)
+        zone = get_zone(score)
+        stage = len(scores)
+        logger.info("AI #%d (%s) scored %.2f -> %s zone", stage, api_name, score, zone)
 
-    if result_a == result_b:
-        return result_a
+        if zone == ZONE_ALLOW:
+            return ClassificationResult(allowed=True, scores=scores)
+        if stage == 1 and zone == ZONE_REJECT:
+            return ClassificationResult(allowed=False, appealable=False, scores=scores)
+        if stage == 3:
+            return ClassificationResult(allowed=False, appealable=(zone == ZONE_MIDDLE), scores=scores)
+        # Middle zone (or reject zone at stage 2): escalate to the next AI.
 
-    if remaining:
-        return call_fn(remaining[0])
+    if not scores:
+        logger.warning("No AI produced a usable score. Rejecting without appeal.")
+        return ClassificationResult(allowed=False)
 
-    logger.warning("Two APIs disagreed with no tiebreaker available. Defaulting to False.")
-    return False
+    appealable = get_zone(scores[-1]) == ZONE_MIDDLE
+    logger.info("Cascade exhausted available AIs. Rejecting (appealable=%s).", appealable)
+    return ClassificationResult(allowed=False, appealable=appealable, scores=scores)
 
 
 def call_text_gemini(text, prompt_template):
@@ -57,7 +126,7 @@ def call_text_gemini(text, prompt_template):
     client = genai.Client(api_key=api_key)
     prompt = prompt_template.format(text=text)
     response = client.models.generate_content(model=GEMINI_MODEL, contents=prompt)
-    return response.text.strip().lower() == 'true'
+    return parse_probability(response.text)
 
 
 def call_text_claude(text, prompt_template):
@@ -69,7 +138,7 @@ def call_text_claude(text, prompt_template):
         max_tokens=10,
         messages=[{"role": "user", "content": prompt}]
     )
-    return response.content[0].text.strip().lower() == 'true'
+    return parse_probability(response.content[0].text)
 
 
 def call_text_openai(text, prompt_template):
@@ -81,7 +150,7 @@ def call_text_openai(text, prompt_template):
         max_tokens=10,
         messages=[{"role": "user", "content": prompt}]
     )
-    return response.choices[0].message.content.strip().lower() == 'true'
+    return parse_probability(response.choices[0].message.content)
 
 
 def _image_to_base64_png(image):
@@ -94,7 +163,7 @@ def call_image_gemini(image, prompt):
     api_key = os.environ.get('GEMINI_API_KEY')
     client = genai.Client(api_key=api_key)
     response = client.models.generate_content(model=GEMINI_MODEL, contents=[prompt, image])
-    return response.text.strip().lower() == 'true'
+    return parse_probability(response.text)
 
 
 def call_image_claude(image, prompt):
@@ -112,7 +181,7 @@ def call_image_claude(image, prompt):
             ]
         }]
     )
-    return response.content[0].text.strip().lower() == 'true'
+    return parse_probability(response.content[0].text)
 
 
 def call_image_openai(image, prompt):
@@ -130,7 +199,7 @@ def call_image_openai(image, prompt):
             ]
         }]
     )
-    return response.choices[0].message.content.strip().lower() == 'true'
+    return parse_probability(response.choices[0].message.content)
 
 
 TEXT_API_DISPATCH = {

--- a/backend/user_system/classifiers/classifier_utils.py
+++ b/backend/user_system/classifiers/classifier_utils.py
@@ -59,16 +59,18 @@ def get_zone(score):
 
 
 def parse_probability(text):
-    """Extracts a probability in [0, 1] from a model response, or None."""
-    match = re.search(r'\d+(?:\.\d+)?|\.\d+', str(text))
-    if not match:
-        logger.warning("Could not parse probability from model response: %r", text)
+    """Extracts a probability in [0, 1] from a model response, or None.
+
+    Takes the last in-range number so a response that echoes the prompt's
+    "between 0.00 and 1.00" range before giving its answer still parses the
+    answer rather than the echoed bounds.
+    """
+    numbers = [float(m) for m in re.findall(r'\d+(?:\.\d+)?|\.\d+', str(text))]
+    in_range = [n for n in numbers if 0.0 <= n <= 1.0]
+    if not in_range:
+        logger.warning("Could not parse an in-range probability from model response: %r", text)
         return None
-    probability = float(match.group())
-    if not 0.0 <= probability <= 1.0:
-        logger.warning("Parsed probability out of range: %s", probability)
-        return None
-    return probability
+    return in_range[-1]
 
 
 def classify_with_thresholds(available_apis, call_fn):

--- a/backend/user_system/classifiers/image_classifier.py
+++ b/backend/user_system/classifiers/image_classifier.py
@@ -6,7 +6,8 @@ from io import BytesIO
 from urllib.parse import urlparse
 from .classifier_constants import POSITIVE_IMAGE_FILENAME, IMAGE_CLASSIFIER_PROMPT
 from .classifier_utils import (
-    get_available_apis, classify_with_voting, IMAGE_API_DISPATCH,
+    get_available_apis, classify_with_thresholds, ClassificationResult,
+    IMAGE_API_DISPATCH,
 )
 from ..utils import convert_to_bool
 
@@ -21,9 +22,9 @@ def is_image_positive(image_url):
 
     if testing:
         parsed_url = urlparse(image_url)
-        result = parsed_url.path.endswith(POSITIVE_IMAGE_FILENAME)
-        logger.debug("Testing mode - path=%s endswith %s -> %s", parsed_url.path, POSITIVE_IMAGE_FILENAME, result)
-        return result
+        allowed = parsed_url.path.endswith(POSITIVE_IMAGE_FILENAME)
+        logger.debug("Testing mode - path=%s endswith %s -> %s", parsed_url.path, POSITIVE_IMAGE_FILENAME, allowed)
+        return ClassificationResult(allowed=allowed)
 
     logger.debug("Checking available AI APIs for image classification")
     available_apis = get_available_apis()
@@ -31,7 +32,7 @@ def is_image_positive(image_url):
 
     if not available_apis:
         logger.error("No AI API keys available.")
-        return False
+        return ClassificationResult(allowed=False)
 
     aws_access_key = os.environ.get("AWS_ACCESS_KEY_ID")
     aws_secret_key = os.environ.get("AWS_SECRET_ACCESS_KEY")
@@ -39,7 +40,7 @@ def is_image_positive(image_url):
     if not aws_access_key or not aws_secret_key:
         logger.error("Missing AWS credentials — AWS_ACCESS_KEY_ID present=%s, AWS_SECRET_ACCESS_KEY present=%s",
                      bool(aws_access_key), bool(aws_secret_key))
-        return False
+        return ClassificationResult(allowed=False)
 
     try:
         region = os.environ.get("AWS_REGION", "us-east-1")
@@ -89,7 +90,7 @@ def is_image_positive(image_url):
 
         if not bucket_name:
             logger.error("Could not determine S3 bucket name from URL=%s and AWS_STORAGE_BUCKET_NAME is unset", image_url)
-            return False
+            return ClassificationResult(allowed=False)
 
         logger.info("Fetching image from S3 — bucket=%s key=%s", bucket_name, key)
         response = s3.get_object(Bucket=bucket_name, Key=key)
@@ -105,20 +106,20 @@ def is_image_positive(image_url):
                 api_func = IMAGE_API_DISPATCH.get(api_name)
                 if not api_func:
                     logger.error("Unsupported API name: %s", api_name)
-                    return False
+                    return None
                 logger.debug("Calling %s API for image classification", api_name)
-                result = api_func(image, IMAGE_CLASSIFIER_PROMPT)
-                logger.debug("%s API returned: %s", api_name, result)
-                return result
+                score = api_func(image, IMAGE_CLASSIFIER_PROMPT)
+                logger.debug("%s API returned: %s", api_name, score)
+                return score
             except Exception:
                 logger.exception("Error calling %s API for image classification", api_name)
-                return False
+                return None
 
-        logger.info("Starting image classification vote with APIs: %s", available_apis)
-        result = classify_with_voting(available_apis, call_api)
+        logger.info("Starting image classification cascade with APIs: %s", available_apis)
+        result = classify_with_thresholds(available_apis, call_api)
         logger.info("Image classification result for key=%s: %s", key, result)
         return result
 
     except Exception:
         logger.exception("Error in image classifier for URL: %s", image_url)
-        return False
+        return ClassificationResult(allowed=False)

--- a/backend/user_system/classifiers/text_classifier.py
+++ b/backend/user_system/classifiers/text_classifier.py
@@ -2,7 +2,8 @@ import os
 import logging
 from .classifier_constants import TEXT_CLASSIFIER_PROMPT
 from .classifier_utils import (
-    get_available_apis, classify_with_voting, TEXT_API_DISPATCH,
+    get_available_apis, classify_with_thresholds, ClassificationResult,
+    TEXT_API_DISPATCH,
 )
 from ..utils import convert_to_bool
 
@@ -10,15 +11,16 @@ logger = logging.getLogger(__name__)
 
 
 def is_text_positive(text):
+    """Returns a ClassificationResult (truthy when the text is allowed)."""
     text = str(text)
     logger.debug("is_text_positive called — text length=%d", len(text))
     testing = os.environ.get("TESTING", False)
     testing = testing if isinstance(testing, bool) else convert_to_bool(testing)
 
     if testing:
-        result = "negative" not in text.lower()
-        logger.debug("Testing mode — result=%s", result)
-        return result
+        allowed = "negative" not in text.lower()
+        logger.debug("Testing mode — allowed=%s", allowed)
+        return ClassificationResult(allowed=allowed)
 
     logger.debug("Checking available AI APIs for text classification")
     available_apis = get_available_apis()
@@ -26,23 +28,23 @@ def is_text_positive(text):
 
     if not available_apis:
         logger.error("No AI API keys available.")
-        return False
+        return ClassificationResult(allowed=False)
 
     def call_api(api_name):
         try:
             api_func = TEXT_API_DISPATCH.get(api_name)
             if not api_func:
                 logger.error("Unsupported API name: %s", api_name)
-                return False
+                return None
             logger.debug("Calling %s API for text classification", api_name)
-            result = api_func(text, TEXT_CLASSIFIER_PROMPT)
-            logger.debug("%s API returned: %s", api_name, result)
-            return result
+            score = api_func(text, TEXT_CLASSIFIER_PROMPT)
+            logger.debug("%s API returned: %s", api_name, score)
+            return score
         except Exception:
             logger.exception("Error calling %s API for text classification", api_name)
-            return False
+            return None
 
-    logger.info("Starting text classification vote with APIs: %s", available_apis)
-    result = classify_with_voting(available_apis, call_api)
+    logger.info("Starting text classification cascade with APIs: %s", available_apis)
+    result = classify_with_thresholds(available_apis, call_api)
     logger.info("Text classification result: %s", result)
     return result

--- a/backend/user_system/tests/test_classifiers.py
+++ b/backend/user_system/tests/test_classifiers.py
@@ -5,7 +5,9 @@ from PIL import Image
 from ..classifiers.text_classifier import is_text_positive
 from ..classifiers.image_classifier import is_image_positive
 from ..classifiers.classifier_constants import POSITIVE_TEXT, POSITIVE_IMAGE_URL, TEXT_CLASSIFIER_PROMPT, IMAGE_CLASSIFIER_PROMPT
-from ..classifiers.classifier_utils import API_GEMINI, API_CLAUDE, API_OPENAI
+from ..classifiers.classifier_utils import (
+    API_GEMINI, API_CLAUDE, API_OPENAI, parse_probability,
+)
 from .test_parent_case import PositiveOnlySocialTestCase
 
 _ALL_AI_KEYS = {
@@ -26,6 +28,11 @@ _AWS_KEYS_NO_BUCKET = {
 _TEXT_DISPATCH = "user_system.classifiers.classifier_utils.TEXT_API_DISPATCH"
 _IMAGE_DISPATCH = "user_system.classifiers.classifier_utils.IMAGE_API_DISPATCH"
 
+# Representative scores for each probability zone.
+ALLOW_SCORE = 0.9
+MIDDLE_SCORE = 0.5
+REJECT_SCORE = 0.1
+
 
 def _make_fake_image_bytes():
     img = Image.new('RGB', (10, 10), color='red')
@@ -35,6 +42,23 @@ def _make_fake_image_bytes():
 
 
 class TestClassifiers(PositiveOnlySocialTestCase):
+
+    # ------------------------------------------------------------------ #
+    # Probability parsing                                                  #
+    # ------------------------------------------------------------------ #
+
+    def test_parse_probability_valid(self):
+        self.assertEqual(parse_probability("0.85"), 0.85)
+        self.assertEqual(parse_probability(" 1.00 "), 1.0)
+        self.assertEqual(parse_probability("0"), 0.0)
+        self.assertEqual(parse_probability("Probability: 0.4"), 0.4)
+        self.assertEqual(parse_probability(".75"), 0.75)
+
+    def test_parse_probability_invalid(self):
+        self.assertIsNone(parse_probability("yes"))
+        self.assertIsNone(parse_probability(""))
+        self.assertIsNone(parse_probability("100"))
+        self.assertIsNone(parse_probability("1.5"))
 
     # ------------------------------------------------------------------ #
     # Text classifier – testing mode                                       #
@@ -51,102 +75,188 @@ class TestClassifiers(PositiveOnlySocialTestCase):
 
     @patch.dict(os.environ, {}, clear=True)
     def test_text_classifier_no_api_keys(self):
-        self.assertFalse(is_text_positive("some text"))
+        result = is_text_positive("some text")
+        self.assertFalse(result)
+        self.assertFalse(result.appealable)
 
     # ------------------------------------------------------------------ #
     # Text classifier – single API                                         #
     # ------------------------------------------------------------------ #
 
     @patch.dict(os.environ, {"GEMINI_API_KEY": "fake_key"}, clear=True)
-    def test_text_classifier_single_gemini_positive(self):
-        mock_gemini = MagicMock(return_value=True)
+    def test_text_classifier_single_gemini_allow_zone(self):
+        mock_gemini = MagicMock(return_value=ALLOW_SCORE)
         with patch.dict(_TEXT_DISPATCH, {API_GEMINI: mock_gemini}):
             self.assertTrue(is_text_positive("I am happy"))
         mock_gemini.assert_called_once_with("I am happy", TEXT_CLASSIFIER_PROMPT)
 
     @patch.dict(os.environ, {"GEMINI_API_KEY": "fake_key"}, clear=True)
-    def test_text_classifier_single_gemini_negative(self):
-        with patch.dict(_TEXT_DISPATCH, {API_GEMINI: MagicMock(return_value=False)}):
-            self.assertFalse(is_text_positive("I am sad"))
+    def test_text_classifier_single_gemini_reject_zone_not_appealable(self):
+        with patch.dict(_TEXT_DISPATCH, {API_GEMINI: MagicMock(return_value=REJECT_SCORE)}):
+            result = is_text_positive("I am sad")
+        self.assertFalse(result)
+        self.assertFalse(result.appealable)
+
+    @patch.dict(os.environ, {"GEMINI_API_KEY": "fake_key"}, clear=True)
+    def test_text_classifier_single_gemini_middle_zone_rejected_but_appealable(self):
+        with patch.dict(_TEXT_DISPATCH, {API_GEMINI: MagicMock(return_value=MIDDLE_SCORE)}):
+            result = is_text_positive("ambiguous text")
+        self.assertFalse(result)
+        self.assertTrue(result.appealable)
 
     @patch.dict(os.environ, {"ANTHROPIC_API_KEY": "fake_key"}, clear=True)
-    def test_text_classifier_single_claude_positive(self):
-        mock_claude = MagicMock(return_value=True)
+    def test_text_classifier_single_claude_allow_zone(self):
+        mock_claude = MagicMock(return_value=ALLOW_SCORE)
         with patch.dict(_TEXT_DISPATCH, {API_CLAUDE: mock_claude}):
             self.assertTrue(is_text_positive("Great day"))
         mock_claude.assert_called_once_with("Great day", TEXT_CLASSIFIER_PROMPT)
 
     @patch.dict(os.environ, {"OPENAI_API_KEY": "fake_key"}, clear=True)
-    def test_text_classifier_single_openai_positive(self):
-        mock_openai = MagicMock(return_value=True)
+    def test_text_classifier_single_openai_allow_zone(self):
+        mock_openai = MagicMock(return_value=ALLOW_SCORE)
         with patch.dict(_TEXT_DISPATCH, {API_OPENAI: mock_openai}):
             self.assertTrue(is_text_positive("Wonderful"))
         mock_openai.assert_called_once_with("Wonderful", TEXT_CLASSIFIER_PROMPT)
 
     # ------------------------------------------------------------------ #
-    # Text classifier – voting: two APIs agree                             #
+    # Text classifier – zone boundaries                                    #
+    # ------------------------------------------------------------------ #
+
+    @patch.dict(os.environ, {"GEMINI_API_KEY": "fake_key"}, clear=True)
+    def test_text_classifier_boundary_scores(self):
+        # Exactly 0.3 is the reject zone (not appealable).
+        with patch.dict(_TEXT_DISPATCH, {API_GEMINI: MagicMock(return_value=0.3)}):
+            result = is_text_positive("some text")
+            self.assertFalse(result)
+            self.assertFalse(result.appealable)
+        # Exactly 0.7 is the allow zone.
+        with patch.dict(_TEXT_DISPATCH, {API_GEMINI: MagicMock(return_value=0.7)}):
+            self.assertTrue(is_text_positive("some text"))
+        # Just inside the middle zone on either side: rejected but appealable.
+        for score in (0.35, 0.65):
+            with patch.dict(_TEXT_DISPATCH, {API_GEMINI: MagicMock(return_value=score)}):
+                result = is_text_positive("some text")
+                self.assertFalse(result)
+                self.assertTrue(result.appealable)
+
+    # ------------------------------------------------------------------ #
+    # Text classifier – cascade between AIs                                #
     # ------------------------------------------------------------------ #
 
     @patch.dict(os.environ, _ALL_AI_KEYS, clear=True)
     @patch("user_system.classifiers.classifier_utils.random")
-    def test_text_voting_two_agree_true(self, mock_random):
-        mock_random.sample.return_value = [API_GEMINI, API_CLAUDE]
-        mock_gemini = MagicMock(return_value=True)
-        mock_claude = MagicMock(return_value=True)
-        mock_openai = MagicMock(return_value=True)
+    def test_text_cascade_first_ai_allows_no_escalation(self, mock_random):
+        mock_random.sample.return_value = [API_GEMINI, API_CLAUDE, API_OPENAI]
+        mock_gemini = MagicMock(return_value=ALLOW_SCORE)
+        mock_claude = MagicMock(return_value=ALLOW_SCORE)
+        mock_openai = MagicMock(return_value=ALLOW_SCORE)
         with patch.dict(_TEXT_DISPATCH, {API_GEMINI: mock_gemini, API_CLAUDE: mock_claude, API_OPENAI: mock_openai}):
             self.assertTrue(is_text_positive("nice text"))
+        mock_claude.assert_not_called()
         mock_openai.assert_not_called()
 
     @patch.dict(os.environ, _ALL_AI_KEYS, clear=True)
     @patch("user_system.classifiers.classifier_utils.random")
-    def test_text_voting_two_agree_false(self, mock_random):
-        mock_random.sample.return_value = [API_GEMINI, API_CLAUDE]
-        mock_gemini = MagicMock(return_value=False)
-        mock_claude = MagicMock(return_value=False)
-        mock_openai = MagicMock(return_value=False)
+    def test_text_cascade_first_ai_rejects_no_escalation_not_appealable(self, mock_random):
+        mock_random.sample.return_value = [API_GEMINI, API_CLAUDE, API_OPENAI]
+        mock_gemini = MagicMock(return_value=REJECT_SCORE)
+        mock_claude = MagicMock(return_value=ALLOW_SCORE)
+        mock_openai = MagicMock(return_value=ALLOW_SCORE)
         with patch.dict(_TEXT_DISPATCH, {API_GEMINI: mock_gemini, API_CLAUDE: mock_claude, API_OPENAI: mock_openai}):
-            self.assertFalse(is_text_positive("bad text"))
+            result = is_text_positive("bad text")
+        self.assertFalse(result)
+        self.assertFalse(result.appealable)
+        mock_claude.assert_not_called()
         mock_openai.assert_not_called()
-
-    # ------------------------------------------------------------------ #
-    # Text classifier – voting: disagree with tiebreaker                   #
-    # ------------------------------------------------------------------ #
 
     @patch.dict(os.environ, _ALL_AI_KEYS, clear=True)
     @patch("user_system.classifiers.classifier_utils.random")
-    def test_text_voting_disagree_tiebreaker_true(self, mock_random):
-        mock_random.sample.return_value = [API_GEMINI, API_CLAUDE]
-        mock_gemini = MagicMock(return_value=True)
-        mock_claude = MagicMock(return_value=False)
-        mock_openai = MagicMock(return_value=True)
+    def test_text_cascade_middle_then_second_allows(self, mock_random):
+        mock_random.sample.return_value = [API_GEMINI, API_CLAUDE, API_OPENAI]
+        mock_gemini = MagicMock(return_value=MIDDLE_SCORE)
+        mock_claude = MagicMock(return_value=ALLOW_SCORE)
+        mock_openai = MagicMock(return_value=REJECT_SCORE)
+        with patch.dict(_TEXT_DISPATCH, {API_GEMINI: mock_gemini, API_CLAUDE: mock_claude, API_OPENAI: mock_openai}):
+            self.assertTrue(is_text_positive("some text"))
+        mock_openai.assert_not_called()
+
+    @patch.dict(os.environ, _ALL_AI_KEYS, clear=True)
+    @patch("user_system.classifiers.classifier_utils.random")
+    def test_text_cascade_middle_then_reject_then_third_allows(self, mock_random):
+        mock_random.sample.return_value = [API_GEMINI, API_CLAUDE, API_OPENAI]
+        mock_gemini = MagicMock(return_value=MIDDLE_SCORE)
+        mock_claude = MagicMock(return_value=REJECT_SCORE)
+        mock_openai = MagicMock(return_value=ALLOW_SCORE)
         with patch.dict(_TEXT_DISPATCH, {API_GEMINI: mock_gemini, API_CLAUDE: mock_claude, API_OPENAI: mock_openai}):
             self.assertTrue(is_text_positive("some text"))
         mock_openai.assert_called_once()
 
     @patch.dict(os.environ, _ALL_AI_KEYS, clear=True)
     @patch("user_system.classifiers.classifier_utils.random")
-    def test_text_voting_disagree_tiebreaker_false(self, mock_random):
-        mock_random.sample.return_value = [API_GEMINI, API_CLAUDE]
-        mock_gemini = MagicMock(return_value=True)
-        mock_claude = MagicMock(return_value=False)
-        mock_openai = MagicMock(return_value=False)
+    def test_text_cascade_third_middle_rejected_but_appealable(self, mock_random):
+        mock_random.sample.return_value = [API_GEMINI, API_CLAUDE, API_OPENAI]
+        mock_gemini = MagicMock(return_value=MIDDLE_SCORE)
+        mock_claude = MagicMock(return_value=MIDDLE_SCORE)
+        mock_openai = MagicMock(return_value=MIDDLE_SCORE)
         with patch.dict(_TEXT_DISPATCH, {API_GEMINI: mock_gemini, API_CLAUDE: mock_claude, API_OPENAI: mock_openai}):
-            self.assertFalse(is_text_positive("some text"))
-        mock_openai.assert_called_once()
+            result = is_text_positive("some text")
+        self.assertFalse(result)
+        self.assertTrue(result.appealable)
+
+    @patch.dict(os.environ, _ALL_AI_KEYS, clear=True)
+    @patch("user_system.classifiers.classifier_utils.random")
+    def test_text_cascade_third_reject_not_appealable(self, mock_random):
+        mock_random.sample.return_value = [API_GEMINI, API_CLAUDE, API_OPENAI]
+        mock_gemini = MagicMock(return_value=MIDDLE_SCORE)
+        mock_claude = MagicMock(return_value=REJECT_SCORE)
+        mock_openai = MagicMock(return_value=REJECT_SCORE)
+        with patch.dict(_TEXT_DISPATCH, {API_GEMINI: mock_gemini, API_CLAUDE: mock_claude, API_OPENAI: mock_openai}):
+            result = is_text_positive("some text")
+        self.assertFalse(result)
+        self.assertFalse(result.appealable)
+
+    @patch.dict(os.environ, {"GEMINI_API_KEY": "gk", "ANTHROPIC_API_KEY": "ak"}, clear=True)
+    @patch("user_system.classifiers.classifier_utils.random")
+    def test_text_cascade_two_apis_second_middle_no_third_rejected_appealable(self, mock_random):
+        mock_random.sample.return_value = [API_GEMINI, API_CLAUDE]
+        mock_gemini = MagicMock(return_value=MIDDLE_SCORE)
+        mock_claude = MagicMock(return_value=MIDDLE_SCORE)
+        with patch.dict(_TEXT_DISPATCH, {API_GEMINI: mock_gemini, API_CLAUDE: mock_claude}):
+            result = is_text_positive("some text")
+        self.assertFalse(result)
+        self.assertTrue(result.appealable)
+
+    @patch.dict(os.environ, {"GEMINI_API_KEY": "gk", "ANTHROPIC_API_KEY": "ak"}, clear=True)
+    @patch("user_system.classifiers.classifier_utils.random")
+    def test_text_cascade_two_apis_second_reject_no_third_rejected_not_appealable(self, mock_random):
+        mock_random.sample.return_value = [API_GEMINI, API_CLAUDE]
+        mock_gemini = MagicMock(return_value=MIDDLE_SCORE)
+        mock_claude = MagicMock(return_value=REJECT_SCORE)
+        with patch.dict(_TEXT_DISPATCH, {API_GEMINI: mock_gemini, API_CLAUDE: mock_claude}):
+            result = is_text_positive("some text")
+        self.assertFalse(result)
+        self.assertFalse(result.appealable)
 
     # ------------------------------------------------------------------ #
-    # Text classifier – voting: two APIs, no tiebreaker, disagree          #
+    # Text classifier – API errors are skipped                             #
     # ------------------------------------------------------------------ #
 
     @patch.dict(os.environ, {"GEMINI_API_KEY": "gk", "ANTHROPIC_API_KEY": "ak"}, clear=True)
     @patch("user_system.classifiers.classifier_utils.random")
-    def test_text_voting_two_apis_disagree_no_tiebreaker(self, mock_random):
+    def test_text_cascade_errored_api_is_skipped(self, mock_random):
         mock_random.sample.return_value = [API_GEMINI, API_CLAUDE]
-        mock_gemini = MagicMock(return_value=True)
-        mock_claude = MagicMock(return_value=False)
+        mock_gemini = MagicMock(side_effect=Exception("boom"))
+        mock_claude = MagicMock(return_value=ALLOW_SCORE)
         with patch.dict(_TEXT_DISPATCH, {API_GEMINI: mock_gemini, API_CLAUDE: mock_claude}):
-            self.assertFalse(is_text_positive("some text"))
+            self.assertTrue(is_text_positive("some text"))
+        mock_claude.assert_called_once()
+
+    @patch.dict(os.environ, {"GEMINI_API_KEY": "fake_key"}, clear=True)
+    def test_text_cascade_all_apis_error_rejected_not_appealable(self):
+        with patch.dict(_TEXT_DISPATCH, {API_GEMINI: MagicMock(side_effect=Exception("boom"))}):
+            result = is_text_positive("some text")
+        self.assertFalse(result)
+        self.assertFalse(result.appealable)
 
     # ------------------------------------------------------------------ #
     # Image classifier – testing mode                                      #
@@ -171,14 +281,14 @@ class TestClassifiers(PositiveOnlySocialTestCase):
 
     @patch.dict(os.environ, {"GEMINI_API_KEY": "fake_key", **_AWS_KEYS}, clear=True)
     @patch("user_system.classifiers.image_classifier.boto3")
-    def test_image_classifier_single_gemini_positive(self, mock_boto3):
+    def test_image_classifier_single_gemini_allow_zone(self, mock_boto3):
         mock_s3 = MagicMock()
         mock_boto3.client.return_value = mock_s3
         mock_body = MagicMock()
         mock_body.read.return_value = _make_fake_image_bytes()
         mock_s3.get_object.return_value = {'Body': mock_body}
 
-        mock_gemini = MagicMock(return_value=True)
+        mock_gemini = MagicMock(return_value=ALLOW_SCORE)
         with patch.dict(_IMAGE_DISPATCH, {API_GEMINI: mock_gemini}):
             self.assertTrue(is_image_positive("some_image.png"))
         mock_s3.get_object.assert_called_with(Bucket="fake_bucket", Key="some_image.png")
@@ -186,86 +296,101 @@ class TestClassifiers(PositiveOnlySocialTestCase):
 
     @patch.dict(os.environ, {"GEMINI_API_KEY": "fake_key", **_AWS_KEYS}, clear=True)
     @patch("user_system.classifiers.image_classifier.boto3")
-    def test_image_classifier_single_gemini_negative(self, mock_boto3):
+    def test_image_classifier_single_gemini_reject_zone(self, mock_boto3):
         mock_s3 = MagicMock()
         mock_boto3.client.return_value = mock_s3
         mock_body = MagicMock()
         mock_body.read.return_value = _make_fake_image_bytes()
         mock_s3.get_object.return_value = {'Body': mock_body}
 
-        with patch.dict(_IMAGE_DISPATCH, {API_GEMINI: MagicMock(return_value=False)}):
-            self.assertFalse(is_image_positive("some_image.png"))
+        with patch.dict(_IMAGE_DISPATCH, {API_GEMINI: MagicMock(return_value=REJECT_SCORE)}):
+            result = is_image_positive("some_image.png")
+        self.assertFalse(result)
+        self.assertFalse(result.appealable)
+
+    @patch.dict(os.environ, {"GEMINI_API_KEY": "fake_key", **_AWS_KEYS}, clear=True)
+    @patch("user_system.classifiers.image_classifier.boto3")
+    def test_image_classifier_single_gemini_middle_zone_appealable(self, mock_boto3):
+        mock_s3 = MagicMock()
+        mock_boto3.client.return_value = mock_s3
+        mock_body = MagicMock()
+        mock_body.read.return_value = _make_fake_image_bytes()
+        mock_s3.get_object.return_value = {'Body': mock_body}
+
+        with patch.dict(_IMAGE_DISPATCH, {API_GEMINI: MagicMock(return_value=MIDDLE_SCORE)}):
+            result = is_image_positive("some_image.png")
+        self.assertFalse(result)
+        self.assertTrue(result.appealable)
 
     @patch.dict(os.environ, {"ANTHROPIC_API_KEY": "fake_key", **_AWS_KEYS}, clear=True)
     @patch("user_system.classifiers.image_classifier.boto3")
-    def test_image_classifier_single_claude_positive(self, mock_boto3):
+    def test_image_classifier_single_claude_allow_zone(self, mock_boto3):
         mock_s3 = MagicMock()
         mock_boto3.client.return_value = mock_s3
         mock_body = MagicMock()
         mock_body.read.return_value = _make_fake_image_bytes()
         mock_s3.get_object.return_value = {'Body': mock_body}
 
-        mock_claude = MagicMock(return_value=True)
+        mock_claude = MagicMock(return_value=ALLOW_SCORE)
         with patch.dict(_IMAGE_DISPATCH, {API_CLAUDE: mock_claude}):
             self.assertTrue(is_image_positive("some_image.png"))
         mock_claude.assert_called_once()
 
     @patch.dict(os.environ, {"OPENAI_API_KEY": "fake_key", **_AWS_KEYS}, clear=True)
     @patch("user_system.classifiers.image_classifier.boto3")
-    def test_image_classifier_single_openai_positive(self, mock_boto3):
+    def test_image_classifier_single_openai_allow_zone(self, mock_boto3):
         mock_s3 = MagicMock()
         mock_boto3.client.return_value = mock_s3
         mock_body = MagicMock()
         mock_body.read.return_value = _make_fake_image_bytes()
         mock_s3.get_object.return_value = {'Body': mock_body}
 
-        mock_openai = MagicMock(return_value=True)
+        mock_openai = MagicMock(return_value=ALLOW_SCORE)
         with patch.dict(_IMAGE_DISPATCH, {API_OPENAI: mock_openai}):
             self.assertTrue(is_image_positive("some_image.png"))
         mock_openai.assert_called_once()
 
     # ------------------------------------------------------------------ #
-    # Image classifier – voting: two agree                                 #
+    # Image classifier – cascade                                           #
     # ------------------------------------------------------------------ #
 
     @patch.dict(os.environ, {**_ALL_AI_KEYS, **_AWS_KEYS}, clear=True)
     @patch("user_system.classifiers.classifier_utils.random")
     @patch("user_system.classifiers.image_classifier.boto3")
-    def test_image_voting_two_agree_true(self, mock_boto3, mock_random):
-        mock_random.sample.return_value = [API_GEMINI, API_CLAUDE]
+    def test_image_cascade_first_allows_no_escalation(self, mock_boto3, mock_random):
+        mock_random.sample.return_value = [API_GEMINI, API_CLAUDE, API_OPENAI]
         mock_s3 = MagicMock()
         mock_boto3.client.return_value = mock_s3
         mock_body = MagicMock()
         mock_body.read.return_value = _make_fake_image_bytes()
         mock_s3.get_object.return_value = {'Body': mock_body}
 
-        mock_gemini = MagicMock(return_value=True)
-        mock_claude = MagicMock(return_value=True)
-        mock_openai = MagicMock(return_value=True)
+        mock_gemini = MagicMock(return_value=ALLOW_SCORE)
+        mock_claude = MagicMock(return_value=ALLOW_SCORE)
+        mock_openai = MagicMock(return_value=ALLOW_SCORE)
         with patch.dict(_IMAGE_DISPATCH, {API_GEMINI: mock_gemini, API_CLAUDE: mock_claude, API_OPENAI: mock_openai}):
             self.assertTrue(is_image_positive("img.png"))
+        mock_claude.assert_not_called()
         mock_openai.assert_not_called()
-
-    # ------------------------------------------------------------------ #
-    # Image classifier – voting: disagree with tiebreaker                  #
-    # ------------------------------------------------------------------ #
 
     @patch.dict(os.environ, {**_ALL_AI_KEYS, **_AWS_KEYS}, clear=True)
     @patch("user_system.classifiers.classifier_utils.random")
     @patch("user_system.classifiers.image_classifier.boto3")
-    def test_image_voting_disagree_tiebreaker_false(self, mock_boto3, mock_random):
-        mock_random.sample.return_value = [API_GEMINI, API_CLAUDE]
+    def test_image_cascade_middle_then_reject_then_reject_not_appealable(self, mock_boto3, mock_random):
+        mock_random.sample.return_value = [API_GEMINI, API_CLAUDE, API_OPENAI]
         mock_s3 = MagicMock()
         mock_boto3.client.return_value = mock_s3
         mock_body = MagicMock()
         mock_body.read.return_value = _make_fake_image_bytes()
         mock_s3.get_object.return_value = {'Body': mock_body}
 
-        mock_gemini = MagicMock(return_value=True)
-        mock_claude = MagicMock(return_value=False)
-        mock_openai = MagicMock(return_value=False)
+        mock_gemini = MagicMock(return_value=MIDDLE_SCORE)
+        mock_claude = MagicMock(return_value=REJECT_SCORE)
+        mock_openai = MagicMock(return_value=REJECT_SCORE)
         with patch.dict(_IMAGE_DISPATCH, {API_GEMINI: mock_gemini, API_CLAUDE: mock_claude, API_OPENAI: mock_openai}):
-            self.assertFalse(is_image_positive("img.png"))
+            result = is_image_positive("img.png")
+        self.assertFalse(result)
+        self.assertFalse(result.appealable)
         mock_openai.assert_called_once()
 
     # ------------------------------------------------------------------ #
@@ -286,7 +411,7 @@ class TestClassifiers(PositiveOnlySocialTestCase):
         """When AWS_STORAGE_BUCKET_NAME is set, virtual-hosted URL key is still extracted from path."""
         mock_s3 = self._make_mock_s3(mock_boto3)
         url = "https://goodvibesonly-images.s3.us-east-2.amazonaws.com/folder/image.jpg"
-        with patch.dict(_IMAGE_DISPATCH, {API_GEMINI: MagicMock(return_value=True)}):
+        with patch.dict(_IMAGE_DISPATCH, {API_GEMINI: MagicMock(return_value=ALLOW_SCORE)}):
             is_image_positive(url)
         mock_s3.get_object.assert_called_with(Bucket="fake_bucket", Key="folder/image.jpg")
 
@@ -296,7 +421,7 @@ class TestClassifiers(PositiveOnlySocialTestCase):
         """When AWS_STORAGE_BUCKET_NAME is unset, bucket is derived from virtual-hosted URL hostname."""
         mock_s3 = self._make_mock_s3(mock_boto3)
         url = "https://goodvibesonly-images.s3.us-east-2.amazonaws.com/folder/image.jpg"
-        with patch.dict(_IMAGE_DISPATCH, {API_GEMINI: MagicMock(return_value=True)}):
+        with patch.dict(_IMAGE_DISPATCH, {API_GEMINI: MagicMock(return_value=ALLOW_SCORE)}):
             is_image_positive(url)
         mock_s3.get_object.assert_called_with(Bucket="goodvibesonly-images", Key="folder/image.jpg")
 
@@ -306,7 +431,7 @@ class TestClassifiers(PositiveOnlySocialTestCase):
         """Path-style URL (s3.amazonaws.com/bucket/key) correctly splits bucket and key."""
         mock_s3 = self._make_mock_s3(mock_boto3)
         url = "https://s3.amazonaws.com/mybucket/path/to/image.jpg"
-        with patch.dict(_IMAGE_DISPATCH, {API_GEMINI: MagicMock(return_value=True)}):
+        with patch.dict(_IMAGE_DISPATCH, {API_GEMINI: MagicMock(return_value=ALLOW_SCORE)}):
             is_image_positive(url)
         mock_s3.get_object.assert_called_with(Bucket="mybucket", Key="path/to/image.jpg")
 
@@ -316,7 +441,7 @@ class TestClassifiers(PositiveOnlySocialTestCase):
         """Dashed-region path-style URL (s3-region.amazonaws.com/bucket/key) is not misread as virtual-hosted."""
         mock_s3 = self._make_mock_s3(mock_boto3)
         url = "https://s3-us-west-2.amazonaws.com/mybucket/path/to/image.jpg"
-        with patch.dict(_IMAGE_DISPATCH, {API_GEMINI: MagicMock(return_value=True)}):
+        with patch.dict(_IMAGE_DISPATCH, {API_GEMINI: MagicMock(return_value=ALLOW_SCORE)}):
             is_image_positive(url)
         mock_s3.get_object.assert_called_with(Bucket="mybucket", Key="path/to/image.jpg")
 
@@ -330,6 +455,7 @@ class TestClassifiers(PositiveOnlySocialTestCase):
             "sexually suggestive content",
             "misinformation",
             "begins sad but ends on a happy or hopeful note",
+            "between 0.00 and 1.00",
         ]:
             self.assertIn(phrase, TEXT_CLASSIFIER_PROMPT, msg=f"Missing in TEXT_CLASSIFIER_PROMPT: {phrase!r}")
 
@@ -339,5 +465,6 @@ class TestClassifiers(PositiveOnlySocialTestCase):
             "sexually suggestive content",
             "misinformation",
             "begins sad but ends on a happy or hopeful note",
+            "between 0.00 and 1.00",
         ]:
             self.assertIn(phrase, IMAGE_CLASSIFIER_PROMPT, msg=f"Missing in IMAGE_CLASSIFIER_PROMPT: {phrase!r}")

--- a/backend/user_system/tests/test_classifiers.py
+++ b/backend/user_system/tests/test_classifiers.py
@@ -54,6 +54,14 @@ class TestClassifiers(PositiveOnlySocialTestCase):
         self.assertEqual(parse_probability("Probability: 0.4"), 0.4)
         self.assertEqual(parse_probability(".75"), 0.75)
 
+    def test_parse_probability_ignores_echoed_range(self):
+        # Models sometimes echo the prompt's "between 0.00 and 1.00" bounds
+        # before answering; the answer (last in-range number) must win.
+        self.assertEqual(parse_probability("On a scale between 0.00 and 1.00, I would say 0.85"), 0.85)
+        self.assertEqual(parse_probability("between 0.00 and 1.00: 0.4"), 0.4)
+        # Out-of-range numbers are ignored in favor of an in-range answer.
+        self.assertEqual(parse_probability("I rate it 0.9 (not 100)"), 0.9)
+
     def test_parse_probability_invalid(self):
         self.assertIsNone(parse_probability("yes"))
         self.assertIsNone(parse_probability(""))


### PR DESCRIPTION
Closes #191.

Sentiment classification now uses a probability instead of a Boolean. Each AI is prompted for a probability (0.00–1.00) that the post caption / comment / username / image is acceptable, and decisions follow three zones:

- **≤ 0.3 (reject zone):** rejected outright, **not appealable** (appeal system is future work)
- **≥ 0.7 (allow zone):** always allowed
- **strictly between (middle zone):** escalate to another AI

### Cascade / tie-breaking rules
1. First AI in the allow zone → allowed; reject zone → rejected, no appeal; middle zone → ask a second AI (if available).
2. Second AI in the allow zone → allowed. Middle or reject zone → ask a third AI (if available).
3. Third AI: allow → allowed; middle → rejected but appealable; reject → rejected, no appeal.
4. If the cascade needs another AI and none is available, the content is rejected — appealable only if the last score was in the middle zone.

AIs are consulted in random order; an AI that errors or returns an unparseable score is skipped as if unavailable. With no usable scores at all, content is rejected without appeal (matches the old no-API behavior).

### Implementation notes
- `is_text_positive` / `is_image_positive` now return a `ClassificationResult` dataclass (`allowed`, `appealable`, `scores`). It is truthy when allowed, so all view call sites are unchanged; `appealable` is carried for the future appeal system.
- The spec leaves 0.3–0.4 and 0.6–0.7 undefined; zones are implemented as ≤ 0.3 / strictly between / ≥ 0.7, so those gaps fall in the middle zone.
- Prompts keep the same content rules but now ask for a number; parsing rejects out-of-range responses (e.g. "100") rather than guessing.

### Testing
- `python manage.py test user_system.tests` — 231 tests pass (classifier tests rewritten for the cascade: zone boundaries, escalation order, appealability, error-skipping, probability parsing).
- `pytest tests` — 19 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)