### PR TITLE
Fix profile follow button, vertical grid, and self-follow/block

### DIFF
--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/ProfileViewModel.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/ProfileViewModel.kt
@@ -66,6 +66,10 @@ class ProfileViewModel(
                 val userSession = keychainHelper.load(UserSession::class.java, service, account)
                 if (userSession == null) {
                     Log.e(TAG, "No active session found — cannot fetch profile")
+                    // Fail safe: without a session we can't claim this is the
+                    // user's own profile, so don't leave a stale `true` that would
+                    // wrongly hide Follow/Block on someone else's profile.
+                    _isOwnProfile.value = false
                     return@launch
                 }
 

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/ProfileViewModel.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/ProfileViewModel.kt
@@ -43,6 +43,9 @@ class ProfileViewModel(
     private val _isRefreshing = MutableStateFlow(false)
     val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
 
+    private val _isOwnProfile = MutableStateFlow(false)
+    val isOwnProfile: StateFlow<Boolean> = _isOwnProfile.asStateFlow()
+
     private val service = "positive-only-social.Positive-Only-Social"
 
     // Pagination state
@@ -65,6 +68,8 @@ class ProfileViewModel(
                     Log.e(TAG, "No active session found — cannot fetch profile")
                     return@launch
                 }
+
+                _isOwnProfile.value = (userSession.username == username)
 
                 // Fetch Profile Details
                 val profileResponse = api.getProfileDetails(userSession.sessionToken, username)

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/ProfileScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/ProfileScreen.kt
@@ -49,6 +49,7 @@ fun ProfileScreen(
         val isFollowing by viewModel.isFollowing.collectAsState()
         val isLoading by viewModel.isLoading.collectAsState()
         val isRefreshing by viewModel.isRefreshing.collectAsState()
+        val isOwnProfile by viewModel.isOwnProfile.collectAsState()
 
         LaunchedEffect(Unit) {
             if (userPosts.isEmpty()) {
@@ -88,30 +89,32 @@ fun ProfileScreen(
                 }
                 
                 Spacer(modifier = Modifier.height(16.dp))
-                
-                Button(
-                    onClick = { viewModel.toggleFollow(username) },
-                    modifier = Modifier.fillMaxWidth(),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = if (isFollowing) MaterialTheme.colorScheme.secondary else MaterialTheme.colorScheme.primary
-                    )
-                ) {
-                    Text(if (isFollowing) "Following" else "Follow")
-                }
-                
-                Spacer(modifier = Modifier.height(8.dp))
-                
-                val isBlocked by viewModel.isBlocked.collectAsState()
-                
-                Button(
-                    onClick = { viewModel.toggleBlock(username) },
-                    modifier = Modifier.fillMaxWidth(),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = if (isBlocked) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.surfaceVariant,
-                        contentColor = if (isBlocked) MaterialTheme.colorScheme.onError else MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                ) {
-                    Text(if (isBlocked) "Unblock" else "Block")
+
+                if (!isOwnProfile) {
+                    Button(
+                        onClick = { viewModel.toggleFollow(username) },
+                        modifier = Modifier.fillMaxWidth(),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = if (isFollowing) MaterialTheme.colorScheme.secondary else MaterialTheme.colorScheme.primary
+                        )
+                    ) {
+                        Text(if (isFollowing) "Following" else "Follow")
+                    }
+
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    val isBlocked by viewModel.isBlocked.collectAsState()
+
+                    Button(
+                        onClick = { viewModel.toggleBlock(username) },
+                        modifier = Modifier.fillMaxWidth(),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = if (isBlocked) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.surfaceVariant,
+                            contentColor = if (isBlocked) MaterialTheme.colorScheme.onError else MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    ) {
+                        Text(if (isBlocked) "Unblock" else "Block")
+                    }
                 }
             }
             

--- a/ios/Positive Only Social/Positive Only Social/ProfileView.swift
+++ b/ios/Positive Only Social/Positive Only Social/ProfileView.swift
@@ -68,10 +68,13 @@ struct ProfileView: View {
             if viewModel.userPosts.isEmpty {
                 viewModel.fetchUserPosts()
             }
-            
+
             if viewModel.profileDetails == nil {
                 viewModel.fetchProfileDetails()
             }
+        }
+        .navigationDestination(for: Post.self) { post in
+            PostDetailView(postIdentifier: post.id, api: api, keychainHelper: keychainHelper)
         }
     }
     
@@ -91,38 +94,40 @@ struct ProfileView: View {
             }
             .padding(.top)
             
-            Button(action: viewModel.toggleFollow) {
-                Text(viewModel.isFollowing ? "Following" : "Follow")
-                    .fontWeight(.semibold)
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 8)
-                    .background(viewModel.isFollowing ? Color.clear : Color.blue)
-                    .foregroundColor(viewModel.isFollowing ? .primary : .white)
-                    .cornerRadius(8)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 8)
-                            .stroke(viewModel.isFollowing ? Color.gray : Color.blue, lineWidth: 1)
-                    )
+            if !viewModel.isOwnProfile {
+                Button(action: viewModel.toggleFollow) {
+                    Text(viewModel.isFollowing ? "Following" : "Follow")
+                        .fontWeight(.semibold)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 8)
+                        .background(viewModel.isFollowing ? Color.clear : Color.blue)
+                        .foregroundColor(viewModel.isFollowing ? .primary : .white)
+                        .cornerRadius(8)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8)
+                                .stroke(viewModel.isFollowing ? Color.gray : Color.blue, lineWidth: 1)
+                        )
+                }
+                .disabled(viewModel.isLoadingProfile || viewModel.isBusy)
+                .padding(.vertical)
+                .accessibilityIdentifier("FollowButton")
+
+                Button(action: viewModel.toggleBlock) {
+                    Text(viewModel.isBlocked ? "Unblock" : "Block")
+                        .fontWeight(.medium)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 8)
+                        .foregroundColor(viewModel.isBlocked ? .white : .red)
+                        .background(viewModel.isBlocked ? Color.red : Color.clear)
+                        .cornerRadius(8)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8)
+                                .stroke(Color.red, lineWidth: 1)
+                        )
+                }
+                .disabled(viewModel.isLoadingProfile || viewModel.isBusy)
+                .padding(.bottom)
             }
-            .disabled(viewModel.isLoadingProfile) // Disable while loading
-            .padding(.vertical)
-            .accessibilityIdentifier("FollowButton")
-            
-            Button(action: viewModel.toggleBlock) {
-                Text(viewModel.isBlocked ? "Unblock" : "Block")
-                    .fontWeight(.medium)
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 8)
-                    .foregroundColor(viewModel.isBlocked ? .white : .red)
-                    .background(viewModel.isBlocked ? Color.red : Color.clear)
-                    .cornerRadius(8)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 8)
-                            .stroke(Color.red, lineWidth: 1)
-                    )
-            }
-            .disabled(viewModel.isLoadingProfile)
-            .padding(.bottom)
         }
     }
     
@@ -143,7 +148,7 @@ struct ProfileView: View {
             LazyVGrid(columns: columns, spacing: 1) {
                 ForEach(viewModel.userPosts) { post in
                     // Wrap each cell in a NavigationLink so tapping a post opens
-                    // its detail view (matches Home/Feed and the destination below).
+                    // its detail view (destination registered on the ScrollView).
                     NavigationLink(value: post) {
                         // Force every post into an identical square, cropping to fill
                         // so images no longer keep their original dimensions.
@@ -165,8 +170,6 @@ struct ProfileView: View {
                         }
                     }
                     .accessibilityIdentifier("ProfilePostImage")
-                }.navigationDestination(for: Post.self) { post in
-                    PostDetailView(postIdentifier: post.id, api: api, keychainHelper: keychainHelper)
                 }
             }
             // Black backing shows through the 1pt gaps as thin borders between posts.

--- a/ios/Positive Only Social/Positive Only Social/viewmodels/ProfileViewModel.swift
+++ b/ios/Positive Only Social/Positive Only Social/viewmodels/ProfileViewModel.swift
@@ -16,28 +16,36 @@ class ProfileViewModel: ObservableObject {
     @Published var isLoading = false
     @Published private(set) var canLoadMore = true
     @Published var profileDetails: ProfileDetailsResponse?
-    @Published var isLoadingProfile = false // For the button
+    @Published var isLoadingProfile = false
+    @Published var isBusy = false // For follow/block button actions
     @Published var isFollowing = false
     @Published var isBlocked = false
-    
+
     // Private state for pagination and API
     private var batch = 0
     private let api: Networking
     private let keychainHelper: KeychainHelperProtocol
     private let account: String
     private let keychainService = GVOAppConstants.keychainService
-    
+
     let user: User // The user this profile is for
+    // The logged-in user's username, loaded once at init for own-profile detection.
+    private let currentLoggedInUsername: String?
+
+    var isOwnProfile: Bool {
+        user.username == (currentLoggedInUsername ?? "")
+    }
 
     convenience init(user: User, api: Networking, keychainHelper: KeychainHelperProtocol) {
         self.init(user: user, api: api, keychainHelper: keychainHelper, account: "userSessionToken")
     }
-    
+
     init(user: User, api: Networking, keychainHelper: KeychainHelperProtocol, account: String) {
         self.user = user
         self.api = api
         self.keychainHelper = keychainHelper
         self.account = account
+        self.currentLoggedInUsername = try? keychainHelper.load(UserSession.self, from: GVOAppConstants.keychainService, account: account)?.username
     }
     
     /// Fetches the next batch of posts for the current user.
@@ -162,93 +170,90 @@ class ProfileViewModel: ObservableObject {
     }
     
     func toggleFollow() {
-        guard !isLoadingProfile else { return } // Use same loader
-        isLoadingProfile = true
-            
+        guard !isBusy else { return }
+        isBusy = true
+
+        // Optimistic update: change UI immediately, revert on error.
+        let wasFollowing = isFollowing
+        isFollowing = !wasFollowing
+        if wasFollowing {
+            profileDetails?.followerCount = max(0, (profileDetails?.followerCount ?? 1) - 1)
+        } else {
+            profileDetails?.followerCount += 1
+        }
+
         Task {
             do {
                 guard let userSession = try keychainHelper.load(UserSession.self, from: keychainService, account: account) else {
                     NSLog("%@", "No active session — cannot toggle follow")
-                    isLoadingProfile = false
+                    revertFollow(wasFollowing: wasFollowing)
+                    isBusy = false
                     return
                 }
                 let token = userSession.sessionToken
 
-                if isFollowing {
-                    // --- Unfollow Logic ---
+                if wasFollowing {
                     let _ = try await api.unfollowUser(sessionManagementToken: token, username: user.username)
-                    
-                    // Update local state directly
-                    self.isFollowing = false
-                    if self.profileDetails != nil {
-                        self.profileDetails?.followerCount -= 1
-                    }
-                    
                 } else {
-                    // --- Follow Logic ---
                     let _ = try await api.followUser(sessionManagementToken: token, username: user.username)
-                    
-                    // Update local state directly
-                    self.isFollowing = true
-                    if self.profileDetails != nil {
-                        self.profileDetails?.followerCount += 1
-                    }
                 }
             } catch {
                 NSLog("%@", "Error toggling follow: \(error)")
-                // Handle error (e.g., show alert)
-                // Since we update the UI *after* the await, we don't need to
-                // manually roll back the change if the API call fails.
+                revertFollow(wasFollowing: wasFollowing)
             }
-            isLoadingProfile = false
+            isBusy = false
+        }
+    }
+
+    private func revertFollow(wasFollowing: Bool) {
+        isFollowing = wasFollowing
+        if wasFollowing {
+            profileDetails?.followerCount += 1
+        } else {
+            profileDetails?.followerCount = max(0, (profileDetails?.followerCount ?? 1) - 1)
         }
     }
 
     func toggleBlock() {
-        // Toggle block status
-        guard !isLoadingProfile else { return }
-        isLoadingProfile = true
-        
+        guard !isBusy else { return }
+        isBusy = true
+
         let previousBlockState = isBlocked
         let previousFollowState = isFollowing
+
         // Optimistic update
         isBlocked.toggle()
-
-        // Blocking also unfollows in our backend logic, so mirror that here.
-        // Only decrement the follower count if we were actually following,
-        // otherwise the count drifts (e.g. follow -> block -> follow would
-        // count the same follow twice).
+        // Blocking also unfollows on the backend; mirror that locally.
         if isBlocked && isFollowing {
             isFollowing = false
-            if self.profileDetails != nil {
-                self.profileDetails?.followerCount -= 1
-            }
+            profileDetails?.followerCount = max(0, (profileDetails?.followerCount ?? 1) - 1)
         }
 
         Task {
             do {
                 guard let userSession = try keychainHelper.load(UserSession.self, from: keychainService, account: account) else {
                     NSLog("%@", "No active session — cannot toggle block")
-                    isLoadingProfile = false
+                    revertBlock(previousBlockState: previousBlockState, previousFollowState: previousFollowState)
+                    isBusy = false
                     return
                 }
                 let token = userSession.sessionToken
 
                 let _ = try await api.toggleBlock(sessionManagementToken: token, username: user.username)
-                
-                // Success, state already updated.
             } catch {
                 NSLog("%@", "Error toggling block: \(error)")
-                // Revert on error, including the optimistic unfollow side-effect.
-                if isBlocked && !previousBlockState && previousFollowState {
-                    isFollowing = previousFollowState
-                    if self.profileDetails != nil {
-                        self.profileDetails?.followerCount += 1
-                    }
-                }
-                isBlocked = previousBlockState
+                revertBlock(previousBlockState: previousBlockState, previousFollowState: previousFollowState)
             }
-            isLoadingProfile = false
+            isBusy = false
+        }
+    }
+
+    private func revertBlock(previousBlockState: Bool, previousFollowState: Bool) {
+        isBlocked = previousBlockState
+        // Only restore the follow state if we had optimistically unfollowed (i.e. we were blocking).
+        if !previousBlockState && previousFollowState {
+            isFollowing = previousFollowState
+            profileDetails?.followerCount += 1
         }
     }
 }

--- a/ios/Positive Only Social/Positive Only Social/viewmodels/ProfileViewModel.swift
+++ b/ios/Positive Only Social/Positive Only Social/viewmodels/ProfileViewModel.swift
@@ -223,7 +223,6 @@ class ProfileViewModel: ObservableObject {
         let previousBlockState = isBlocked
         let previousFollowState = isFollowing
 
-        // Optimistic update
         isBlocked.toggle()
         // Blocking also unfollows on the backend; mirror that locally.
         if isBlocked && isFollowing {

--- a/ios/Positive Only Social/Positive Only Social/viewmodels/ProfileViewModel.swift
+++ b/ios/Positive Only Social/Positive Only Social/viewmodels/ProfileViewModel.swift
@@ -169,6 +169,16 @@ class ProfileViewModel: ObservableObject {
         }
     }
     
+    /// Adjusts the follower count by `delta`, clamped at zero. Copies the struct
+    /// and reassigns rather than mutating `profileDetails?.followerCount` in place,
+    /// so we never read and write `profileDetails` in the same expression (which
+    /// Swift rejects as an exclusive-access violation).
+    private func adjustFollowerCount(by delta: Int) {
+        guard var details = profileDetails else { return }
+        details.followerCount = max(0, details.followerCount + delta)
+        profileDetails = details
+    }
+
     func toggleFollow() {
         guard !isBusy else { return }
         isBusy = true
@@ -176,11 +186,7 @@ class ProfileViewModel: ObservableObject {
         // Optimistic update: change UI immediately, revert on error.
         let wasFollowing = isFollowing
         isFollowing = !wasFollowing
-        if wasFollowing {
-            profileDetails?.followerCount = max(0, (profileDetails?.followerCount ?? 1) - 1)
-        } else {
-            profileDetails?.followerCount += 1
-        }
+        adjustFollowerCount(by: wasFollowing ? -1 : 1)
 
         Task {
             do {
@@ -207,11 +213,7 @@ class ProfileViewModel: ObservableObject {
 
     private func revertFollow(wasFollowing: Bool) {
         isFollowing = wasFollowing
-        if wasFollowing {
-            profileDetails?.followerCount += 1
-        } else {
-            profileDetails?.followerCount = max(0, (profileDetails?.followerCount ?? 1) - 1)
-        }
+        adjustFollowerCount(by: wasFollowing ? 1 : -1)
     }
 
     func toggleBlock() {
@@ -226,7 +228,7 @@ class ProfileViewModel: ObservableObject {
         // Blocking also unfollows on the backend; mirror that locally.
         if isBlocked && isFollowing {
             isFollowing = false
-            profileDetails?.followerCount = max(0, (profileDetails?.followerCount ?? 1) - 1)
+            adjustFollowerCount(by: -1)
         }
 
         Task {
@@ -253,7 +255,7 @@ class ProfileViewModel: ObservableObject {
         // Only restore the follow state if we had optimistically unfollowed (i.e. we were blocking).
         if !previousBlockState && previousFollowState {
             isFollowing = previousFollowState
-            profileDetails?.followerCount += 1
+            adjustFollowerCount(by: 1)
         }
     }
 }

--- a/website/src/pages/ProfilePage.tsx
+++ b/website/src/pages/ProfilePage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Navigate, useNavigate, useParams } from 'react-router-dom'
 import { apiClient } from '../api/client'
+import { getCurrentUsername } from '../api/session'
 import type { FeedPost, ProfileDetails } from '../api/types'
 import './MainApp.css'
 
@@ -22,6 +23,7 @@ function ProfilePage() {
 
 function ProfileView({ username }: { username: string }) {
   const navigate = useNavigate()
+  const isOwnProfile = getCurrentUsername() === username
 
   // Track mount state so async loads that resolve after navigating away don't
   // set state on an unmounted view.
@@ -187,24 +189,26 @@ function ProfileView({ username }: { username: string }) {
             </div>
           </div>
 
-          <div className="profile-actions">
-            <button
-              type="button"
-              className={`btn ${isFollowing ? 'btn-outline' : 'btn-primary'}`}
-              disabled={isBusy}
-              onClick={toggleFollow}
-            >
-              {isFollowing ? 'Following' : 'Follow'}
-            </button>
-            <button
-              type="button"
-              className={`btn ${isBlocked ? 'btn-danger--filled' : 'btn-danger'}`}
-              disabled={isBusy}
-              onClick={toggleBlock}
-            >
-              {isBlocked ? 'Unblock' : 'Block'}
-            </button>
-          </div>
+          {!isOwnProfile && (
+            <div className="profile-actions">
+              <button
+                type="button"
+                className={`btn ${isFollowing ? 'btn-outline' : 'btn-primary'}`}
+                disabled={isBusy}
+                onClick={toggleFollow}
+              >
+                {isFollowing ? 'Following' : 'Follow'}
+              </button>
+              <button
+                type="button"
+                className={`btn ${isBlocked ? 'btn-danger--filled' : 'btn-danger'}`}
+                disabled={isBusy}
+                onClick={toggleBlock}
+              >
+                {isBlocked ? 'Unblock' : 'Block'}
+              </button>
+            </div>
+          )}
         </div>
 
         <button


### PR DESCRIPTION
Fixes three release-blocking profile issues. All three were confirmed in the iOS `ProfileView`; #262 also affected Android and Web, which are addressed here too.

## #259 — Follow button not working (iOS)
[Issue](https://github.com/andrewkatson/pos/issues/259): tapping Follow did nothing, even locally.

`toggleFollow` only updated the UI *after* the network call resolved, so a slow or locally-failing call produced no visible change. Rewrote it with **optimistic updates** (flip immediately, revert on error) — the same pattern Android already used. Also split out a dedicated `isBusy` flag for the follow/block actions so the button is no longer disabled by `isLoadingProfile` (which is owned by the initial profile fetch). Applied the same `isBusy` + extracted-revert cleanup to `toggleBlock`, including reverting optimistic state when there's no active session.

## #258 — Profile images show vertically (iOS)
[Issue](https://github.com/andrewkatson/pos/issues/258): posts stacked in a column instead of the 3-column grid.

`.navigationDestination(for: Post.self)` was attached to the `ForEach` *inside* the `LazyVGrid`, which broke the lazy grid's cell measurement and collapsed it to a vertical stack. Moved the destination up to the `ScrollView`, matching `HomeView`.

## #262 — Should not be able to follow/block yourself (iOS / Android / Web)
[Issue](https://github.com/andrewkatson/pos/issues/262): own profile showed Follow/Block.

- **iOS**: VM loads the logged-in username from the keychain at init, exposes computed `isOwnProfile`; buttons wrapped in `if !viewModel.isOwnProfile`.
- **Android**: new `isOwnProfile` `StateFlow` set in `fetchProfile` once the session loads; `ProfileScreen` gates both buttons on it.
- **Web**: `getCurrentUsername() === username` (helper already used by `PostDetailPage`) gates the `profile-actions` block.

## Notes for reviewers
- #258 and #259 are iOS-only — Android (`LazyVerticalGrid`) and Web (CSS grid) layouts were already correct, and Android already did optimistic follow updates.
- Existing `ProfileViewModel` tests still target `toggleFollow`/`toggleBlock` behavior and follower-count consistency; the optimistic rewrite preserves those final states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)