### PR TITLE
iOS: reorganize file references, bump version to 1.03, update Kingfisher

### DIFF
--- a/ios/Positive Only Social/Positive Only Social.xcodeproj/project.pbxproj
+++ b/ios/Positive Only Social/Positive Only Social.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 				api/Networking.swift,
 				api/RealAPI.swift,
 				api/StatefulStubbedAPI.swift,
+				AppealsView.swift,
 				AuthRequirements.swift,
 				CharacterCounter.swift,
 				FeedView.swift,
@@ -77,13 +78,12 @@
 				state/AuthenticationManager.swift,
 				uploader/AWSManager.swift,
 				VerifyResetView.swift,
+				viewmodels/AppealsViewModel.swift,
 				viewmodels/FeedViewModel.swift,
 				viewmodels/FollowingFeedViewModel.swift,
 				viewmodels/HomeViewModel.swift,
 				viewmodels/PostDetailViewModel.swift,
 				viewmodels/ProfileViewModel.swift,
-				AppealsView.swift,
-				viewmodels/AppealsViewModel.swift,
 				viewmodels/SettingsViewModel.swift,
 			);
 			target = 248836DF2E6282C5002D47F1 /* Positive Only SocialTests */;
@@ -97,6 +97,7 @@
 				api/Networking.swift,
 				api/RealAPI.swift,
 				api/StatefulStubbedAPI.swift,
+				AppealsView.swift,
 				AuthRequirements.swift,
 				CharacterCounter.swift,
 				FeedView.swift,
@@ -116,13 +117,12 @@
 				state/AuthenticationManager.swift,
 				uploader/AWSManager.swift,
 				VerifyResetView.swift,
+				viewmodels/AppealsViewModel.swift,
 				viewmodels/FeedViewModel.swift,
 				viewmodels/FollowingFeedViewModel.swift,
 				viewmodels/HomeViewModel.swift,
 				viewmodels/PostDetailViewModel.swift,
 				viewmodels/ProfileViewModel.swift,
-				AppealsView.swift,
-				viewmodels/AppealsViewModel.swift,
 				viewmodels/SettingsViewModel.swift,
 			);
 			target = 248836E92E6282C5002D47F1 /* Positive Only SocialUITests */;
@@ -542,11 +542,11 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 7L9M852R4K;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_CFBundleDisplayName = "Good Vibes Only";
+				INFOPLIST_KEY_CFBundleDisplayName = Vibes;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.social-networking";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -557,7 +557,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.01;
+				MARKETING_VERSION = 1.03;
 				PRODUCT_BUNDLE_IDENTIFIER = com.katsonsoftware.goodvibesonly;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -572,11 +572,11 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 7L9M852R4K;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_CFBundleDisplayName = "Good Vibes Only";
+				INFOPLIST_KEY_CFBundleDisplayName = Vibes;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.social-networking";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -587,7 +587,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.01;
+				MARKETING_VERSION = 1.03;
 				PRODUCT_BUNDLE_IDENTIFIER = com.katsonsoftware.goodvibesonly;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/ios/Positive Only Social/Positive Only Social.xcodeproj/project.pbxproj
+++ b/ios/Positive Only Social/Positive Only Social.xcodeproj/project.pbxproj
@@ -725,7 +725,7 @@
 			repositoryURL = "https://github.com/onevcat/Kingfisher.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 8.9.0;
+				minimumVersion = 8.10.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ios/Positive Only Social/Positive Only Social.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Positive Only Social/Positive Only Social.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/onevcat/Kingfisher.git",
       "state" : {
-        "revision" : "cf8be20d07654570554c8a8a4952bc8a5766a8b0",
-        "version" : "8.9.0"
+        "revision" : "ac632bd26a1c00f139ff62fd01806f21cf67325e",
+        "version" : "8.10.0"
       }
     },
     {


### PR DESCRIPTION
## Summary
- Move `AppealsView.swift` and `AppealsViewModel.swift` to alphabetically correct positions in test target file lists in `project.pbxproj`
- Bump `MARKETING_VERSION` 1.01 → 1.03 and `CURRENT_PROJECT_VERSION` 3 → 1
- Rename app display name from "Good Vibes Only" → "Vibes"
- Update Kingfisher Swift package dependency 8.9.0 → 8.10.0

## Test plan
- [ ] Build succeeds on iOS simulator
- [ ] App display name shows "Vibes" on home screen
- [ ] Version number reflects 1.03

🤖 Generated with [Claude Code](https://claude.com/claude-code)