### PR TITLE
Android: hidden content & appeals UI (issue #47, chunk 9)

### DIFF
--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/api/PositiveOnlySocialAPI.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/api/PositiveOnlySocialAPI.kt
@@ -207,4 +207,32 @@ interface PositiveOnlySocialAPI {
         @Header("Authorization") token: String,
         @Path("username") username: String
     ): Response<ProfileDetailsResponse>
+
+    // ============================================================================================
+    // APPEALS
+    // ============================================================================================
+
+    @GET("appeals/hidden/posts/{batch}/")
+    suspend fun getHiddenPosts(
+        @Header("Authorization") token: String,
+        @Path("batch") batch: Int
+    ): Response<List<HiddenPost>>
+
+    @GET("appeals/hidden/comments/{batch}/")
+    suspend fun getHiddenComments(
+        @Header("Authorization") token: String,
+        @Path("batch") batch: Int
+    ): Response<List<HiddenComment>>
+
+    @GET("appeals/mine/{batch}/")
+    suspend fun getMyAppeals(
+        @Header("Authorization") token: String,
+        @Path("batch") batch: Int
+    ): Response<List<MyAppeal>>
+
+    @POST("appeals/submit/")
+    suspend fun submitAppeal(
+        @Header("Authorization") token: String,
+        @Body request: SubmitAppealRequest
+    ): Response<SubmitAppealResponse>
 }

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/api/StatefulStubbedAPI.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/api/StatefulStubbedAPI.kt
@@ -706,15 +706,21 @@ class StatefulStubbedAPI : PositiveOnlySocialAPI {
     override suspend fun submitAppeal(token: String, request: SubmitAppealRequest): Response<SubmitAppealResponse> {
         val user = getAuthorizedUser(token) ?: return errorGeneric(401, "Unauthorized")
 
-        val snapshot: String = if (request.targetType == "post") {
-            val post = posts.find { it.postIdentifier == request.targetIdentifier && it.authorId == user.id && it.hidden }
-                ?: return errorGeneric(400, "No appealable item with that identifier")
-            post.caption
-        } else {
-            val comment = commentThreads.flatMap { it.comments }
-                .find { it.commentIdentifier == request.targetIdentifier && it.authorId == user.id && it.hidden }
-                ?: return errorGeneric(400, "No appealable item with that identifier")
-            comment.body
+        val snapshot: String = when (request.targetType) {
+            "post" -> {
+                val post = posts.find { it.postIdentifier == request.targetIdentifier && it.authorId == user.id && it.hidden }
+                    ?: return errorGeneric(400, "No appealable item with that identifier")
+                post.caption
+            }
+            "comment" -> {
+                val comment = commentThreads.flatMap { it.comments }
+                    .find { it.commentIdentifier == request.targetIdentifier && it.authorId == user.id && it.hidden }
+                    ?: return errorGeneric(400, "No appealable item with that identifier")
+                comment.body
+            }
+            // Match the backend, which rejects any target_type other than
+            // post/comment rather than treating it as a comment.
+            else -> return errorGeneric(400, "Invalid target_type")
         }
 
         if (hasAppeal(request.targetIdentifier)) {

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/api/StatefulStubbedAPI.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/api/StatefulStubbedAPI.kt
@@ -28,6 +28,7 @@ class StatefulStubbedAPI : PositiveOnlySocialAPI {
     private val loginCookies = mutableListOf<LoginCookieMock>()
     private val posts = mutableListOf<PostMock>()
     private val commentThreads = mutableListOf<CommentThreadMock>()
+    private val appeals = mutableListOf<AppealMock>()
 
     // Simulates the "Authorization: Bearer <token>" header.
     // Set this variable before making authenticated calls.
@@ -76,8 +77,19 @@ class StatefulStubbedAPI : PositiveOnlySocialAPI {
         val caption: String,
         val creationTime: Long = System.currentTimeMillis(),
         var hidden: Boolean = false,
+        var hiddenReason: String = "",
         val likes: MutableSet<String> = mutableSetOf(), // Set of User IDs
         val reports: MutableSet<String> = mutableSetOf() // Set of User IDs
+    )
+
+    private data class AppealMock(
+        val appealIdentifier: String = UUID.randomUUID().toString(),
+        val appellantId: String,
+        val targetType: String, // "post" or "comment"
+        val targetId: String,
+        val reason: String,
+        val contentSnapshot: String,
+        val status: String = "pending"
     )
 
     private data class CommentThreadMock(
@@ -92,6 +104,7 @@ class StatefulStubbedAPI : PositiveOnlySocialAPI {
         val body: String,
         val creationTime: Long = System.currentTimeMillis(),
         var hidden: Boolean = false,
+        var hiddenReason: String = "",
         val likes: MutableSet<String> = mutableSetOf(),
         val reports: MutableSet<String> = mutableSetOf()
     )
@@ -341,6 +354,7 @@ class StatefulStubbedAPI : PositiveOnlySocialAPI {
         post.reports.add(user.id)
         if (post.reports.size > MAX_BEFORE_HIDING_POST) {
             post.hidden = true
+            post.hiddenReason = "reports"
         }
         return Response.success(GenericResponse("Post reported", null))
     }
@@ -513,7 +527,10 @@ class StatefulStubbedAPI : PositiveOnlySocialAPI {
         if (comment.reports.contains(user.id)) return error(404, "Already reported")
 
         comment.reports.add(user.id)
-        if (comment.reports.size > 5) comment.hidden = true // Stub limit
+        if (comment.reports.size > 5) { // Stub limit
+            comment.hidden = true
+            comment.hiddenReason = "reports"
+        }
 
         return Response.success(GenericResponse("Comment reported", null))
     }
@@ -648,6 +665,71 @@ class StatefulStubbedAPI : PositiveOnlySocialAPI {
             isFollowing,
             isBlocked
         ))
+    }
+
+    // ============================================================================================
+    // APPEALS
+    // ============================================================================================
+
+    private fun hasAppeal(targetId: String): Boolean = appeals.any { it.targetId == targetId }
+
+    override suspend fun getHiddenPosts(token: String, batch: Int): Response<List<HiddenPost>> {
+        val user = getAuthorizedUser(token) ?: return errorGeneric(401, "Unauthorized")
+        val hidden = posts.filter { it.authorId == user.id && it.hidden }
+            .sortedByDescending { it.creationTime }
+        val dtos = getBatch(hidden, batch, POST_BATCH_SIZE).map {
+            HiddenPost(it.postIdentifier, it.imageUrl, it.caption, it.hiddenReason, hasAppeal(it.postIdentifier))
+        }
+        return Response.success(dtos)
+    }
+
+    override suspend fun getHiddenComments(token: String, batch: Int): Response<List<HiddenComment>> {
+        val user = getAuthorizedUser(token) ?: return errorGeneric(401, "Unauthorized")
+        val hidden = commentThreads.flatMap { it.comments }
+            .filter { it.authorId == user.id && it.hidden }
+            .sortedByDescending { it.creationTime }
+        val dtos = getBatch(hidden, batch, COMMENT_BATCH_SIZE).map {
+            HiddenComment(it.commentIdentifier, it.body, it.hiddenReason, hasAppeal(it.commentIdentifier))
+        }
+        return Response.success(dtos)
+    }
+
+    override suspend fun getMyAppeals(token: String, batch: Int): Response<List<MyAppeal>> {
+        val user = getAuthorizedUser(token) ?: return errorGeneric(401, "Unauthorized")
+        val mine = appeals.filter { it.appellantId == user.id }
+        val dtos = getBatch(mine, batch, POST_BATCH_SIZE).map {
+            MyAppeal(it.appealIdentifier, it.targetType, it.status, it.reason, it.contentSnapshot, null)
+        }
+        return Response.success(dtos)
+    }
+
+    override suspend fun submitAppeal(token: String, request: SubmitAppealRequest): Response<SubmitAppealResponse> {
+        val user = getAuthorizedUser(token) ?: return errorGeneric(401, "Unauthorized")
+
+        val snapshot: String = if (request.targetType == "post") {
+            val post = posts.find { it.postIdentifier == request.targetIdentifier && it.authorId == user.id && it.hidden }
+                ?: return errorGeneric(400, "No appealable item with that identifier")
+            post.caption
+        } else {
+            val comment = commentThreads.flatMap { it.comments }
+                .find { it.commentIdentifier == request.targetIdentifier && it.authorId == user.id && it.hidden }
+                ?: return errorGeneric(400, "No appealable item with that identifier")
+            comment.body
+        }
+
+        if (hasAppeal(request.targetIdentifier)) {
+            return errorGeneric(400, "This item has already been appealed")
+        }
+
+        val appeal = AppealMock(
+            appellantId = user.id,
+            targetType = request.targetType,
+            targetId = request.targetIdentifier,
+            reason = request.reason,
+            contentSnapshot = snapshot
+        )
+        appeals.add(appeal)
+        return Response.success(SubmitAppealResponse(appeal.appealIdentifier))
     }
 
     // ============================================================================================

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/api/StatefulStubbedAPI.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/api/StatefulStubbedAPI.kt
@@ -310,7 +310,7 @@ class StatefulStubbedAPI : PositiveOnlySocialAPI {
     }
 
     // ============================================================================================
-    // POSTS
+    // posts
     // ============================================================================================
 
     override suspend fun makePost(token: String, request: CreatePostRequest): Response<CreatePostResponse> {
@@ -383,7 +383,7 @@ class StatefulStubbedAPI : PositiveOnlySocialAPI {
     }
 
     // ============================================================================================
-    // FEED / RETRIEVAL
+    // feed / retrieval
     // ============================================================================================
 
     override suspend fun getPostsInFeed(token: String, batch: Int): Response<List<Post>> {
@@ -457,7 +457,7 @@ class StatefulStubbedAPI : PositiveOnlySocialAPI {
     }
 
     // ============================================================================================
-    // COMMENTS
+    // comments
     // ============================================================================================
 
     override suspend fun commentOnPost(token: String, postId: String, request: CommentRequest): Response<CommentResponse> {
@@ -668,7 +668,7 @@ class StatefulStubbedAPI : PositiveOnlySocialAPI {
     }
 
     // ============================================================================================
-    // APPEALS
+    // appeals
     // ============================================================================================
 
     private fun hasAppeal(targetId: String): Boolean = appeals.any { it.targetId == targetId }
@@ -739,7 +739,7 @@ class StatefulStubbedAPI : PositiveOnlySocialAPI {
     }
 
     // ============================================================================================
-    // UTILS
+    // utils
     // ============================================================================================
 
     private fun <T> getBatch(list: List<T>, batchIndex: Int, batchSize: Int): List<T> {

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/model/Models.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/model/Models.kt
@@ -77,7 +77,13 @@ data class CreatePostRequest(
 )
 
 data class CreatePostResponse(
-    @SerializedName("post_identifier") val postIdentifier: String
+    @SerializedName("post_identifier") val postIdentifier: String,
+    // Present (true) when the post was created hidden pending appeal — the
+    // classifier flagged it but the rejection is appealable. Absent/false for
+    // a normal post.
+    val hidden: Boolean = false,
+    @SerializedName("hidden_reason") val hiddenReason: String? = null,
+    val message: String? = null
 )
 
 data class ReportRequest(
@@ -186,4 +192,44 @@ data class CommentViewData(
 data class CommentThreadViewData(
     val id: String,
     val comments: List<CommentViewData>
+)
+// =============================================================================
+// APPEALS (backend appeal endpoints)
+// =============================================================================
+
+/** One of the signed-in user's hidden posts, from the appeals endpoint. */
+data class HiddenPost(
+    @SerializedName("post_identifier") val postIdentifier: String,
+    @SerializedName("image_url") val imageUrl: String,
+    val caption: String,
+    @SerializedName("hidden_reason") val hiddenReason: String = "",
+    @SerializedName("has_appeal") val hasAppeal: Boolean = false
+)
+
+/** One of the signed-in user's hidden comments. */
+data class HiddenComment(
+    @SerializedName("comment_identifier") val commentIdentifier: String,
+    val body: String,
+    @SerializedName("hidden_reason") val hiddenReason: String = "",
+    @SerializedName("has_appeal") val hasAppeal: Boolean = false
+)
+
+/** An appeal the signed-in user has filed, with its current status. */
+data class MyAppeal(
+    @SerializedName("appeal_identifier") val appealIdentifier: String,
+    @SerializedName("target_type") val targetType: String?,
+    val status: String,
+    val reason: String,
+    @SerializedName("content_snapshot") val contentSnapshot: String?,
+    @SerializedName("resolution_note") val resolutionNote: String?
+)
+
+data class SubmitAppealRequest(
+    @SerializedName("target_type") val targetType: String,
+    @SerializedName("target_identifier") val targetIdentifier: String,
+    val reason: String
+)
+
+data class SubmitAppealResponse(
+    @SerializedName("appeal_identifier") val appealIdentifier: String
 )

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/AppealsViewModel.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/AppealsViewModel.kt
@@ -4,16 +4,19 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.positiveonlysocial.api.PositiveOnlySocialAPI
+import com.example.positiveonlysocial.data.model.GenericResponse
 import com.example.positiveonlysocial.data.model.HiddenComment
 import com.example.positiveonlysocial.data.model.HiddenPost
 import com.example.positiveonlysocial.data.model.MyAppeal
 import com.example.positiveonlysocial.data.model.SubmitAppealRequest
 import com.example.positiveonlysocial.data.model.UserSession
 import com.example.positiveonlysocial.data.security.KeychainHelperProtocol
+import com.google.gson.Gson
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import retrofit2.Response
 
 private const val TAG = "AppealsViewModel"
 
@@ -44,6 +47,7 @@ class AppealsViewModel(
     val errorMessage: StateFlow<String?> = _errorMessage.asStateFlow()
 
     private val service = "positive-only-social.Positive-Only-Social"
+    private val gson = Gson()
 
     fun clearError() {
         _errorMessage.value = null
@@ -52,9 +56,23 @@ class AppealsViewModel(
     private fun session(): UserSession? =
         keychainHelper.load(UserSession::class.java, service, account)
 
+    /**
+     * Extracts the backend's `error` message from a failed response body so the
+     * UI shows the message rather than the raw `{"error": ...}` JSON.
+     */
+    private fun errorOf(response: Response<*>): String {
+        val raw = response.errorBody()?.string()
+        return try {
+            gson.fromJson(raw, GenericResponse::class.java)?.error ?: raw ?: "Request failed"
+        } catch (e: Exception) {
+            raw ?: "Request failed"
+        }
+    }
+
     /** Loads (or reloads) the first page of hidden content and filed appeals. */
     fun load() {
         _isLoading.value = true
+        _errorMessage.value = null // drop any stale error from a previous load/submit
         viewModelScope.launch {
             try {
                 val userSession = session()
@@ -68,17 +86,21 @@ class AppealsViewModel(
                 if (postsResp.isSuccessful) {
                     _hiddenPosts.value = postsResp.body() ?: emptyList()
                 } else {
-                    _errorMessage.value = postsResp.errorBody()?.string()
+                    _errorMessage.value = errorOf(postsResp)
                 }
 
                 val commentsResp = api.getHiddenComments(token, 0)
                 if (commentsResp.isSuccessful) {
                     _hiddenComments.value = commentsResp.body() ?: emptyList()
+                } else {
+                    _errorMessage.value = errorOf(commentsResp)
                 }
 
                 val appealsResp = api.getMyAppeals(token, 0)
                 if (appealsResp.isSuccessful) {
                     _appeals.value = appealsResp.body() ?: emptyList()
+                } else {
+                    _errorMessage.value = errorOf(appealsResp)
                 }
             } catch (e: Exception) {
                 _errorMessage.value = e.localizedMessage
@@ -114,7 +136,7 @@ class AppealsViewModel(
                     load()
                     onResult(true)
                 } else {
-                    _errorMessage.value = response.errorBody()?.string()
+                    _errorMessage.value = errorOf(response)
                     onResult(false)
                 }
             } catch (e: Exception) {

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/AppealsViewModel.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/AppealsViewModel.kt
@@ -1,0 +1,127 @@
+package com.example.positiveonlysocial.models.viewmodels
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.positiveonlysocial.api.PositiveOnlySocialAPI
+import com.example.positiveonlysocial.data.model.HiddenComment
+import com.example.positiveonlysocial.data.model.HiddenPost
+import com.example.positiveonlysocial.data.model.MyAppeal
+import com.example.positiveonlysocial.data.model.SubmitAppealRequest
+import com.example.positiveonlysocial.data.model.UserSession
+import com.example.positiveonlysocial.data.security.KeychainHelperProtocol
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+private const val TAG = "AppealsViewModel"
+
+/**
+ * Loads the signed-in user's hidden posts/comments and the appeals they have
+ * filed, and submits new content appeals. Ban appeals are not here — those go
+ * through the suspension email (an outright-banned user has no session).
+ */
+class AppealsViewModel(
+    private val api: PositiveOnlySocialAPI,
+    private val keychainHelper: KeychainHelperProtocol,
+    private val account: String = "userSessionToken"
+) : ViewModel() {
+
+    private val _hiddenPosts = MutableStateFlow<List<HiddenPost>>(emptyList())
+    val hiddenPosts: StateFlow<List<HiddenPost>> = _hiddenPosts.asStateFlow()
+
+    private val _hiddenComments = MutableStateFlow<List<HiddenComment>>(emptyList())
+    val hiddenComments: StateFlow<List<HiddenComment>> = _hiddenComments.asStateFlow()
+
+    private val _appeals = MutableStateFlow<List<MyAppeal>>(emptyList())
+    val appeals: StateFlow<List<MyAppeal>> = _appeals.asStateFlow()
+
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+
+    private val _errorMessage = MutableStateFlow<String?>(null)
+    val errorMessage: StateFlow<String?> = _errorMessage.asStateFlow()
+
+    private val service = "positive-only-social.Positive-Only-Social"
+
+    fun clearError() {
+        _errorMessage.value = null
+    }
+
+    private fun session(): UserSession? =
+        keychainHelper.load(UserSession::class.java, service, account)
+
+    /** Loads (or reloads) the first page of hidden content and filed appeals. */
+    fun load() {
+        _isLoading.value = true
+        viewModelScope.launch {
+            try {
+                val userSession = session()
+                if (userSession == null) {
+                    Log.e(TAG, "No active session found — cannot load appeals")
+                    return@launch
+                }
+                val token = userSession.sessionToken
+
+                val postsResp = api.getHiddenPosts(token, 0)
+                if (postsResp.isSuccessful) {
+                    _hiddenPosts.value = postsResp.body() ?: emptyList()
+                } else {
+                    _errorMessage.value = postsResp.errorBody()?.string()
+                }
+
+                val commentsResp = api.getHiddenComments(token, 0)
+                if (commentsResp.isSuccessful) {
+                    _hiddenComments.value = commentsResp.body() ?: emptyList()
+                }
+
+                val appealsResp = api.getMyAppeals(token, 0)
+                if (appealsResp.isSuccessful) {
+                    _appeals.value = appealsResp.body() ?: emptyList()
+                }
+            } catch (e: Exception) {
+                _errorMessage.value = e.localizedMessage
+                Log.e(TAG, "Error loading appeals", e)
+            } finally {
+                _isLoading.value = false
+            }
+        }
+    }
+
+    /**
+     * Files an appeal for a hidden post or comment. `targetType` is "post" or
+     * "comment". Reloads on success and reports the outcome via [onResult].
+     */
+    fun submitAppeal(
+        targetType: String,
+        targetIdentifier: String,
+        reason: String,
+        onResult: (Boolean) -> Unit = {}
+    ) {
+        viewModelScope.launch {
+            try {
+                val userSession = session()
+                if (userSession == null) {
+                    onResult(false)
+                    return@launch
+                }
+                val response = api.submitAppeal(
+                    userSession.sessionToken,
+                    SubmitAppealRequest(targetType, targetIdentifier, reason)
+                )
+                if (response.isSuccessful) {
+                    load()
+                    onResult(true)
+                } else {
+                    _errorMessage.value = response.errorBody()?.string()
+                    onResult(false)
+                }
+            } catch (e: Exception) {
+                _errorMessage.value = e.localizedMessage
+                Log.e(TAG, "Error submitting appeal", e)
+                onResult(false)
+            }
+        }
+    }
+}

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/AppealsViewModelFactory.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/AppealsViewModelFactory.kt
@@ -1,0 +1,21 @@
+package com.example.positiveonlysocial.models.viewmodels
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.example.positiveonlysocial.api.PositiveOnlySocialAPI
+import com.example.positiveonlysocial.data.security.KeychainHelperProtocol
+
+class AppealsViewModelFactory(
+    private val api: PositiveOnlySocialAPI,
+    private val keychainHelper: KeychainHelperProtocol,
+    private val account: String = "userSessionToken"
+) : ViewModelProvider.Factory {
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(AppealsViewModel::class.java)) {
+            return AppealsViewModel(api, keychainHelper, account) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/AppealsScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/AppealsScreen.kt
@@ -1,0 +1,202 @@
+package com.example.positiveonlysocial.ui.main
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import com.example.positiveonlysocial.api.PositiveOnlySocialAPI
+import com.example.positiveonlysocial.data.model.MyAppeal
+import com.example.positiveonlysocial.data.security.KeychainHelperProtocol
+import com.example.positiveonlysocial.models.viewmodels.AppealsViewModel
+import com.example.positiveonlysocial.models.viewmodels.AppealsViewModelFactory
+import com.example.positiveonlysocial.ui.preview.PreviewHelpers
+import com.example.positiveonlysocial.ui.theme.PositiveOnlySocialTheme
+
+private fun hiddenReasonLabel(reason: String): String = when (reason) {
+    "classifier" -> "Flagged by automated review"
+    "reports" -> "Hidden after user reports"
+    else -> "Hidden"
+}
+
+/** The item being appealed (drives the reason dialog). */
+private data class AppealTarget(val type: String, val id: String, val preview: String)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AppealsScreen(
+    navController: NavController,
+    api: PositiveOnlySocialAPI,
+    keychainHelper: KeychainHelperProtocol
+) {
+    PositiveOnlySocialTheme {
+        val viewModel: AppealsViewModel = viewModel(
+            factory = AppealsViewModelFactory(api, keychainHelper)
+        )
+
+        val hiddenPosts by viewModel.hiddenPosts.collectAsState()
+        val hiddenComments by viewModel.hiddenComments.collectAsState()
+        val appeals by viewModel.appeals.collectAsState()
+        val errorMessage by viewModel.errorMessage.collectAsState()
+
+        var target by remember { mutableStateOf<AppealTarget?>(null) }
+        var reasonText by remember { mutableStateOf("") }
+
+        LaunchedEffect(Unit) { viewModel.load() }
+
+        if (errorMessage != null) {
+            AlertDialog(
+                onDismissRequest = { viewModel.clearError() },
+                title = { Text("Error") },
+                text = { Text(errorMessage ?: "Unknown error") },
+                confirmButton = { Button(onClick = { viewModel.clearError() }) { Text("OK") } }
+            )
+        }
+
+        target?.let { t ->
+            AlertDialog(
+                onDismissRequest = { target = null; reasonText = "" },
+                title = { Text("Appeal this ${t.type}") },
+                text = {
+                    Column {
+                        Text(t.preview, style = MaterialTheme.typography.bodySmall, color = Color.Gray)
+                        Spacer(Modifier.height(8.dp))
+                        TextField(
+                            value = reasonText,
+                            onValueChange = { reasonText = it },
+                            label = { Text("Why should this be restored?") },
+                            modifier = Modifier.testTag("appealReasonField")
+                        )
+                    }
+                },
+                confirmButton = {
+                    Button(
+                        enabled = reasonText.isNotBlank(),
+                        onClick = {
+                            viewModel.submitAppeal(t.type, t.id, reasonText.trim()) { ok ->
+                                if (ok) { target = null; reasonText = "" }
+                            }
+                        }
+                    ) { Text("Submit") }
+                },
+                dismissButton = {
+                    Button(onClick = { target = null; reasonText = "" }) { Text("Cancel") }
+                }
+            )
+        }
+
+        Scaffold(
+            topBar = {
+                TopAppBar(
+                    title = { Text("Hidden Content & Appeals") },
+                    navigationIcon = {
+                        IconButton(onClick = { navController.popBackStack() }) {
+                            Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        }
+                    }
+                )
+            }
+        ) { padding ->
+            LazyColumn(modifier = Modifier.fillMaxSize().padding(padding)) {
+                item {
+                    SectionHeader("Hidden Content")
+                    if (hiddenPosts.isEmpty() && hiddenComments.isEmpty()) {
+                        MutedText("None of your content is hidden.")
+                    }
+                }
+                items(hiddenPosts, key = { it.postIdentifier }) { post ->
+                    HiddenRow(text = post.caption, reason = post.hiddenReason, hasAppeal = post.hasAppeal) {
+                        target = AppealTarget("post", post.postIdentifier, post.caption)
+                    }
+                    HorizontalDivider()
+                }
+                items(hiddenComments, key = { it.commentIdentifier }) { comment ->
+                    HiddenRow(text = comment.body, reason = comment.hiddenReason, hasAppeal = comment.hasAppeal) {
+                        target = AppealTarget("comment", comment.commentIdentifier, comment.body)
+                    }
+                    HorizontalDivider()
+                }
+                item {
+                    SectionHeader("Your Appeals")
+                    if (appeals.isEmpty()) {
+                        MutedText("You haven't filed any appeals.")
+                    }
+                }
+                items(appeals, key = { it.appealIdentifier }) { appeal ->
+                    AppealRow(appeal)
+                    HorizontalDivider()
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionHeader(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.titleMedium,
+        modifier = Modifier.padding(16.dp)
+    )
+}
+
+@Composable
+private fun MutedText(text: String) {
+    Text(text = text, color = Color.Gray, modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp))
+}
+
+@Composable
+private fun HiddenRow(text: String, reason: String, hasAppeal: Boolean, onAppeal: () -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(text, maxLines = 2, overflow = TextOverflow.Ellipsis)
+            Text(hiddenReasonLabel(reason), style = MaterialTheme.typography.bodySmall, color = Color.Gray)
+        }
+        Spacer(Modifier.width(8.dp))
+        if (hasAppeal) {
+            Text("Appealed", style = MaterialTheme.typography.bodySmall, color = Color.Gray)
+        } else {
+            Button(onClick = onAppeal, modifier = Modifier.testTag("appealButton")) { Text("Appeal") }
+        }
+    }
+}
+
+@Composable
+private fun AppealRow(appeal: MyAppeal) {
+    Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+        Text(appeal.contentSnapshot ?: appeal.targetType ?: "Appeal", maxLines = 2, overflow = TextOverflow.Ellipsis)
+        Text("Reason: ${appeal.reason}", style = MaterialTheme.typography.bodySmall, color = Color.Gray)
+        appeal.resolutionNote?.takeIf { it.isNotBlank() }?.let {
+            Text("Note: $it", style = MaterialTheme.typography.bodySmall, color = Color.Gray)
+        }
+        Text(
+            appeal.status.replaceFirstChar { it.uppercase() },
+            style = MaterialTheme.typography.labelMedium
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun AppealsScreenPreview() {
+    AppealsScreen(
+        navController = rememberNavController(),
+        api = PreviewHelpers.mockApi,
+        keychainHelper = PreviewHelpers.mockKeychainHelper
+    )
+}

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/NewPostScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/NewPostScreen.kt
@@ -40,6 +40,7 @@ fun NewPostScreen(
         var selectedImageUri by remember { mutableStateOf<Uri?>(null) }
         var isLoading by remember { mutableStateOf(false) }
         var showSuccessAlert by remember { mutableStateOf(false) }
+        var successMessage by remember { mutableStateOf("Your post was shared successfully!") }
         var showFailureAlert by remember { mutableStateOf(false) }
         var failureMessage by remember { mutableStateOf("") }
 
@@ -55,7 +56,7 @@ fun NewPostScreen(
             AlertDialog(
                 onDismissRequest = { showSuccessAlert = false },
                 title = { Text("Success!") },
-                text = { Text("Your post was shared successfully!") },
+                text = { Text(successMessage) },
                 confirmButton = {
                     Button(onClick = { 
                         showSuccessAlert = false
@@ -181,10 +182,20 @@ fun NewPostScreen(
                                     imageUrl = uploadUrl.toString(),
                                     caption = caption
                                 )
-                                api.makePost(
+                                val response = api.makePost(
                                     token = session.sessionToken,
                                     request = request
                                 )
+                                // A post flagged by automated review is created
+                                // hidden pending appeal; say so rather than
+                                // implying it went live.
+                                val body = response.body()
+                                successMessage = if (body?.hidden == true) {
+                                    body.message
+                                        ?: "Your post did not pass automated review. It is hidden for now but you can appeal the decision."
+                                } else {
+                                    "Your post was shared successfully!"
+                                }
                                 showSuccessAlert = true
 
                             } catch (e: Exception) {

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/NewPostScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/NewPostScreen.kt
@@ -186,6 +186,14 @@ fun NewPostScreen(
                                     token = session.sessionToken,
                                     request = request
                                 )
+                                if (!response.isSuccessful) {
+                                    // A non-2xx (e.g. final classifier rejection)
+                                    // must not show a success dialog.
+                                    val raw = response.errorBody()?.string()
+                                    failureMessage = "Failed to share post: ${raw ?: "Please try again."}"
+                                    showFailureAlert = true
+                                    return@launch
+                                }
                                 // A post flagged by automated review is created
                                 // hidden pending appeal; say so rather than
                                 // implying it went live.

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/SettingsScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/SettingsScreen.kt
@@ -254,7 +254,13 @@ fun SettingsScreen(
             }
 
             HorizontalDivider()
-            
+
+            ListListItem(text = "Hidden Content & Appeals") {
+                navController.navigate(Screen.Appeals.route)
+            }
+
+            HorizontalDivider()
+
             ListListItem(text = "Logout", textColor = Color.Red) {
                 showingLogoutConfirm = true
             }

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/navigation/NavGraph.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/navigation/NavGraph.kt
@@ -114,5 +114,9 @@ fun NavGraph(
             val postId = backStackEntry.arguments?.getString("postId") ?: ""
             PostDetailScreen(navController, api, keychainHelper, postId)
         }
+
+        composable(Screen.Appeals.route) {
+            AppealsScreen(navController, api, keychainHelper)
+        }
     }
 }

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/navigation/Screen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/navigation/Screen.kt
@@ -21,4 +21,5 @@ sealed class Screen(val route: String) {
         fun createRoute(username: String) = "profile/$username"
     }
     object Settings : Screen("settings")
+    object Appeals : Screen("appeals")
 }

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/preview/PreviewHelpers.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/preview/PreviewHelpers.kt
@@ -419,6 +419,18 @@ class MockPositiveOnlySocialAPI : PositiveOnlySocialAPI {
             )
         )
     }
+
+    override suspend fun getHiddenPosts(token: String, batch: Int): Response<List<HiddenPost>> =
+        Response.success(emptyList())
+
+    override suspend fun getHiddenComments(token: String, batch: Int): Response<List<HiddenComment>> =
+        Response.success(emptyList())
+
+    override suspend fun getMyAppeals(token: String, batch: Int): Response<List<MyAppeal>> =
+        Response.success(emptyList())
+
+    override suspend fun submitAppeal(token: String, request: SubmitAppealRequest): Response<SubmitAppealResponse> =
+        Response.success(SubmitAppealResponse("preview-appeal"))
 }
 
 object PreviewHelpers {

--- a/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/AppealsViewModelTest.kt
+++ b/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/AppealsViewModelTest.kt
@@ -70,7 +70,7 @@ class AppealsViewModelTest {
     }
 
     @Test
-    fun `submitAppeal failure sets error and reports false`() = runTest {
+    fun `submitAppeal failure extracts the backend error message`() = runTest {
         val errorBody = "{\"error\":\"This item has already been appealed\"}"
             .toResponseBody("application/json".toMediaTypeOrNull())
         whenever(api.submitAppeal(any(), any())).thenReturn(Response.error(400, errorBody))
@@ -79,6 +79,7 @@ class AppealsViewModelTest {
         viewModel.submitAppeal("post", "p1", "again") { result = it }
 
         assertEquals(false, result)
-        assertNotNull(viewModel.errorMessage.value)
+        // The user sees the message, not the raw {"error": ...} JSON.
+        assertEquals("This item has already been appealed", viewModel.errorMessage.value)
     }
 }

--- a/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/AppealsViewModelTest.kt
+++ b/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/AppealsViewModelTest.kt
@@ -1,0 +1,84 @@
+package com.example.positiveonlysocial.models.viewmodels
+
+import com.example.positiveonlysocial.MainDispatcherRule
+import com.example.positiveonlysocial.api.PositiveOnlySocialAPI
+import com.example.positiveonlysocial.data.model.HiddenComment
+import com.example.positiveonlysocial.data.model.HiddenPost
+import com.example.positiveonlysocial.data.model.MyAppeal
+import com.example.positiveonlysocial.data.model.SubmitAppealResponse
+import com.example.positiveonlysocial.data.model.UserSession
+import com.example.positiveonlysocial.data.security.KeychainHelperProtocol
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import retrofit2.Response
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AppealsViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private lateinit var viewModel: AppealsViewModel
+    private lateinit var api: PositiveOnlySocialAPI
+    private lateinit var keychainHelper: KeychainHelperProtocol
+
+    private val session = UserSession("token123", "ada", "1", false, null, null)
+
+    @Before
+    fun setup() {
+        api = mock()
+        keychainHelper = mock()
+        whenever(keychainHelper.load(any<Class<UserSession>>(), any(), any())).thenReturn(session)
+        viewModel = AppealsViewModel(api, keychainHelper)
+    }
+
+    @Test
+    fun `load populates hidden content and clears loading`() = runTest {
+        val posts = listOf(HiddenPost("p1", "url", "a caption", "classifier", false))
+        whenever(api.getHiddenPosts("token123", 0)).thenReturn(Response.success(posts))
+        whenever(api.getHiddenComments("token123", 0)).thenReturn(Response.success(emptyList<HiddenComment>()))
+        whenever(api.getMyAppeals("token123", 0)).thenReturn(Response.success(emptyList<MyAppeal>()))
+
+        viewModel.load()
+
+        assertEquals(posts, viewModel.hiddenPosts.value)
+        assertFalse(viewModel.isLoading.value)
+    }
+
+    @Test
+    fun `submitAppeal success reloads and reports true`() = runTest {
+        whenever(api.getHiddenPosts(any(), any())).thenReturn(Response.success(emptyList<HiddenPost>()))
+        whenever(api.getHiddenComments(any(), any())).thenReturn(Response.success(emptyList<HiddenComment>()))
+        whenever(api.getMyAppeals(any(), any())).thenReturn(Response.success(emptyList<MyAppeal>()))
+        whenever(api.submitAppeal(any(), any())).thenReturn(Response.success(SubmitAppealResponse("a1")))
+
+        var result: Boolean? = null
+        viewModel.submitAppeal("post", "p1", "please reconsider") { result = it }
+
+        assertEquals(true, result)
+    }
+
+    @Test
+    fun `submitAppeal failure sets error and reports false`() = runTest {
+        val errorBody = "{\"error\":\"This item has already been appealed\"}"
+            .toResponseBody("application/json".toMediaTypeOrNull())
+        whenever(api.submitAppeal(any(), any())).thenReturn(Response.error(400, errorBody))
+
+        var result: Boolean? = null
+        viewModel.submitAppeal("post", "p1", "again") { result = it }
+
+        assertEquals(false, result)
+        assertNotNull(viewModel.errorMessage.value)
+    }
+}

--- a/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/AppealsViewModelTest.kt
+++ b/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/AppealsViewModelTest.kt
@@ -30,25 +30,25 @@ class AppealsViewModelTest {
     val mainDispatcherRule = MainDispatcherRule()
 
     private lateinit var viewModel: AppealsViewModel
-    private lateinit var api: PositiveOnlySocialAPI
+    private lateinit var mockApi: PositiveOnlySocialAPI
     private lateinit var keychainHelper: KeychainHelperProtocol
 
     private val session = UserSession("token123", "ada", "1", false, null, null)
 
     @Before
     fun setup() {
-        api = mock()
+        mockApi = mock()
         keychainHelper = mock()
         whenever(keychainHelper.load(any<Class<UserSession>>(), any(), any())).thenReturn(session)
-        viewModel = AppealsViewModel(api, keychainHelper)
+        viewModel = AppealsViewModel(mockApi, keychainHelper)
     }
 
     @Test
     fun `load populates hidden content and clears loading`() = runTest {
         val posts = listOf(HiddenPost("p1", "url", "a caption", "classifier", false))
-        whenever(api.getHiddenPosts("token123", 0)).thenReturn(Response.success(posts))
-        whenever(api.getHiddenComments("token123", 0)).thenReturn(Response.success(emptyList<HiddenComment>()))
-        whenever(api.getMyAppeals("token123", 0)).thenReturn(Response.success(emptyList<MyAppeal>()))
+        whenever(mockApi.getHiddenPosts("token123", 0)).thenReturn(Response.success(posts))
+        whenever(mockApi.getHiddenComments("token123", 0)).thenReturn(Response.success(emptyList<HiddenComment>()))
+        whenever(mockApi.getMyAppeals("token123", 0)).thenReturn(Response.success(emptyList<MyAppeal>()))
 
         viewModel.load()
 
@@ -58,10 +58,10 @@ class AppealsViewModelTest {
 
     @Test
     fun `submitAppeal success reloads and reports true`() = runTest {
-        whenever(api.getHiddenPosts(any(), any())).thenReturn(Response.success(emptyList<HiddenPost>()))
-        whenever(api.getHiddenComments(any(), any())).thenReturn(Response.success(emptyList<HiddenComment>()))
-        whenever(api.getMyAppeals(any(), any())).thenReturn(Response.success(emptyList<MyAppeal>()))
-        whenever(api.submitAppeal(any(), any())).thenReturn(Response.success(SubmitAppealResponse("a1")))
+        whenever(mockApi.getHiddenPosts(any(), any())).thenReturn(Response.success(emptyList<HiddenPost>()))
+        whenever(mockApi.getHiddenComments(any(), any())).thenReturn(Response.success(emptyList<HiddenComment>()))
+        whenever(mockApi.getMyAppeals(any(), any())).thenReturn(Response.success(emptyList<MyAppeal>()))
+        whenever(mockApi.submitAppeal(any(), any())).thenReturn(Response.success(SubmitAppealResponse("a1")))
 
         var result: Boolean? = null
         viewModel.submitAppeal("post", "p1", "please reconsider") { result = it }
@@ -73,7 +73,7 @@ class AppealsViewModelTest {
     fun `submitAppeal failure extracts the backend error message`() = runTest {
         val errorBody = "{\"error\":\"This item has already been appealed\"}"
             .toResponseBody("application/json".toMediaTypeOrNull())
-        whenever(api.submitAppeal(any(), any())).thenReturn(Response.error(400, errorBody))
+        whenever(mockApi.submitAppeal(any(), any())).thenReturn(Response.error(400, errorBody))
 
         var result: Boolean? = null
         viewModel.submitAppeal("post", "p1", "again") { result = it }


### PR DESCRIPTION
Chunk 9 of the appeals system for [issue #47](https://github.com/andrewkatson/pos/issues/47) — the **Android app**, completing the client work. Backend chunks 1–6 are on `main`. Independent of the web (chunk 7) and iOS (chunk 8) chunks.

## What changed

- **API layer** — `getHiddenPosts` / `getHiddenComments` / `getMyAppeals` / `submitAppeal` added to the Retrofit `PositiveOnlySocialAPI` interface and both implementations (`StatefulStubbedAPI`, the preview `MockPositiveOnlySocialAPI`). Models add `HiddenPost` / `HiddenComment` / `MyAppeal` / `SubmitAppeal` request+response; `CreatePostResponse` gains `hidden` / `hidden_reason` / `message`.
- **`AppealsScreen` + `AppealsViewModel` (+ Factory)** — lists the user's own hidden posts and comments with the hide reason and an **Appeal** button (one per item; already-appealed items show a status), plus the status of filed appeals. Reached from a new **Settings** row, routed at a new `Screen.Appeals` destination; a reason dialog drives submission. Ban appeals stay on the email flow, matching the backend.
- **`NewPostScreen`** — shows the "hidden pending appeal" message when a post is created hidden, instead of "shared successfully".

## Testing
- New `AppealsViewModelTest` (3 tests, Mockito): `load` populates hidden content; `submitAppeal` success reloads and reports true; `submitAppeal` failure sets the error and reports false.
- Ran locally with JDK 21 + Android SDK: `./gradlew :app:testDebugUnitTest` **BUILD SUCCESSFUL**, all main Compose sources compile, and the 3 new tests pass (0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)