### PR TITLE
Run PR test workflows on any base branch for stacked PRs

### DIFF
--- a/.github/workflows/android-tests.yml
+++ b/.github/workflows/android-tests.yml
@@ -7,7 +7,6 @@ on:
       - 'android/**'
       - '.github/workflows/android-tests.yml'
   pull_request:
-    branches: [ "main" ]
     paths:
       - 'android/**'
       - '.github/workflows/android-tests.yml'

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -7,7 +7,6 @@ on:
       - 'backend/**'
       - '.github/workflows/backend-tests.yml'
   pull_request:
-    branches: [ "main" ]
     paths:
       - 'backend/**'
       - '.github/workflows/backend-tests.yml'

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -6,7 +6,6 @@ on:
       - 'ios/**'
       - '.github/workflows/ios-tests.yml'
   pull_request:
-    branches: [ "main" ]
     paths:
       - 'ios/**'
       - '.github/workflows/ios-tests.yml'

--- a/.github/workflows/website-tests.yml
+++ b/.github/workflows/website-tests.yml
@@ -7,7 +7,6 @@ on:
       - 'website/**'
       - '.github/workflows/website-tests.yml'
   pull_request:
-    branches: [ "main" ]
     paths:
       - 'website/**'
       - '.github/workflows/website-tests.yml'

--- a/ios/Positive Only Social/Positive Only Social/state/AuthenticationManager.swift
+++ b/ios/Positive Only Social/Positive Only Social/state/AuthenticationManager.swift
@@ -26,7 +26,12 @@ final class AuthenticationManager: ObservableObject {
     }
     
     private let keychainHelper: KeychainHelperProtocol
-    
+
+    // The notification center used to observe app-wide events such as
+    // account bans. Injectable so tests can isolate it from the shared
+    // `.default` center and avoid cross-test contamination.
+    private let notificationCenter: NotificationCenter
+
     // A private lock to ensure thread-safe access to the keychain.
     private let lock = NSLock()
     
@@ -42,9 +47,10 @@ final class AuthenticationManager: ObservableObject {
         self.init(shouldAutoLogin: false, keychainHelper: KeychainHelper())
     }
     
-    init(shouldAutoLogin: Bool, keychainHelper: KeychainHelperProtocol) {
+    init(shouldAutoLogin: Bool, keychainHelper: KeychainHelperProtocol, notificationCenter: NotificationCenter = .default) {
         self.keychainHelper = keychainHelper
-        
+        self.notificationCenter = notificationCenter
+
         // Check for a session token when the app starts
         if shouldAutoLogin {
             checkInitialState()
@@ -56,7 +62,7 @@ final class AuthenticationManager: ObservableObject {
         // A banned account has its sessions revoked server-side; when the API
         // layer sees the account_banned rejection, drop the local session so
         // the user lands back on the welcome screen.
-        NotificationCenter.default.publisher(for: .accountBanned)
+        notificationCenter.publisher(for: .accountBanned)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in self?.logout() }
             .store(in: &cancellables)

--- a/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_AuthenticationManager.swift
+++ b/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_AuthenticationManager.swift
@@ -22,11 +22,16 @@ struct Positive_Only_SocialTests_AuthenticationManager {
     
     // A helper to access the keychain for setup/teardown
     private let keychain : KeychainHelperProtocol!
-    
+
+    // An isolated notification center so the `.accountBanned` post in
+    // testAccountBannedNotification_LogsOut cannot reach managers created by
+    // other tests running in parallel (which would call an extra logout()).
+    private let notificationCenter = NotificationCenter()
+
     // --- Test setup ---
     init() {
         keychain = KeychainHelper()
-        
+
         try? keychain.delete(service: keychainService, account: userSessionAccount)
     }
     
@@ -36,7 +41,7 @@ struct Positive_Only_SocialTests_AuthenticationManager {
         // Given: The keychain is empty (guaranteed by our init() setup)
         
         // When: The AuthenticationManager is initialized
-        sut = AuthenticationManager(shouldAutoLogin: true, keychainHelper: keychain)
+        sut = AuthenticationManager(shouldAutoLogin: true, keychainHelper: keychain, notificationCenter: notificationCenter)
         
         // Then: The user should be logged out
         #expect(sut.isLoggedIn == false, "isLoggedIn should be false when no token exists")
@@ -55,7 +60,7 @@ struct Positive_Only_SocialTests_AuthenticationManager {
         try keychain.save(userSession, for: keychainService, account: userSessionAccount)
         
         // When: The AuthenticationManager is initialized
-        sut = AuthenticationManager(shouldAutoLogin: true, keychainHelper: keychain)
+        sut = AuthenticationManager(shouldAutoLogin: true, keychainHelper: keychain, notificationCenter: notificationCenter)
         
         // Then: The user should be logged in
         #expect(sut.isLoggedIn == true, "isLoggedIn should be true when a token exists")
@@ -67,7 +72,7 @@ struct Positive_Only_SocialTests_AuthenticationManager {
 
     @Test mutating func testLogin_SetsIsLoggedInToTrue() async throws {
         // Given: The SUT is initialized in a logged-out state
-        sut = AuthenticationManager(shouldAutoLogin: true, keychainHelper: keychain)
+        sut = AuthenticationManager(shouldAutoLogin: true, keychainHelper: keychain, notificationCenter: notificationCenter)
         #expect(sut.isLoggedIn == false) // Verify initial state
 
         // When: login() is called
@@ -95,7 +100,7 @@ struct Positive_Only_SocialTests_AuthenticationManager {
         let testUsername = "username"
         let userSession = UserSession(sessionToken: token, username: testUsername, userId: "1", isIdentityVerified: false)
         try keychain.save(userSession, for: keychainService, account: userSessionAccount)
-        sut = AuthenticationManager(shouldAutoLogin: true, keychainHelper: keychain)
+        sut = AuthenticationManager(shouldAutoLogin: true, keychainHelper: keychain, notificationCenter: notificationCenter)
         
         // Wait to login
         try await Task.sleep(for: .seconds(TestConstants.shortTimeout))
@@ -125,12 +130,12 @@ struct Positive_Only_SocialTests_AuthenticationManager {
 
     @Test mutating func testAccountBannedNotification_LogsOut() async throws {
         // Given: A logged-in manager
-        sut = AuthenticationManager(shouldAutoLogin: false, keychainHelper: keychain)
+        sut = AuthenticationManager(shouldAutoLogin: false, keychainHelper: keychain, notificationCenter: notificationCenter)
         sut.login(with: UserSession(sessionToken: "token", username: "banneduser", userId: "user-id", isIdentityVerified: false))
         #expect(sut.isLoggedIn == true)
 
         // When: The API layer reports the account is banned
-        NotificationCenter.default.post(name: .accountBanned, object: nil)
+        notificationCenter.post(name: .accountBanned, object: nil)
         try await Task.sleep(for: .seconds(TestConstants.shortTimeout))
 
         // Then: The session is dropped

--- a/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_SettingsViewModel.swift
+++ b/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_SettingsViewModel.swift
@@ -146,7 +146,7 @@ struct Positive_Only_SocialTests_SettingsViewModel {
         let token = try await setupLoggedInUser(username: "verifyUser")
         let sut = SettingsViewModel(api: stubAPI, keychainHelper: keychainHelper, account: "verifyUser_account")
         let authenticationManager = makeAuthManager()
-        let dateOfBirth = Date() // Today
+        let dateOfBirth = Date.now
         
         // When: Verify Identity is called
         sut.verifyIdentity(authManager: authenticationManager, dateOfBirth: dateOfBirth)

--- a/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_SettingsViewModel.swift
+++ b/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_SettingsViewModel.swift
@@ -15,6 +15,18 @@ struct Positive_Only_SocialTests_SettingsViewModel {
     // --- SUT & Stubs ---
     var stubAPI: StatefulStubbedAPI!
     var keychainHelper: KeychainHelperProtocol!
+
+    // An isolated notification center so a parallel test posting `.accountBanned`
+    // to the shared `.default` center cannot trigger an extra logout() on the
+    // AuthenticationManager instances created here.
+    private let notificationCenter = NotificationCenter()
+
+    /// Builds an AuthenticationManager isolated from the shared notification center.
+    private func makeAuthManager() -> AuthenticationManager {
+        AuthenticationManager(shouldAutoLogin: false,
+                              keychainHelper: keychainHelper,
+                              notificationCenter: notificationCenter)
+    }
     
     // --- Keychain Test Fixtures ---
     
@@ -54,7 +66,7 @@ struct Positive_Only_SocialTests_SettingsViewModel {
         // Given: A logged-in user
         let token = try await setupLoggedInUser(username: "logoutUser")
         let sut = SettingsViewModel(api: stubAPI, keychainHelper: keychainHelper, account: "logoutUser_account")
-        let authenticationManager = AuthenticationManager()
+        let authenticationManager = makeAuthManager()
         
         // When: Logout is called
         sut.logout(authManager: authenticationManager)
@@ -72,7 +84,7 @@ struct Positive_Only_SocialTests_SettingsViewModel {
     @Test func testLogout_NoSessionInKeychain_OnlyCallsAuthManager() async throws {
         // Given: No user is logged in (keychain is empty)
         let sut = SettingsViewModel(api: stubAPI, keychainHelper: keychainHelper, account: "logoutNoSession_account")
-        let authenticationManager = AuthenticationManager()
+        let authenticationManager = makeAuthManager()
         
         // When: Logout is called
         sut.logout(authManager: authenticationManager)
@@ -93,7 +105,7 @@ struct Positive_Only_SocialTests_SettingsViewModel {
         // Given: A logged-in user
         let token = try await setupLoggedInUser(username: "deleteUser")
         let sut = SettingsViewModel(api: stubAPI, keychainHelper: keychainHelper, account: "deleteUser_account")
-        let authenticationManager = AuthenticationManager()
+        let authenticationManager = makeAuthManager()
         
         // When: Delete account is called
         sut.deleteAccount(authManager: authenticationManager)
@@ -113,7 +125,7 @@ struct Positive_Only_SocialTests_SettingsViewModel {
     @Test func testDeleteAccount_NoSessionInKeychain_ShowsError() async throws {
         // Given: No user is logged in (keychain is empty)
         let sut = SettingsViewModel(api: stubAPI, keychainHelper: keychainHelper, account: "deleteAccountNoSession_account")
-        let authenticationManager = AuthenticationManager()
+        let authenticationManager = makeAuthManager()
         
         // When: Delete account is called
         sut.deleteAccount(authManager: authenticationManager)
@@ -133,7 +145,7 @@ struct Positive_Only_SocialTests_SettingsViewModel {
         // Given: A logged-in user
         let token = try await setupLoggedInUser(username: "verifyUser")
         let sut = SettingsViewModel(api: stubAPI, keychainHelper: keychainHelper, account: "verifyUser_account")
-        let authenticationManager = AuthenticationManager()
+        let authenticationManager = makeAuthManager()
         let dateOfBirth = Date() // Today
         
         // When: Verify Identity is called


### PR DESCRIPTION
## Summary

For stacked/chained PRs, only the bottom PR (whose base is `main`) was triggering the test workflows. The `pull_request` triggers had a `branches: [ "main" ]` filter, which matches against the PR's **base branch** — so PRs targeting intermediate branches in a stack never ran CI.

This removes that filter from the `pull_request` trigger in all four test workflows so every PR in a stack runs CI against its actual base. The `paths:` filters still scope which workflows run, and `push` remains gated to `main`.

Also, fix flaky tests on `iOS` uncovered by this change.

## Changes

- `android-tests.yml`, `backend-tests.yml`, `ios-tests.yml`, `website-tests.yml`: drop `branches: [ "main" ]` from `pull_request`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)