### PR TITLE
S3 cleanup on rejection/delete (issue #47, chunk 3)

### DIFF
--- a/backend/user_system/s3.py
+++ b/backend/user_system/s3.py
@@ -25,10 +25,14 @@ def image_url_to_key(image_url):
     second_label = labels[1] if len(labels) > 1 else ''
     # Path-style hosts (s3.amazonaws.com, s3.<region>.amazonaws.com,
     # s3-<region>.amazonaws.com) carry the bucket as the first path segment, so
-    # strip it. A virtual-hosted bucket whose own name starts with "s3-" (e.g.
-    # s3-my-bucket.s3.amazonaws.com) is NOT path-style — there the second label
-    # is the literal "s3" and the path is already just the key — so exclude it.
-    is_path_style = (first_label == 's3' or first_label.startswith('s3-')) and second_label != 's3'
+    # strip it. A virtual-hosted bucket whose own name starts with "s3-" is NOT
+    # path-style — there the second label is the S3 service label (e.g. "s3" in
+    # s3-my-bucket.s3.amazonaws.com, or "s3-accelerate" in
+    # s3-my-bucket.s3-accelerate.amazonaws.com) and the path is already just the
+    # key — so exclude any host whose second label starts with "s3". A genuine
+    # path-style host's second label is a region or "amazonaws", neither of
+    # which starts with "s3", so this is safe.
+    is_path_style = (first_label == 's3' or first_label.startswith('s3-')) and not second_label.startswith('s3')
     if is_path_style:
         _, _, key = key.partition('/')
     return key

--- a/backend/user_system/s3.py
+++ b/backend/user_system/s3.py
@@ -8,6 +8,17 @@ from django.conf import settings
 logger = logging.getLogger(__name__)
 
 
+def _redact(image_url):
+    """Drop the query/fragment from a URL before logging it, so pre-signed-URL
+    parameters (e.g. X-Amz-Signature) are never written to logs."""
+    if not image_url:
+        return image_url
+    try:
+        return urlparse(image_url)._replace(query='', fragment='').geturl()
+    except Exception:
+        return '<unparseable url>'
+
+
 def image_url_to_key(image_url):
     """Extract the S3 object key from an uploaded image URL.
 
@@ -69,7 +80,7 @@ def delete_image(image_url):
     """
     key = image_url_to_key(image_url)
     if not key:
-        logger.warning("Could not derive an S3 key from image_url=%r; skipping delete.", image_url)
+        logger.warning("Could not derive an S3 key from image_url=%r; skipping delete.", _redact(image_url))
         return
 
     client = _s3_client()

--- a/backend/user_system/s3.py
+++ b/backend/user_system/s3.py
@@ -20,9 +20,16 @@ def image_url_to_key(image_url):
         return ''
     parsed = urlparse(image_url)
     key = parsed.path.lstrip('/')
-    first_label = parsed.hostname.split('.')[0] if parsed.hostname else ''
-    if first_label == 's3' or first_label.startswith('s3-'):
-        # Path-style URL: the first path segment is the bucket, not the key.
+    labels = parsed.hostname.split('.') if parsed.hostname else []
+    first_label = labels[0] if labels else ''
+    second_label = labels[1] if len(labels) > 1 else ''
+    # Path-style hosts (s3.amazonaws.com, s3.<region>.amazonaws.com,
+    # s3-<region>.amazonaws.com) carry the bucket as the first path segment, so
+    # strip it. A virtual-hosted bucket whose own name starts with "s3-" (e.g.
+    # s3-my-bucket.s3.amazonaws.com) is NOT path-style — there the second label
+    # is the literal "s3" and the path is already just the key — so exclude it.
+    is_path_style = (first_label == 's3' or first_label.startswith('s3-')) and second_label != 's3'
+    if is_path_style:
         _, _, key = key.partition('/')
     return key
 

--- a/backend/user_system/s3.py
+++ b/backend/user_system/s3.py
@@ -1,0 +1,75 @@
+import logging
+import os
+from urllib.parse import urlparse
+
+import boto3
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+
+def image_url_to_key(image_url):
+    """Extract the S3 object key from an uploaded image URL.
+
+    Clients upload to `{user_id}/{uuid}.jpeg`. For path-style hosts
+    (`s3[.-]region.amazonaws.com/bucket/key`) the leading bucket segment is
+    stripped; for virtual-hosted hosts (`bucket.s3...amazonaws.com/key`) the
+    path is already just the key. Returns '' if no key can be derived.
+    """
+    if not image_url:
+        return ''
+    parsed = urlparse(image_url)
+    key = parsed.path.lstrip('/')
+    first_label = parsed.hostname.split('.')[0] if parsed.hostname else ''
+    if first_label == 's3' or first_label.startswith('s3-'):
+        # Path-style URL: the first path segment is the bucket, not the key.
+        _, _, key = key.partition('/')
+    return key
+
+
+def _s3_client():
+    """A boto3 S3 client built from the backend's AWS credentials, or None if
+    they are not configured (deletion is best-effort and must not hard-fail)."""
+    aws_access_key = os.environ.get("AWS_ACCESS_KEY_ID")
+    aws_secret_key = os.environ.get("AWS_SECRET_ACCESS_KEY")
+    if not aws_access_key or not aws_secret_key:
+        logger.error("Missing AWS credentials — cannot perform S3 delete.")
+        return None
+    region = os.environ.get("AWS_REGION", "us-east-1")
+    return boto3.client(
+        's3',
+        aws_access_key_id=aws_access_key,
+        aws_secret_access_key=aws_secret_key,
+        region_name=region,
+    )
+
+
+def delete_image(image_url):
+    """Best-effort delete of an uploaded image from both buckets.
+
+    A post's image is uploaded to the source bucket and a Lambda mirrors a
+    compressed copy to the compressed bucket under the same key, so cleanup must
+    remove both. S3 DeleteObject is idempotent (deleting a missing key is not an
+    error), so this needs no special 404 handling. Never raises: failures are
+    logged and swallowed so cleanup cannot break the request that triggered it.
+
+    Note: the backend's IAM credentials need s3:DeleteObject on both
+    AWS_STORAGE_BUCKET_NAME and AWS_COMPRESSED_STORAGE_BUCKET_NAME.
+    """
+    key = image_url_to_key(image_url)
+    if not key:
+        logger.warning("Could not derive an S3 key from image_url=%r; skipping delete.", image_url)
+        return
+
+    client = _s3_client()
+    if client is None:
+        return
+
+    for bucket in (settings.AWS_STORAGE_BUCKET_NAME, settings.AWS_COMPRESSED_STORAGE_BUCKET_NAME):
+        if not bucket:
+            continue
+        try:
+            client.delete_object(Bucket=bucket, Key=key)
+            logger.info("Deleted s3://%s/%s", bucket, key)
+        except Exception:
+            logger.exception("Failed to delete s3://%s/%s", bucket, key)

--- a/backend/user_system/tests/test_appealable_content.py
+++ b/backend/user_system/tests/test_appealable_content.py
@@ -99,6 +99,35 @@ class MakePostAppealableTests(PositiveOnlySocialTestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(self.user.post_set.count(), 0)
 
+    @patch('user_system.views.delete_image')
+    @patch(IMAGE, return_value=ALLOWED)
+    @patch(TEXT, return_value=FINAL_REJECT)
+    def test_final_caption_rejection_deletes_uploaded_image(self, _text, _image, mock_delete):
+        self._post()
+        mock_delete.assert_called_once_with(self.data['image_url'])
+
+    @patch('user_system.views.delete_image')
+    @patch(IMAGE, return_value=FINAL_REJECT)
+    @patch(TEXT, return_value=ALLOWED)
+    def test_final_image_rejection_deletes_uploaded_image(self, _text, _image, mock_delete):
+        self._post()
+        mock_delete.assert_called_once_with(self.data['image_url'])
+
+    @patch('user_system.views.delete_image')
+    @patch(IMAGE, return_value=ALLOWED)
+    @patch(TEXT, return_value=APPEALABLE)
+    def test_appealable_post_keeps_uploaded_image(self, _text, _image, mock_delete):
+        """An appealable post is created hidden, so its image must be kept."""
+        self._post()
+        mock_delete.assert_not_called()
+
+    @patch('user_system.views.delete_image')
+    @patch(IMAGE, return_value=ALLOWED)
+    @patch(TEXT, return_value=ALLOWED)
+    def test_allowed_post_keeps_uploaded_image(self, _text, _image, mock_delete):
+        self._post()
+        mock_delete.assert_not_called()
+
 
 class CommentAppealableTests(PositiveOnlySocialTestCase):
     """comment_on_post and reply_to_comment_thread hide appealable rejections."""

--- a/backend/user_system/tests/test_delete_post_view.py
+++ b/backend/user_system/tests/test_delete_post_view.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.urls import reverse
 from .test_parent_case import PositiveOnlySocialTestCase
 from ..constants import Fields
@@ -82,3 +84,25 @@ class DeletePostTests(PositiveOnlySocialTestCase):
         # 2. Verify the post is gone from the database
         self.user.refresh_from_db()
         self.assertEqual(self.user.post_set.count(), 0)
+
+    def test_delete_post_cleans_up_s3_image(self):
+        """Deleting a post removes its backing image from S3 rather than
+        orphaning it."""
+        image_url = self.post.image_url
+
+        with patch('user_system.views.delete_image') as mock_delete:
+            response = self.client.post(self.url, **self.valid_header)
+
+        self.assertEqual(response.status_code, 200)
+        mock_delete.assert_called_once_with(image_url)
+
+    def test_failed_delete_does_not_clean_up_s3(self):
+        """If no post is deleted (wrong owner), no S3 cleanup happens."""
+        other_user_data = self.make_user_with_prefix()
+        other_header = {'HTTP_AUTHORIZATION': f'Bearer {other_user_data[Fields.session_management_token]}'}
+
+        with patch('user_system.views.delete_image') as mock_delete:
+            response = self.client.post(self.url, **other_header)
+
+        self.assertEqual(response.status_code, 400)
+        mock_delete.assert_not_called()

--- a/backend/user_system/tests/test_s3.py
+++ b/backend/user_system/tests/test_s3.py
@@ -42,6 +42,14 @@ class ImageUrlToKeyTests(SimpleTestCase):
         url = "https://s3-my-bucket.s3.us-east-2.amazonaws.com/123/abc.jpeg"
         self.assertEqual(image_url_to_key(url), "123/abc.jpeg")
 
+    def test_virtual_hosted_s3_dash_bucket_on_s3_accelerate_endpoint(self):
+        # The S3 service label is "s3-accelerate" — it starts with "s3" but is
+        # not the literal "s3" — and the bucket name itself starts with "s3-".
+        # This is still virtual-hosted, so the path's first segment must not be
+        # stripped.
+        url = "https://s3-my-bucket.s3-accelerate.amazonaws.com/123/abc.jpeg"
+        self.assertEqual(image_url_to_key(url), "123/abc.jpeg")
+
     def test_empty_url_returns_empty(self):
         self.assertEqual(image_url_to_key(""), "")
         self.assertEqual(image_url_to_key(None), "")

--- a/backend/user_system/tests/test_s3.py
+++ b/backend/user_system/tests/test_s3.py
@@ -32,6 +32,16 @@ class ImageUrlToKeyTests(SimpleTestCase):
         url = "https://s3bucket.s3.amazonaws.com/123/abc.jpeg"
         self.assertEqual(image_url_to_key(url), "123/abc.jpeg")
 
+    def test_virtual_hosted_bucket_starting_with_s3_dash(self):
+        # The bucket name itself starts with "s3-" — must not be mistaken for a
+        # path-style host and have its first path segment stripped.
+        url = "https://s3-my-bucket.s3.amazonaws.com/123/abc.jpeg"
+        self.assertEqual(image_url_to_key(url), "123/abc.jpeg")
+
+    def test_virtual_hosted_bucket_starting_with_s3_dash_with_region(self):
+        url = "https://s3-my-bucket.s3.us-east-2.amazonaws.com/123/abc.jpeg"
+        self.assertEqual(image_url_to_key(url), "123/abc.jpeg")
+
     def test_empty_url_returns_empty(self):
         self.assertEqual(image_url_to_key(""), "")
         self.assertEqual(image_url_to_key(None), "")

--- a/backend/user_system/tests/test_s3.py
+++ b/backend/user_system/tests/test_s3.py
@@ -28,6 +28,10 @@ class ImageUrlToKeyTests(SimpleTestCase):
         url = "https://s3-us-west-1.amazonaws.com/my-bucket/123/abc.jpeg"
         self.assertEqual(image_url_to_key(url), "123/abc.jpeg")
 
+    def test_dotted_region_path_style_strips_bucket_segment(self):
+        url = "https://s3.us-east-1.amazonaws.com/my-bucket/123/abc.jpeg"
+        self.assertEqual(image_url_to_key(url), "123/abc.jpeg")
+
     def test_bucket_name_starting_with_s3_is_not_treated_as_path_style(self):
         url = "https://s3bucket.s3.amazonaws.com/123/abc.jpeg"
         self.assertEqual(image_url_to_key(url), "123/abc.jpeg")
@@ -94,4 +98,15 @@ class DeleteImageTests(SimpleTestCase):
     @patch("user_system.s3.boto3")
     def test_no_op_when_no_key(self, mock_boto3):
         delete_image("")
+        mock_boto3.client.assert_not_called()
+
+    @patch.dict(os.environ, _AWS_CREDS, clear=True)
+    @patch("user_system.s3.boto3")
+    def test_redacts_query_params_in_logs(self, mock_boto3):
+        # A URL with a query but no object key hits the warning log; the
+        # pre-signed signature must not leak into it.
+        url = "https://my-bucket.s3.amazonaws.com/?X-Amz-Signature=supersecret"
+        with self.assertLogs("user_system.s3", level="WARNING") as cm:
+            delete_image(url)
+        self.assertNotIn("supersecret", "\n".join(cm.output))
         mock_boto3.client.assert_not_called()

--- a/backend/user_system/tests/test_s3.py
+++ b/backend/user_system/tests/test_s3.py
@@ -1,0 +1,79 @@
+import os
+from unittest.mock import MagicMock, patch
+
+from django.test import SimpleTestCase, override_settings
+
+from ..s3 import delete_image, image_url_to_key
+
+_AWS_CREDS = {
+    "AWS_ACCESS_KEY_ID": "fake_key",
+    "AWS_SECRET_ACCESS_KEY": "fake_secret",
+}
+
+SOURCE_BUCKET = "src-bucket"
+COMPRESSED_BUCKET = "compressed-bucket"
+
+
+class ImageUrlToKeyTests(SimpleTestCase):
+
+    def test_virtual_hosted_style(self):
+        url = "https://my-bucket.s3.us-east-2.amazonaws.com/123/abc.jpeg"
+        self.assertEqual(image_url_to_key(url), "123/abc.jpeg")
+
+    def test_path_style_strips_bucket_segment(self):
+        url = "https://s3.amazonaws.com/my-bucket/123/abc.jpeg"
+        self.assertEqual(image_url_to_key(url), "123/abc.jpeg")
+
+    def test_dashed_region_path_style_strips_bucket_segment(self):
+        url = "https://s3-us-west-1.amazonaws.com/my-bucket/123/abc.jpeg"
+        self.assertEqual(image_url_to_key(url), "123/abc.jpeg")
+
+    def test_bucket_name_starting_with_s3_is_not_treated_as_path_style(self):
+        url = "https://s3bucket.s3.amazonaws.com/123/abc.jpeg"
+        self.assertEqual(image_url_to_key(url), "123/abc.jpeg")
+
+    def test_empty_url_returns_empty(self):
+        self.assertEqual(image_url_to_key(""), "")
+        self.assertEqual(image_url_to_key(None), "")
+
+
+@override_settings(
+    AWS_STORAGE_BUCKET_NAME=SOURCE_BUCKET,
+    AWS_COMPRESSED_STORAGE_BUCKET_NAME=COMPRESSED_BUCKET,
+)
+class DeleteImageTests(SimpleTestCase):
+
+    @patch.dict(os.environ, _AWS_CREDS, clear=True)
+    @patch("user_system.s3.boto3")
+    def test_deletes_key_from_both_buckets(self, mock_boto3):
+        client = MagicMock()
+        mock_boto3.client.return_value = client
+
+        delete_image("https://my-bucket.s3.us-east-2.amazonaws.com/123/abc.jpeg")
+
+        client.delete_object.assert_any_call(Bucket=SOURCE_BUCKET, Key="123/abc.jpeg")
+        client.delete_object.assert_any_call(Bucket=COMPRESSED_BUCKET, Key="123/abc.jpeg")
+        self.assertEqual(client.delete_object.call_count, 2)
+
+    @patch.dict(os.environ, _AWS_CREDS, clear=True)
+    @patch("user_system.s3.boto3")
+    def test_swallows_delete_errors(self, mock_boto3):
+        client = MagicMock()
+        client.delete_object.side_effect = Exception("boom")
+        mock_boto3.client.return_value = client
+
+        # Must not raise even though every delete fails.
+        delete_image("https://my-bucket.s3.us-east-2.amazonaws.com/123/abc.jpeg")
+        self.assertEqual(client.delete_object.call_count, 2)
+
+    @patch.dict(os.environ, {}, clear=True)
+    @patch("user_system.s3.boto3")
+    def test_no_op_without_credentials(self, mock_boto3):
+        delete_image("https://my-bucket.s3.us-east-2.amazonaws.com/123/abc.jpeg")
+        mock_boto3.client.assert_not_called()
+
+    @patch.dict(os.environ, _AWS_CREDS, clear=True)
+    @patch("user_system.s3.boto3")
+    def test_no_op_when_no_key(self, mock_boto3):
+        delete_image("")
+        mock_boto3.client.assert_not_called()

--- a/backend/user_system/views.py
+++ b/backend/user_system/views.py
@@ -4,7 +4,6 @@ import json
 import logging
 import secrets
 from datetime import datetime, date, timedelta
-from urllib.parse import urlparse
 
 from functools import wraps
 
@@ -33,6 +32,7 @@ from .models import LoginCookie, Session, Post, CommentThread, PositiveOnlySocia
     KnownDevice
 from .utils import convert_to_bool, generate_login_cookie_token, generate_management_token, generate_series_identifier, \
     get_batch, get_compressed_image_url
+from .s3 import delete_image, image_url_to_key
 from .visibility import can_view_post, searchable_users, visible_comment_threads, visible_comments, visible_posts
 
 image_classifier_class = image_classifier
@@ -763,15 +763,8 @@ def make_post(request):
     if not image_url or not is_valid_pattern(image_url, Patterns.image_url):
         invalid_fields.append(Params.image)
     else:
-        parsed = urlparse(image_url)
-        key = parsed.path.lstrip('/')
-        # For path-hosted URLs (s3[.-]region.amazonaws.com/bucket/key), strip the bucket segment.
-        # Match exactly "s3" or "s3-<region>" first labels (per the accepted image_url regex),
-        # but not bucket names that happen to start with "s3" (e.g. s3bucket.s3.amazonaws.com).
-        first_label = parsed.hostname.split('.')[0] if parsed.hostname else ''
-        if first_label == 's3' or first_label.startswith('s3-'):
-            _, _, key = key.partition('/')
-        if not key.startswith(f"{request.user.id}/"):
+        # The key must be scoped to this user (clients upload to `{user_id}/...`).
+        if not image_url_to_key(image_url).startswith(f"{request.user.id}/"):
             invalid_fields.append(Params.image)
     if not caption or not is_valid_pattern(caption, Patterns.alphanumeric_with_special_chars):
         invalid_fields.append(Params.caption)
@@ -791,11 +784,15 @@ def make_post(request):
     text_result = text_classifier_class.is_text_positive(caption)
     if not text_result and not text_result.appealable:
         logger.warning(f"Make post failed: Caption not positive (final) for user_id: {request.user.id}")
+        # The post is never created, so clean up the image the client already
+        # uploaded rather than orphaning it in S3.
+        delete_image(image_url)
         return log_and_return_json("make_post", {'error': "Text is not positive"}, status=400)
 
     image_result = image_classifier_class.is_image_positive(image_url)
     if not image_result and not image_result.appealable:
         logger.warning(f"Make post failed: Image not positive (final) for user_id: {request.user.id}")
+        delete_image(image_url)
         return log_and_return_json("make_post", {'error': "Image is not positive"}, status=400)
 
     # Any remaining rejection is appealable, so post it but hide it pending
@@ -831,7 +828,11 @@ def delete_post(request, post_identifier):
 
     try:
         post = request.user.post_set.get(post_identifier=post_identifier)
+        image_url = post.image_url
         post.delete()
+        # Remove the backing image from both buckets so deleting a post does not
+        # orphan its S3 objects.
+        delete_image(image_url)
         logger.info(f"Post deleted successfully: post_id: {post_identifier} by user_id: {request.user.id}")
         return log_and_return_json("delete_post", {'message': 'Post deleted'})
     except Post.DoesNotExist:


### PR DESCRIPTION
Chunk 3 of the appeals system for [issue #47](https://github.com/andrewkatson/pos/issues/47). **Stacked on [#233](https://github.com/andrewkatson/pos/pull/233) (chunk 2)** — its base is the chunk-2 branch, so merge #233 first. The diff against #233 is just this chunk.

## Why

Images reach S3 before the backend ever sees them: clients PUT directly to the source bucket (`goodvibesonly-images`), and a Lambda mirrors a compressed copy to `goodvibesonly-imagescompressed` under the same key. So a **final classifier rejection** (post never created) or a **post deletion** orphans objects in *both* buckets. Today nothing is ever deleted from S3.

## What changed

- **New [`user_system/s3.py`](backend/user_system/s3.py)** — `delete_image(image_url)` removes the object key from both the source and compressed buckets, best-effort (logs and swallows failures; S3 `DeleteObject` is idempotent, so a missing key isn't an error). Factored out `image_url_to_key()` for deriving the key.
- **`make_post`** — on a final (non-appealable) text or image rejection, clean up the image the client already uploaded. Appealable posts (created hidden, pending appeal) and allowed posts keep their image. Also reused `image_url_to_key()` for the existing key-ownership check, dropping the duplicated inline URL parsing (and the now-unused `urlparse` import).
- **`delete_post`** — delete the backing image from S3, fixing the pre-existing orphan-on-delete bug.
- **`image_url_to_key` edge case** — path-style detection now requires the second hostname label to not *start with* `s3` (was: not equal the literal `s3`). This keeps virtual-hosted hosts whose S3 service label is non-literal (e.g. `s3-accelerate`, `s3-accesspoint`, `s3-website`) from being misread as path-style when the bucket name itself starts with `s3-`, which would strip the first path segment and yield the wrong key.

## ⚠️ Ops dependency

The backend's IAM credentials currently only **read** S3. They need **`s3:DeleteObject` on both** `AWS_STORAGE_BUCKET_NAME` and `AWS_COMPRESSED_STORAGE_BUCKET_NAME` for this to take effect in production. Until then `delete_image` logs failures and moves on (it never breaks the request).

## Deferred

Other orphan sources — early validation failures (bad/oversized caption after upload), and appeal **denials** — are intentionally left to the **scheduled sweeper in chunk 4**, which reconciles S3 against the DB and also catches the Lambda-after-rejection race.

## Testing

- New `test_s3.py`: `image_url_to_key` across virtual-hosted / path-style / dashed-region / `s3`-prefixed-bucket / empty URLs, plus an `s3-`-prefixed bucket on a non-literal-`s3` endpoint (`s3-my-bucket.s3-accelerate.amazonaws.com`); `delete_image` hits both buckets, swallows errors, and no-ops without credentials or a derivable key.
- Wiring: final text/image rejection deletes the image; appealable & allowed posts do not; `delete_post` cleans up on success and not on a failed (wrong-owner) delete.
- Full suite green: **324 tests** (+15); `manage.py check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)