### PR TITLE
Web: hidden content & appeals UI (issue #47, chunk 7)

### DIFF
--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -8,6 +8,7 @@ import ResetPasswordPage from './pages/ResetPasswordPage'
 import HomePage from './pages/HomePage'
 import PostDetailPage from './pages/PostDetailPage'
 import ProfilePage from './pages/ProfilePage'
+import AppealsPage from './pages/AppealsPage'
 
 function App() {
   return (
@@ -21,6 +22,7 @@ function App() {
       <Route path="/home" element={<HomePage />} />
       <Route path="/post/:postId" element={<PostDetailPage />} />
       <Route path="/profile/:username" element={<ProfilePage />} />
+      <Route path="/appeals" element={<AppealsPage />} />
     </Routes>
   )
 }

--- a/website/src/api/PositiveOnlySocialAPI.ts
+++ b/website/src/api/PositiveOnlySocialAPI.ts
@@ -11,16 +11,21 @@ import type {
   CreatePostRequest,
   CreatePostResponse,
   FeedPost,
+  HiddenComment,
+  HiddenPost,
   LoginRequest,
   LoginWithRememberMeRequest,
   LoginWithRememberMeResponse,
   MessageResponse,
+  MyAppeal,
   PostDetails,
   ProfileDetails,
   RegisterRequest,
   ReplyResponse,
   RequestResetRequest,
   ResetPasswordRequest,
+  SubmitAppealRequest,
+  SubmitAppealResponse,
   UserSearchResult,
   VerifyResetRequest,
   VerifyResetResponse,
@@ -96,4 +101,10 @@ export interface PositiveOnlySocialAPI {
   unfollowUser(username: string): Promise<MessageResponse>
   toggleBlock(username: string): Promise<MessageResponse>
   getProfile(username: string): Promise<ProfileDetails>
+
+  // Appeals
+  getHiddenPosts(batch: number): Promise<HiddenPost[]>
+  getHiddenComments(batch: number): Promise<HiddenComment[]>
+  getMyAppeals(batch: number): Promise<MyAppeal[]>
+  submitAppeal(body: SubmitAppealRequest): Promise<SubmitAppealResponse>
 }

--- a/website/src/api/StatefulStubbedAPI.test.ts
+++ b/website/src/api/StatefulStubbedAPI.test.ts
@@ -198,3 +198,79 @@ test('password reset flow updates the password', async () => {
   })
   expect(login.username).toBe('ada')
 })
+
+// --- Appeals -----------------------------------------------------------------
+
+async function makeReportHiddenPost(api: StatefulStubbedAPI) {
+  await register(api, 'author')
+  const post = await api.createPost({
+    image_url: 'https://example.com/a.jpg',
+    caption: 'flagged caption',
+  })
+  // Report past the stub hide threshold (one report per distinct user).
+  for (let i = 0; i < 6; i += 1) {
+    await register(api, `reporter${i}`)
+    await api.reportPost(post.post_identifier, 'bad')
+  }
+  await api.login({ username_or_email: 'author', password: 'password123' })
+  return post
+}
+
+test('getHiddenPosts is empty when nothing is hidden', async () => {
+  const api = new StatefulStubbedAPI()
+  await register(api, 'author')
+  await api.createPost({ image_url: 'https://example.com/a.jpg', caption: 'fine' })
+
+  expect(await api.getHiddenPosts(0)).toEqual([])
+})
+
+test('a report-hidden post appears in getHiddenPosts with its reason', async () => {
+  const api = new StatefulStubbedAPI()
+  const post = await makeReportHiddenPost(api)
+
+  const hidden = await api.getHiddenPosts(0)
+  expect(hidden).toHaveLength(1)
+  expect(hidden[0].post_identifier).toBe(post.post_identifier)
+  expect(hidden[0].hidden_reason).toBe('reports')
+  expect(hidden[0].has_appeal).toBe(false)
+})
+
+test('appealing a hidden post records a pending appeal and flips has_appeal', async () => {
+  const api = new StatefulStubbedAPI()
+  const post = await makeReportHiddenPost(api)
+
+  const result = await api.submitAppeal({
+    target_type: 'post',
+    target_identifier: post.post_identifier,
+    reason: 'please reconsider',
+  })
+  expect(result.appeal_identifier).toBeTruthy()
+
+  const appeals = await api.getMyAppeals(0)
+  expect(appeals).toHaveLength(1)
+  expect(appeals[0].status).toBe('pending')
+  expect(appeals[0].reason).toBe('please reconsider')
+
+  const hidden = await api.getHiddenPosts(0)
+  expect(hidden[0].has_appeal).toBe(true)
+})
+
+test('cannot appeal a post that is not hidden', async () => {
+  const api = new StatefulStubbedAPI()
+  await register(api, 'author')
+  const post = await api.createPost({ image_url: 'https://example.com/a.jpg', caption: 'fine' })
+
+  await expect(
+    api.submitAppeal({ target_type: 'post', target_identifier: post.post_identifier, reason: 'x' }),
+  ).rejects.toThrow('No appealable item with that identifier')
+})
+
+test('cannot appeal the same item twice', async () => {
+  const api = new StatefulStubbedAPI()
+  const post = await makeReportHiddenPost(api)
+  await api.submitAppeal({ target_type: 'post', target_identifier: post.post_identifier, reason: 'a' })
+
+  await expect(
+    api.submitAppeal({ target_type: 'post', target_identifier: post.post_identifier, reason: 'b' }),
+  ).rejects.toThrow('already been appealed')
+})

--- a/website/src/api/StatefulStubbedAPI.test.ts
+++ b/website/src/api/StatefulStubbedAPI.test.ts
@@ -274,3 +274,13 @@ test('cannot appeal the same item twice', async () => {
     api.submitAppeal({ target_type: 'post', target_identifier: post.post_identifier, reason: 'b' }),
   ).rejects.toThrow('already been appealed')
 })
+
+test('rejects an invalid appeal target type', async () => {
+  const api = new StatefulStubbedAPI()
+  await register(api, 'author')
+
+  await expect(
+    // 'ban' is not appealable in-app; cast past the type to exercise the guard.
+    api.submitAppeal({ target_type: 'ban' as never, target_identifier: '1', reason: 'x' }),
+  ).rejects.toThrow('Invalid target_type')
+})

--- a/website/src/api/StatefulStubbedAPI.ts
+++ b/website/src/api/StatefulStubbedAPI.ts
@@ -13,16 +13,21 @@ import type {
   CreatePostRequest,
   CreatePostResponse,
   FeedPost,
+  HiddenComment,
+  HiddenPost,
   LoginRequest,
   LoginWithRememberMeRequest,
   LoginWithRememberMeResponse,
   MessageResponse,
+  MyAppeal,
   PostDetails,
   ProfileDetails,
   RegisterRequest,
   ReplyResponse,
   RequestResetRequest,
   ResetPasswordRequest,
+  SubmitAppealRequest,
+  SubmitAppealResponse,
   UserSearchResult,
   VerifyResetRequest,
   VerifyResetResponse,
@@ -70,6 +75,7 @@ interface PostMock {
   caption: string
   creationTime: number
   hidden: boolean
+  hiddenReason: string
   likes: Set<string>
   reports: Set<string>
 }
@@ -80,8 +86,20 @@ interface CommentMock {
   body: string
   creationTime: number
   hidden: boolean
+  hiddenReason: string
   likes: Set<string>
   reports: Set<string>
+}
+
+interface AppealMock {
+  appealIdentifier: string
+  appellantId: string
+  targetType: 'post' | 'comment'
+  targetId: string
+  reason: string
+  contentSnapshot: string
+  status: 'pending' | 'approved' | 'denied'
+  creationTime: number
 }
 
 interface CommentThreadMock {
@@ -118,6 +136,7 @@ export class StatefulStubbedAPI implements PositiveOnlySocialAPI {
   private loginCookies: LoginCookieMock[] = []
   private posts: PostMock[] = []
   private commentThreads: CommentThreadMock[] = []
+  private appeals: AppealMock[] = []
 
   // Mirrors the "Authorization: Bearer <token>" header.
   private token: string | null = null
@@ -378,6 +397,7 @@ export class StatefulStubbedAPI implements PositiveOnlySocialAPI {
       caption: body.caption,
       creationTime: Date.now(),
       hidden: false,
+      hiddenReason: '',
       likes: new Set(),
       reports: new Set(),
     }
@@ -407,6 +427,7 @@ export class StatefulStubbedAPI implements PositiveOnlySocialAPI {
     post.reports.add(user.id)
     if (post.reports.size > MAX_BEFORE_HIDING_POST) {
       post.hidden = true
+      post.hiddenReason = 'reports'
     }
     return { message: 'Post reported' }
   }
@@ -519,6 +540,7 @@ export class StatefulStubbedAPI implements PositiveOnlySocialAPI {
       body: commentText,
       creationTime: Date.now(),
       hidden: false,
+      hiddenReason: '',
       likes: new Set(),
       reports: new Set(),
     }
@@ -547,6 +569,7 @@ export class StatefulStubbedAPI implements PositiveOnlySocialAPI {
       body: commentText,
       creationTime: Date.now(),
       hidden: false,
+      hiddenReason: '',
       likes: new Set(),
       reports: new Set(),
     }
@@ -661,6 +684,7 @@ export class StatefulStubbedAPI implements PositiveOnlySocialAPI {
     comment.reports.add(user.id)
     if (comment.reports.size > MAX_BEFORE_HIDING_COMMENT) {
       comment.hidden = true
+      comment.hiddenReason = 'reports'
     }
     return { message: 'Comment reported' }
   }
@@ -755,5 +779,98 @@ export class StatefulStubbedAPI implements PositiveOnlySocialAPI {
       identity_is_verified: target.isVerified,
       is_adult: target.isAdult,
     }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Appeals
+  // ---------------------------------------------------------------------------
+
+  private hasAppeal(targetId: string): boolean {
+    return this.appeals.some((a) => a.targetId === targetId)
+  }
+
+  async getHiddenPosts(batch: number): Promise<HiddenPost[]> {
+    const user = this.requireUser()
+    const hidden = this.posts
+      .filter((p) => p.authorId === user.id && p.hidden)
+      .sort((a, b) => b.creationTime - a.creationTime)
+    return this.batch(hidden, batch, POST_BATCH_SIZE).map((p) => ({
+      post_identifier: p.postIdentifier,
+      image_url: p.imageUrl,
+      caption: p.caption,
+      hidden_reason: p.hiddenReason,
+      creation_time: new Date(p.creationTime).toISOString(),
+      has_appeal: this.hasAppeal(p.postIdentifier),
+    }))
+  }
+
+  async getHiddenComments(batch: number): Promise<HiddenComment[]> {
+    const user = this.requireUser()
+    const hidden = this.commentThreads
+      .flatMap((t) => t.comments)
+      .filter((c) => c.authorId === user.id && c.hidden)
+      .sort((a, b) => b.creationTime - a.creationTime)
+    return this.batch(hidden, batch, COMMENT_BATCH_SIZE).map((c) => ({
+      comment_identifier: c.commentIdentifier,
+      body: c.body,
+      hidden_reason: c.hiddenReason,
+      creation_time: new Date(c.creationTime).toISOString(),
+      has_appeal: this.hasAppeal(c.commentIdentifier),
+    }))
+  }
+
+  async getMyAppeals(batch: number): Promise<MyAppeal[]> {
+    const user = this.requireUser()
+    const mine = this.appeals
+      .filter((a) => a.appellantId === user.id)
+      .sort((a, b) => b.creationTime - a.creationTime)
+    return this.batch(mine, batch, POST_BATCH_SIZE).map((a) => ({
+      appeal_identifier: a.appealIdentifier,
+      target_type: a.targetType,
+      target_identifier: a.targetId,
+      status: a.status,
+      reason: a.reason,
+      content_snapshot: a.contentSnapshot,
+      resolution_note: null,
+      creation_time: new Date(a.creationTime).toISOString(),
+      resolved_time: null,
+    }))
+  }
+
+  async submitAppeal(body: SubmitAppealRequest): Promise<SubmitAppealResponse> {
+    const user = this.requireUser()
+    let snapshot: string
+    if (body.target_type === 'post') {
+      const post = this.posts.find(
+        (p) => p.postIdentifier === body.target_identifier && p.authorId === user.id && p.hidden,
+      )
+      if (!post) {
+        throw new ApiError(400, 'No appealable item with that identifier')
+      }
+      snapshot = post.caption
+    } else {
+      const comment = this.commentThreads
+        .flatMap((t) => t.comments)
+        .find((c) => c.commentIdentifier === body.target_identifier && c.authorId === user.id && c.hidden)
+      if (!comment) {
+        throw new ApiError(400, 'No appealable item with that identifier')
+      }
+      snapshot = comment.body
+    }
+    if (this.hasAppeal(body.target_identifier)) {
+      throw new ApiError(400, 'This item has already been appealed')
+    }
+    const appeal: AppealMock = {
+      appealIdentifier: newId(),
+      appellantId: user.id,
+      targetType: body.target_type,
+      targetId: body.target_identifier,
+      reason: body.reason,
+      contentSnapshot: snapshot,
+      status: 'pending',
+      creationTime: Date.now(),
+    }
+    this.appeals.push(appeal)
+    return { appeal_identifier: appeal.appealIdentifier }
   }
 }

--- a/website/src/api/StatefulStubbedAPI.ts
+++ b/website/src/api/StatefulStubbedAPI.ts
@@ -848,7 +848,7 @@ export class StatefulStubbedAPI implements PositiveOnlySocialAPI {
         throw new ApiError(400, 'No appealable item with that identifier')
       }
       snapshot = post.caption
-    } else {
+    } else if (body.target_type === 'comment') {
       const comment = this.commentThreads
         .flatMap((t) => t.comments)
         .find((c) => c.commentIdentifier === body.target_identifier && c.authorId === user.id && c.hidden)
@@ -856,6 +856,10 @@ export class StatefulStubbedAPI implements PositiveOnlySocialAPI {
         throw new ApiError(400, 'No appealable item with that identifier')
       }
       snapshot = comment.body
+    } else {
+      // Match the backend, which rejects any target_type other than
+      // post/comment rather than treating it as a comment.
+      throw new ApiError(400, 'Invalid target_type')
     }
     if (this.hasAppeal(body.target_identifier)) {
       throw new ApiError(400, 'This item has already been appealed')

--- a/website/src/api/client.ts
+++ b/website/src/api/client.ts
@@ -17,16 +17,21 @@ import type {
   CreatePostRequest,
   CreatePostResponse,
   FeedPost,
+  HiddenComment,
+  HiddenPost,
   LoginRequest,
   LoginWithRememberMeRequest,
   LoginWithRememberMeResponse,
   MessageResponse,
+  MyAppeal,
   PostDetails,
   ProfileDetails,
   RegisterRequest,
   ReplyResponse,
   RequestResetRequest,
   ResetPasswordRequest,
+  SubmitAppealRequest,
+  SubmitAppealResponse,
   UserSearchResult,
   VerifyResetRequest,
   VerifyResetResponse,
@@ -369,6 +374,26 @@ export class ApiClient implements PositiveOnlySocialAPI {
 
   getProfile(username: string): Promise<ProfileDetails> {
     return this.request<ProfileDetails>('GET', `/users/${username}/profile/`, { auth: true })
+  }
+
+  // ===========================================================================
+  // APPEALS
+  // ===========================================================================
+
+  getHiddenPosts(batch: number): Promise<HiddenPost[]> {
+    return this.request<HiddenPost[]>('GET', `/appeals/hidden/posts/${batch}/`, { auth: true })
+  }
+
+  getHiddenComments(batch: number): Promise<HiddenComment[]> {
+    return this.request<HiddenComment[]>('GET', `/appeals/hidden/comments/${batch}/`, { auth: true })
+  }
+
+  getMyAppeals(batch: number): Promise<MyAppeal[]> {
+    return this.request<MyAppeal[]>('GET', `/appeals/mine/${batch}/`, { auth: true })
+  }
+
+  submitAppeal(body: SubmitAppealRequest): Promise<SubmitAppealResponse> {
+    return this.request<SubmitAppealResponse>('POST', '/appeals/submit/', { auth: true, body })
   }
 }
 

--- a/website/src/api/types.ts
+++ b/website/src/api/types.ts
@@ -69,6 +69,12 @@ export interface CreatePostRequest {
 
 export interface CreatePostResponse {
   post_identifier: string
+  /** True when the post was created hidden pending appeal (classifier flagged
+   * it but the rejection is appealable). Absent/false for a normal post. */
+  hidden?: boolean
+  hidden_reason?: string
+  /** User-facing explanation when the post is hidden pending appeal. */
+  message?: string
 }
 
 /** A post as returned by the feed/listing endpoints. */
@@ -124,4 +130,58 @@ export interface ProfileDetails {
   is_blocked: boolean
   identity_is_verified: boolean
   is_adult: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Appeals (backend/user_system/views.py appeal endpoints)
+// ---------------------------------------------------------------------------
+
+/** What a content appeal can target in-app. Ban appeals go via email. */
+export type AppealTargetType = 'post' | 'comment'
+
+/** One of the signed-in user's hidden posts. */
+export interface HiddenPost {
+  post_identifier: string
+  image_url: string
+  caption: string
+  /** Why it was hidden: 'classifier', 'reports', or '' (unspecified). */
+  hidden_reason: string
+  creation_time: string
+  /** True once an appeal has been filed for it (it can only be appealed once). */
+  has_appeal: boolean
+}
+
+/** One of the signed-in user's hidden comments. */
+export interface HiddenComment {
+  comment_identifier: string
+  body: string
+  hidden_reason: string
+  creation_time: string
+  has_appeal: boolean
+}
+
+/** An appeal the signed-in user has filed, with its current status. */
+export interface MyAppeal {
+  appeal_identifier: string
+  /** 'post' | 'comment' | 'ban', or null once a resolved target was removed. */
+  target_type: AppealTargetType | 'ban' | null
+  target_identifier: string | null
+  /** 'pending' | 'approved' | 'denied'. */
+  status: string
+  reason: string
+  /** Snapshot of the appealed content, kept when the target was removed. */
+  content_snapshot: string | null
+  resolution_note: string | null
+  creation_time: string
+  resolved_time: string | null
+}
+
+export interface SubmitAppealRequest {
+  target_type: AppealTargetType
+  target_identifier: string
+  reason: string
+}
+
+export interface SubmitAppealResponse {
+  appeal_identifier: string
 }

--- a/website/src/components/NewPostTab.test.tsx
+++ b/website/src/components/NewPostTab.test.tsx
@@ -86,6 +86,25 @@ test('uploads the photo to S3 and creates the post on success', async () => {
   expect(onPosted).toHaveBeenCalled()
 })
 
+test('shows the appeal message when the post is hidden pending appeal', async () => {
+  mockUploadImage.mockResolvedValue(
+    'https://goodvibesonly-images.s3.us-east-2.amazonaws.com/user-123/abc.jpeg',
+  )
+  mockCreatePost.mockResolvedValue({
+    post_identifier: 'p1',
+    hidden: true,
+    hidden_reason: 'classifier',
+    message: 'Your post did not pass automated review. It is hidden for now but you can appeal the decision.',
+  })
+  render(<NewPostTab onPosted={() => {}} />)
+
+  await userEvent.upload(screen.getByLabelText('Choose a photo'), makeFile())
+  await userEvent.type(screen.getByLabelText('Caption'), 'maybe edgy')
+  await userEvent.click(screen.getByRole('button', { name: 'Share Post' }))
+
+  expect(await screen.findByText(/hidden for now but you can appeal/i)).toBeInTheDocument()
+})
+
 test('shows an error when the upload fails', async () => {
   mockUploadImage.mockRejectedValue({ message: 'Upload failed' })
   render(<NewPostTab onPosted={() => {}} />)

--- a/website/src/components/NewPostTab.tsx
+++ b/website/src/components/NewPostTab.tsx
@@ -56,11 +56,18 @@ function NewPostTab({ onPosted }: NewPostTabProps) {
     setSuccessMessage(null)
     try {
       const imageUrl = await uploadImage(file, userId)
-      await apiClient.createPost({ image_url: imageUrl, caption: caption.trim() })
+      const result = await apiClient.createPost({ image_url: imageUrl, caption: caption.trim() })
       setFile(null)
       setPreviewUrl(null)
       setCaption('')
-      setSuccessMessage('Your post was shared successfully!')
+      // A post flagged by automated review is created hidden pending appeal; tell
+      // the user it's hidden but appealable rather than implying it's live.
+      setSuccessMessage(
+        result.hidden
+          ? (result.message ??
+              'Your post did not pass automated review. It is hidden for now but you can appeal the decision.')
+          : 'Your post was shared successfully!',
+      )
       onPosted()
     } catch (err) {
       const apiErr = err as ApiError

--- a/website/src/components/SettingsTab.test.tsx
+++ b/website/src/components/SettingsTab.test.tsx
@@ -24,6 +24,7 @@ function renderTab() {
       <Routes>
         <Route path="/home" element={<SettingsTab />} />
         <Route path="/" element={<div>Landing page</div>} />
+        <Route path="/appeals" element={<div>Appeals page</div>} />
       </Routes>
     </MemoryRouter>,
   )
@@ -79,4 +80,10 @@ test('privacy policy can be shown', async () => {
   renderTab()
   await userEvent.click(screen.getByRole('button', { name: 'Privacy Policy' }))
   expect(screen.getByRole('dialog', { name: 'Privacy Policy' })).toBeInTheDocument()
+})
+
+test('opens the hidden content & appeals page', async () => {
+  renderTab()
+  await userEvent.click(screen.getByRole('button', { name: 'Hidden Content & Appeals' }))
+  expect(await screen.findByText('Appeals page')).toBeInTheDocument()
 })

--- a/website/src/components/SettingsTab.tsx
+++ b/website/src/components/SettingsTab.tsx
@@ -98,6 +98,13 @@ function SettingsTab() {
         <button
           type="button"
           className="settings-row"
+          onClick={() => navigate('/appeals')}
+        >
+          Hidden Content &amp; Appeals
+        </button>
+        <button
+          type="button"
+          className="settings-row"
           onClick={() => setActiveModal('privacy')}
         >
           Privacy Policy

--- a/website/src/pages/AppealsPage.test.tsx
+++ b/website/src/pages/AppealsPage.test.tsx
@@ -1,0 +1,134 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { vi, beforeEach, test, expect } from 'vitest'
+import AppealsPage from './AppealsPage'
+import type { HiddenComment, HiddenPost, MyAppeal } from '../api/types'
+
+vi.mock('../api/client', () => ({
+  apiClient: {
+    isAuthenticated: vi.fn(() => true),
+    getHiddenPosts: vi.fn(),
+    getHiddenComments: vi.fn(),
+    getMyAppeals: vi.fn(),
+    submitAppeal: vi.fn(),
+  },
+}))
+
+import { apiClient } from '../api/client'
+const mockHiddenPosts = vi.mocked(apiClient.getHiddenPosts)
+const mockHiddenComments = vi.mocked(apiClient.getHiddenComments)
+const mockAppeals = vi.mocked(apiClient.getMyAppeals)
+const mockSubmit = vi.mocked(apiClient.submitAppeal)
+
+const hiddenPost: HiddenPost = {
+  post_identifier: 'post-1',
+  image_url: 'http://img/1.jpg',
+  caption: 'a flagged caption',
+  hidden_reason: 'classifier',
+  creation_time: '2026-01-01T00:00:00Z',
+  has_appeal: false,
+}
+
+const hiddenComment: HiddenComment = {
+  comment_identifier: 'comment-1',
+  body: 'a flagged comment',
+  hidden_reason: 'reports',
+  creation_time: '2026-01-01T00:00:00Z',
+  has_appeal: false,
+}
+
+const pendingAppeal: MyAppeal = {
+  appeal_identifier: 'appeal-1',
+  target_type: 'post',
+  target_identifier: 'post-9',
+  status: 'pending',
+  reason: 'please reconsider',
+  content_snapshot: 'old caption',
+  resolution_note: null,
+  creation_time: '2026-01-01T00:00:00Z',
+  resolved_time: null,
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/appeals']}>
+      <Routes>
+        <Route path="/appeals" element={<AppealsPage />} />
+        <Route path="/login" element={<div>Login page</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  mockHiddenPosts.mockReset().mockResolvedValue([])
+  mockHiddenComments.mockReset().mockResolvedValue([])
+  mockAppeals.mockReset().mockResolvedValue([])
+  mockSubmit.mockReset().mockResolvedValue({ appeal_identifier: 'new-appeal' })
+})
+
+test('lists hidden posts and comments with their reason', async () => {
+  mockHiddenPosts.mockResolvedValue([hiddenPost])
+  mockHiddenComments.mockResolvedValue([hiddenComment])
+
+  renderPage()
+
+  expect(await screen.findByText('a flagged caption')).toBeInTheDocument()
+  expect(screen.getByText('Flagged by automated review')).toBeInTheDocument()
+  expect(screen.getByText('a flagged comment')).toBeInTheDocument()
+  expect(screen.getByText('Hidden after user reports')).toBeInTheDocument()
+})
+
+test('shows empty states when nothing is hidden or appealed', async () => {
+  renderPage()
+  expect(await screen.findByText('None of your content is hidden.')).toBeInTheDocument()
+  expect(screen.getByText("You haven't filed any appeals.")).toBeInTheDocument()
+})
+
+test('already-appealed content shows a status instead of a button', async () => {
+  mockHiddenPosts.mockResolvedValue([{ ...hiddenPost, has_appeal: true }])
+  renderPage()
+  expect(await screen.findByText('Appealed')).toBeInTheDocument()
+  expect(screen.queryByRole('button', { name: 'Appeal post' })).not.toBeInTheDocument()
+})
+
+test('submitting an appeal posts the reason and reloads', async () => {
+  mockHiddenPosts.mockResolvedValue([hiddenPost])
+  const user = userEvent.setup()
+  renderPage()
+
+  await user.click(await screen.findByRole('button', { name: 'Appeal post' }))
+  await user.type(screen.getByLabelText('Appeal reason'), 'this was a mistake')
+  await user.click(screen.getByRole('button', { name: 'Submit Appeal' }))
+
+  await waitFor(() =>
+    expect(mockSubmit).toHaveBeenCalledWith({
+      target_type: 'post',
+      target_identifier: 'post-1',
+      reason: 'this was a mistake',
+    }),
+  )
+  // Reloaded after submit (initial load + reload).
+  expect(mockHiddenPosts).toHaveBeenCalledTimes(2)
+})
+
+test('renders filed appeals with their status', async () => {
+  mockAppeals.mockResolvedValue([pendingAppeal])
+  renderPage()
+  expect(await screen.findByText('old caption')).toBeInTheDocument()
+  expect(screen.getByText('pending')).toBeInTheDocument()
+})
+
+test('surfaces a submit error and keeps the modal open', async () => {
+  mockHiddenPosts.mockResolvedValue([hiddenPost])
+  mockSubmit.mockRejectedValue(Object.assign(new Error('This item has already been appealed'), {}))
+  const user = userEvent.setup()
+  renderPage()
+
+  await user.click(await screen.findByRole('button', { name: 'Appeal post' }))
+  await user.type(screen.getByLabelText('Appeal reason'), 'again')
+  await user.click(screen.getByRole('button', { name: 'Submit Appeal' }))
+
+  expect(await screen.findByText('This item has already been appealed')).toBeInTheDocument()
+})

--- a/website/src/pages/AppealsPage.tsx
+++ b/website/src/pages/AppealsPage.tsx
@@ -57,6 +57,7 @@ function AppealsView() {
 
   const load = useCallback(async () => {
     try {
+      if (isMounted.current) setErrorMessage(null) // drop any stale error before reloading
       const [posts, comments, mine] = await Promise.all([
         apiClient.getHiddenPosts(0),
         apiClient.getHiddenComments(0),

--- a/website/src/pages/AppealsPage.tsx
+++ b/website/src/pages/AppealsPage.tsx
@@ -1,0 +1,261 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Navigate, useNavigate } from 'react-router-dom'
+import { apiClient } from '../api/client'
+import type { ApiError } from '../api/client'
+import type { AppealTargetType, HiddenComment, HiddenPost, MyAppeal } from '../api/types'
+import './MainApp.css'
+
+/**
+ * "Hidden content & appeals": the signed-in user's own hidden posts and
+ * comments, each appealable once, plus the status of appeals they have filed.
+ * Mirrors the iOS/Android appeals views. Ban appeals are not here — those go
+ * through the suspension email (an outright-banned user has no session).
+ */
+function AppealsPage() {
+  if (!apiClient.isAuthenticated()) {
+    return <Navigate to="/login" replace />
+  }
+  return <AppealsView />
+}
+
+const REASON_LABEL: Record<string, string> = {
+  classifier: 'Flagged by automated review',
+  reports: 'Hidden after user reports',
+  '': 'Hidden',
+}
+
+function hiddenReasonLabel(reason: string): string {
+  return REASON_LABEL[reason] ?? 'Hidden'
+}
+
+interface AppealTarget {
+  type: AppealTargetType
+  id: string
+  preview: string
+}
+
+function AppealsView() {
+  const navigate = useNavigate()
+  const isMounted = useRef(true)
+  useEffect(() => {
+    isMounted.current = true
+    return () => {
+      isMounted.current = false
+    }
+  }, [])
+
+  const [hiddenPosts, setHiddenPosts] = useState<HiddenPost[]>([])
+  const [hiddenComments, setHiddenComments] = useState<HiddenComment[]>([])
+  const [appeals, setAppeals] = useState<MyAppeal[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  // The item currently being appealed (drives the reason modal).
+  const [target, setTarget] = useState<AppealTarget | null>(null)
+  const [reason, setReason] = useState('')
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const load = useCallback(async () => {
+    try {
+      const [posts, comments, mine] = await Promise.all([
+        apiClient.getHiddenPosts(0),
+        apiClient.getHiddenComments(0),
+        apiClient.getMyAppeals(0),
+      ])
+      if (!isMounted.current) return
+      setHiddenPosts(posts)
+      setHiddenComments(comments)
+      setAppeals(mine)
+    } catch (err) {
+      if (isMounted.current) setErrorMessage((err as ApiError).message ?? 'Failed to load.')
+    } finally {
+      if (isMounted.current) setIsLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void Promise.resolve().then(load)
+  }, [load])
+
+  function openAppeal(t: AppealTarget) {
+    setTarget(t)
+    setReason('')
+    setErrorMessage(null)
+  }
+
+  async function submitAppeal() {
+    if (!target || reason.trim().length === 0) return
+    setIsSubmitting(true)
+    setErrorMessage(null)
+    try {
+      await apiClient.submitAppeal({
+        target_type: target.type,
+        target_identifier: target.id,
+        reason: reason.trim(),
+      })
+      setTarget(null)
+      setIsLoading(true)
+      await load()
+    } catch (err) {
+      setErrorMessage((err as ApiError).message ?? 'Failed to submit appeal.')
+    } finally {
+      if (isMounted.current) setIsSubmitting(false)
+    }
+  }
+
+  const nothingHidden = hiddenPosts.length === 0 && hiddenComments.length === 0
+  const noAppeals = appeals.length === 0
+
+  return (
+    <div className="app-shell">
+      <header className="app-bar">
+        <button type="button" className="app-bar__back" onClick={() => navigate(-1)}>
+          ← Back
+        </button>
+        <h1 className="app-bar__title">Hidden Content &amp; Appeals</h1>
+      </header>
+
+      <main className="app-content">
+        {errorMessage && (
+          <div className="auth-error" role="alert">
+            <p>{errorMessage}</p>
+            <button
+              type="button"
+              className="auth-error__dismiss"
+              aria-label="Dismiss error"
+              onClick={() => setErrorMessage(null)}
+            >
+              ✕
+            </button>
+          </div>
+        )}
+
+        {isLoading ? (
+          <div className="center-spinner">
+            <span className="spinner" />
+          </div>
+        ) : (
+          <>
+            <section className="settings-group">
+              <span className="settings-group__header">Hidden Content</span>
+              {nothingHidden && <p className="muted">None of your content is hidden.</p>}
+
+              {hiddenPosts.map(post => (
+                <div key={post.post_identifier} className="appeal-item">
+                  <img className="appeal-item__thumb" src={post.image_url} alt={post.caption} />
+                  <div className="appeal-item__body">
+                    <p className="appeal-item__text">{post.caption}</p>
+                    <p className="muted">{hiddenReasonLabel(post.hidden_reason)}</p>
+                  </div>
+                  <AppealAction
+                    hasAppeal={post.has_appeal}
+                    label={`Appeal post`}
+                    onAppeal={() =>
+                      openAppeal({ type: 'post', id: post.post_identifier, preview: post.caption })
+                    }
+                  />
+                </div>
+              ))}
+
+              {hiddenComments.map(comment => (
+                <div key={comment.comment_identifier} className="appeal-item">
+                  <div className="appeal-item__body">
+                    <p className="appeal-item__text">{comment.body}</p>
+                    <p className="muted">{hiddenReasonLabel(comment.hidden_reason)}</p>
+                  </div>
+                  <AppealAction
+                    hasAppeal={comment.has_appeal}
+                    label={`Appeal comment`}
+                    onAppeal={() =>
+                      openAppeal({
+                        type: 'comment',
+                        id: comment.comment_identifier,
+                        preview: comment.body,
+                      })
+                    }
+                  />
+                </div>
+              ))}
+            </section>
+
+            <section className="settings-group">
+              <span className="settings-group__header">Your Appeals</span>
+              {noAppeals && <p className="muted">You haven't filed any appeals.</p>}
+              {appeals.map(appeal => (
+                <div key={appeal.appeal_identifier} className="appeal-item">
+                  <div className="appeal-item__body">
+                    <p className="appeal-item__text">
+                      {appeal.content_snapshot ?? appeal.target_type ?? 'Appeal'}
+                    </p>
+                    <p className="muted">Reason: {appeal.reason}</p>
+                    {appeal.resolution_note && (
+                      <p className="muted">Note: {appeal.resolution_note}</p>
+                    )}
+                  </div>
+                  <span className={`appeal-status appeal-status--${appeal.status}`}>
+                    {appeal.status}
+                  </span>
+                </div>
+              ))}
+            </section>
+          </>
+        )}
+      </main>
+
+      {target && (
+        <div className="modal-overlay">
+          <div className="modal" role="dialog" aria-modal="true" aria-label="Appeal">
+            <h2 className="modal__title">Appeal this {target.type}</h2>
+            <p className="modal__body">{target.preview}</p>
+            <textarea
+              className="text-area"
+              rows={4}
+              aria-label="Appeal reason"
+              placeholder="Why should this be restored?"
+              value={reason}
+              onChange={e => setReason(e.target.value)}
+              disabled={isSubmitting}
+            />
+            <div className="modal__actions">
+              <button
+                type="button"
+                className="modal__cancel"
+                onClick={() => setTarget(null)}
+                disabled={isSubmitting}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="modal__confirm"
+                disabled={reason.trim().length === 0 || isSubmitting}
+                onClick={submitAppeal}
+              >
+                Submit Appeal
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface AppealActionProps {
+  hasAppeal: boolean
+  label: string
+  onAppeal: () => void
+}
+
+function AppealAction({ hasAppeal, label, onAppeal }: AppealActionProps) {
+  if (hasAppeal) {
+    return <span className="appeal-status appeal-status--pending">Appealed</span>
+  }
+  return (
+    <button type="button" className="btn btn-primary appeal-item__action" onClick={onAppeal}>
+      {label}
+    </button>
+  )
+}
+
+export default AppealsPage

--- a/website/src/pages/MainApp.css
+++ b/website/src/pages/MainApp.css
@@ -748,3 +748,63 @@
   cursor: pointer;
   padding: 0.25rem 0 0 2rem;
 }
+
+/* Appeals / hidden content (AppealsPage) */
+.appeal-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  background: #1a1a1a;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  padding: 0.75rem 1rem;
+}
+
+.appeal-item__thumb {
+  width: 48px;
+  height: 48px;
+  object-fit: cover;
+  border-radius: 8px;
+  flex-shrink: 0;
+}
+
+.appeal-item__body {
+  flex: 1;
+  min-width: 0;
+}
+
+.appeal-item__text {
+  margin: 0 0 0.25rem;
+  overflow-wrap: anywhere;
+}
+
+.appeal-item__action {
+  flex-shrink: 0;
+  width: auto;
+  padding: 0.4rem 0.8rem;
+  font-size: 0.85rem;
+}
+
+.appeal-status {
+  flex-shrink: 0;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: capitalize;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+}
+
+.appeal-status--pending {
+  color: #ffd479;
+  background: rgba(255, 212, 121, 0.15);
+}
+
+.appeal-status--approved {
+  color: #7be495;
+  background: rgba(123, 228, 149, 0.15);
+}
+
+.appeal-status--denied {
+  color: #ff8a8a;
+  background: rgba(255, 138, 138, 0.15);
+}


### PR DESCRIPTION
Chunk 7 of the appeals system for [issue #47](https://github.com/andrewkatson/pos/issues/47) — the **web client**. Backend chunks 1–6 are on `main`; this surfaces them in the website. Independent of the iOS/Android client chunks (8, 9).

## What changed

- **API layer** — `getHiddenPosts`, `getHiddenComments`, `getMyAppeals`, `submitAppeal` added to the `PositiveOnlySocialAPI` interface, the real `ApiClient`, and the in-memory `StatefulStubbedAPI`. `CreatePostResponse` gains optional `hidden` / `hidden_reason` / `message`.
- **`AppealsPage`** ("Hidden Content & Appeals") — lists the user's own hidden posts and comments with the hide reason and an **Appeal** button (one appeal per item; already-appealed items show a status chip), plus the status of appeals they've filed. Reached via a new **Settings** row, routed at `/appeals`. A reason modal drives submission. Ban appeals stay on the email flow, matching the backend decision.
- **`NewPostTab`** — when a post is created hidden pending appeal, shows the backend's "hidden but you can appeal" message instead of "shared successfully".

## Testing

- New `AppealsPage.test.tsx` (6): listing + reason labels, empty states, submit→reload, already-appealed chip, filed-appeal status, submit-error keeps modal open.
- `NewPostTab.test.tsx` — hidden-response message.
- `SettingsTab.test.tsx` — navigates to the appeals page.
- `StatefulStubbedAPI.test.ts` — appeal flow via the report-hide path (hidden listing, submit, has_appeal flip, can't-appeal-visible, no-duplicate).
- **150 web tests pass**; `tsc -b`, `eslint`, and `vite build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)