### PR TITLE
Add explicit CodeQL workflow for all contributors

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,45 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '30 5 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: javascript-typescript
+            build-mode: none
+          - language: python
+            build-mode: none
+          - language: actions
+            build-mode: none
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{ matrix.language }}
+        build-mode: ${{ matrix.build-mode }}
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/codeql.yml` to replace the invisible GitHub Default Setup
- The explicit workflow triggers on `pull_request` to `main` (and `push` to `main` + weekly schedule), matching the same languages already configured: `javascript-typescript`, `python`, `actions`
- With Default Setup, CodeQL only reliably auto-ran for the repo owner; other admins/collaborators (especially those contributing via forks) were not triggering it automatically
- The explicit workflow makes this behavior transparent and consistent for all same-repo contributors

## Why this matters

The "Main" ruleset has a `code_scanning` rule requiring CodeQL to pass before merging. Without CodeQL actually running on admin PRs, that check either stayed pending or was bypassed via the Admin role bypass actor.

## Note on fork PRs

For contributors submitting PRs from **forks** (not same-repo branches), GitHub still requires a maintainer to approve the first Actions run — that's a GitHub platform security feature for public repos. To reduce friction for trusted fork contributors, go to **Settings → Actions → General → Fork pull request workflows** and set it to "Require approval for first-time contributors only."

## Note on admin bypass

The Main ruleset currently has `bypass_mode: always` for the Admin role. If you want admins to also be required to pass CodeQL (not just bypass it), update the ruleset in **Settings → Rules → Main** to remove or change the bypass actor.

## Test plan

- [ ] Merge this PR and open a test PR from another admin's account — verify CodeQL appears as a running check
- [ ] Confirm the `CodeQL` check shows up in the PR's status checks list (not just after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)