### PR TITLE
fix: trust unix-socket proxy in AdminIPAllowlistMiddleware

### DIFF
--- a/backend/pos_backend/middleware.py
+++ b/backend/pos_backend/middleware.py
@@ -15,9 +15,16 @@ def _get_trusted_proxies():
 
 def _client_ip(request):
     remote_addr = request.META.get("REMOTE_ADDR", "")
-    if remote_addr in _get_trusted_proxies():
-        # Request arrived through a known proxy (e.g. nginx on the same host).
-        # Trust the X-Real-IP header it set; fall back to REMOTE_ADDR if absent.
+    # A request can reach us through a trusted reverse proxy in two ways:
+    #   * Over a unix domain socket (nginx -> Gunicorn on the same host), where
+    #     Gunicorn reports an empty REMOTE_ADDR. Only a local process can open
+    #     that socket, and a direct TCP client always has a non-empty
+    #     REMOTE_ADDR, so an empty value cannot be forged by a remote client and
+    #     reliably identifies the local proxy.
+    #   * Over TCP from a proxy whose address is listed in TRUSTED_PROXY_IPS.
+    # In both cases the proxy sets X-Real-IP to the real client IP, so trust it,
+    # falling back to REMOTE_ADDR if the proxy didn't set the header.
+    if not remote_addr or remote_addr in _get_trusted_proxies():
         return request.META.get("HTTP_X_REAL_IP") or remote_addr
     return remote_addr
 

--- a/backend/pos_backend/middleware.py
+++ b/backend/pos_backend/middleware.py
@@ -17,14 +17,15 @@ def _client_ip(request):
     remote_addr = request.META.get("REMOTE_ADDR", "")
     # A request can reach us through a trusted reverse proxy in two ways:
     #   * Over a unix domain socket (nginx -> Gunicorn on the same host), where
-    #     Gunicorn reports an empty REMOTE_ADDR. Only a local process can open
-    #     that socket, and a direct TCP client always has a non-empty
-    #     REMOTE_ADDR, so an empty value cannot be forged by a remote client and
-    #     reliably identifies the local proxy.
+    #     Gunicorn reports REMOTE_ADDR as exactly "". Only a local process can
+    #     open that socket, and a direct TCP client always has a non-empty
+    #     REMOTE_ADDR, so an empty string cannot be forged by a remote client and
+    #     reliably identifies the local proxy. We match "" specifically rather
+    #     than any falsy value so a missing/malformed REMOTE_ADDR isn't trusted.
     #   * Over TCP from a proxy whose address is listed in TRUSTED_PROXY_IPS.
     # In both cases the proxy sets X-Real-IP to the real client IP, so trust it,
     # falling back to REMOTE_ADDR if the proxy didn't set the header.
-    if not remote_addr or remote_addr in _get_trusted_proxies():
+    if remote_addr == "" or remote_addr in _get_trusted_proxies():
         return request.META.get("HTTP_X_REAL_IP") or remote_addr
     return remote_addr
 

--- a/backend/tests/test_admin_middleware.py
+++ b/backend/tests/test_admin_middleware.py
@@ -152,3 +152,43 @@ def test_empty_trusted_proxy_ips_means_no_proxies_trusted():
     with patch.dict("os.environ", env, clear=False):
         with pytest.raises(Http404):
             middleware(request)
+
+
+# --- IP source: behind a unix-socket proxy (nginx -> Gunicorn, empty REMOTE_ADDR) ---
+
+def test_unix_socket_uses_x_real_ip():
+    """An empty REMOTE_ADDR (unix-socket proxy) trusts X-Real-IP without
+    needing TRUSTED_PROXY_IPS, since the empty value can't be forged remotely."""
+    middleware = make_middleware()
+    request = make_request("/admin/", remote_addr="", x_real_ip="10.0.0.1")
+    with patch.dict("os.environ", {"ADMIN_IP_ALLOWLIST": "10.0.0.1"}, clear=False):
+        response = middleware(request)
+    assert response.status_code == 200
+
+
+def test_unix_socket_unlisted_real_ip_blocked():
+    """A unix-socket request whose real client IP isn't allowlisted is blocked."""
+    middleware = make_middleware()
+    request = make_request("/admin/", remote_addr="", x_real_ip="9.9.9.9")
+    with patch.dict("os.environ", {"ADMIN_IP_ALLOWLIST": "10.0.0.1"}, clear=False):
+        with pytest.raises(Http404):
+            middleware(request)
+
+
+def test_unix_socket_without_x_real_ip_blocked():
+    """With no X-Real-IP, the empty REMOTE_ADDR falls back to '' and is never
+    in the allowlist, so the request is blocked rather than allowed."""
+    middleware = make_middleware()
+    request = make_request("/admin/", remote_addr="")
+    with patch.dict("os.environ", {"ADMIN_IP_ALLOWLIST": "10.0.0.1"}, clear=False):
+        with pytest.raises(Http404):
+            middleware(request)
+
+
+def test_unix_socket_x_forwarded_for_not_trusted():
+    """X-Forwarded-For must not grant access over a unix socket either."""
+    middleware = make_middleware()
+    request = make_request("/admin/", remote_addr="", spoofed_xff="10.0.0.1")
+    with patch.dict("os.environ", {"ADMIN_IP_ALLOWLIST": "10.0.0.1"}, clear=False):
+        with pytest.raises(Http404):
+            middleware(request)

--- a/backend/tests/test_admin_middleware.py
+++ b/backend/tests/test_admin_middleware.py
@@ -161,7 +161,7 @@ def test_unix_socket_uses_x_real_ip():
     needing TRUSTED_PROXY_IPS, since the empty value can't be forged remotely."""
     middleware = make_middleware()
     request = make_request("/admin/", remote_addr="", x_real_ip="10.0.0.1")
-    with patch.dict("os.environ", {"ADMIN_IP_ALLOWLIST": "10.0.0.1"}, clear=False):
+    with patch.dict("os.environ", {"ADMIN_IP_ALLOWLIST": "10.0.0.1"}, clear=True):
         response = middleware(request)
     assert response.status_code == 200
 
@@ -170,7 +170,7 @@ def test_unix_socket_unlisted_real_ip_blocked():
     """A unix-socket request whose real client IP isn't allowlisted is blocked."""
     middleware = make_middleware()
     request = make_request("/admin/", remote_addr="", x_real_ip="9.9.9.9")
-    with patch.dict("os.environ", {"ADMIN_IP_ALLOWLIST": "10.0.0.1"}, clear=False):
+    with patch.dict("os.environ", {"ADMIN_IP_ALLOWLIST": "10.0.0.1"}, clear=True):
         with pytest.raises(Http404):
             middleware(request)
 
@@ -180,7 +180,7 @@ def test_unix_socket_without_x_real_ip_blocked():
     in the allowlist, so the request is blocked rather than allowed."""
     middleware = make_middleware()
     request = make_request("/admin/", remote_addr="")
-    with patch.dict("os.environ", {"ADMIN_IP_ALLOWLIST": "10.0.0.1"}, clear=False):
+    with patch.dict("os.environ", {"ADMIN_IP_ALLOWLIST": "10.0.0.1"}, clear=True):
         with pytest.raises(Http404):
             middleware(request)
 
@@ -189,6 +189,6 @@ def test_unix_socket_x_forwarded_for_not_trusted():
     """X-Forwarded-For must not grant access over a unix socket either."""
     middleware = make_middleware()
     request = make_request("/admin/", remote_addr="", spoofed_xff="10.0.0.1")
-    with patch.dict("os.environ", {"ADMIN_IP_ALLOWLIST": "10.0.0.1"}, clear=False):
+    with patch.dict("os.environ", {"ADMIN_IP_ALLOWLIST": "10.0.0.1"}, clear=True):
         with pytest.raises(Http404):
             middleware(request)


### PR DESCRIPTION
## Problem

When nginx proxies to Gunicorn over a **unix domain socket** (the topology the deploy script `backend/tools/setup-django.sh` provisions), Gunicorn reports an **empty `REMOTE_ADDR`**. The admin IP allowlist's proxy-trust logic only honored `X-Real-IP` when `REMOTE_ADDR` was in `TRUSTED_PROXY_IPS` — but `_get_trusted_proxies()` filters out empty strings, so an empty `REMOTE_ADDR` could never be trusted.

The result: `_client_ip()` always returned `""`, which is never in `ADMIN_IP_ALLOWLIST`, so **every `/admin/` request was rejected with a 404 no matter how the env vars were set.** The middleware effectively assumed a TCP proxy with a real loopback `REMOTE_ADDR`, which doesn't match the unix-socket deployment.

This was diagnosed in production: `/user_index/` worked, `resolve('/admin/')` matched the route (middleware is bypassed by `resolve`), but requests through both nginx and the socket returned Django's `Http404`. The Gunicorn access log showed an empty host field, confirming the empty `REMOTE_ADDR`.

## Fix

Treat an empty `REMOTE_ADDR` as a trusted local proxy and consult `X-Real-IP`:

- Only a local process can open the unix socket, and a direct TCP client **always** has a non-empty `REMOTE_ADDR`, so an empty value cannot be forged by a remote client — it reliably identifies the local nginx proxy.
- TCP proxies are unchanged: their address must still be listed in `TRUSTED_PROXY_IPS`.
- Default-deny is preserved: with no `X-Real-IP`, the client IP falls back to `""`, which is never in the allowlist.

## Tests

Added 4 cases to `backend/tests/test_admin_middleware.py` covering the unix-socket path (empty `REMOTE_ADDR`): allowed via `X-Real-IP`, blocked when the real IP isn't listed, blocked when `X-Real-IP` is absent, and `X-Forwarded-For` still not trusted. All 18 middleware tests pass.

## Deploy note

After merging, `ADMIN_IP_ALLOWLIST` must be set in the backend `.env` to the operator's public IP(s) for `/admin/` to be reachable. `TRUSTED_PROXY_IPS` is no longer required for the unix-socket deployment (still needed if switching to a TCP proxy). Note the allowlist is exact-match (no CIDR ranges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)