### PR TITLE
Fix Remember Me persistence on Android and website

### DIFF
--- a/android/PositiveOnlySocial/app/src/androidTest/java/com/example/positiveonlysocial/PositiveOnlySocialIntegrationTests.kt
+++ b/android/PositiveOnlySocial/app/src/androidTest/java/com/example/positiveonlysocial/PositiveOnlySocialIntegrationTests.kt
@@ -4,6 +4,8 @@ import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.espresso.Espresso
+import com.example.positiveonlysocial.di.DependencyProvider
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -14,6 +16,17 @@ class PositiveOnlySocialIntegrationTests {
 
     @get:Rule
     val composeTestRule = createAndroidComposeRule<MainActivity>()
+
+    // "Remember Me" logins now persist tokens to the keychain, and these tests
+    // share one process, so a prior test's session could auto-log-in on the next
+    // test's launch and skip the Welcome screen. Clear it so every test starts
+    // from a clean, signed-out state.
+    @Before
+    fun clearPersistedAuth() {
+        val keychain = DependencyProvider.keychainHelper
+        keychain.delete("positive-only-social.Positive-Only-Social", "userRememberMeTokens")
+        keychain.delete("positive-only-social.Positive-Only-Social", "userSessionToken")
+    }
 
     private val testUsername = "test_user_${UUID.randomUUID().toString().take(5)}"
     private val otherTestUsername = "other_user_${UUID.randomUUID().toString().take(5)}"

--- a/android/PositiveOnlySocial/app/src/androidTest/java/com/example/positiveonlysocial/RememberMeLoginTest.kt
+++ b/android/PositiveOnlySocial/app/src/androidTest/java/com/example/positiveonlysocial/RememberMeLoginTest.kt
@@ -146,7 +146,9 @@ class RememberMeLoginTest {
 
         composeTestRule.onNodeWithText("Username or Email").performTextInput(username)
         composeTestRule.onNodeWithText("Password").performTextInput(password)
-        composeTestRule.onNodeWithText("Remember Me").performClick()
+        // Flip the actual switch, not the "Remember Me" label next to it — the
+        // label is a plain sibling and clicking it leaves remember-me off.
+        composeTestRule.onNodeWithTag("RememberMeToggle").performClick()
 
         composeTestRule.onNodeWithText("Login").performClick()
         assertOnHomeView()

--- a/android/PositiveOnlySocial/app/src/androidTest/java/com/example/positiveonlysocial/RememberMeLoginTest.kt
+++ b/android/PositiveOnlySocial/app/src/androidTest/java/com/example/positiveonlysocial/RememberMeLoginTest.kt
@@ -1,11 +1,7 @@
 package com.example.positiveonlysocial
 
-import androidx.compose.ui.test.assertExists
+import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
-import androidx.compose.ui.test.onAllNodesWithText
-import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.performTextInput
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.example.positiveonlysocial.di.DependencyProvider

--- a/android/PositiveOnlySocial/app/src/androidTest/java/com/example/positiveonlysocial/RememberMeLoginTest.kt
+++ b/android/PositiveOnlySocial/app/src/androidTest/java/com/example/positiveonlysocial/RememberMeLoginTest.kt
@@ -1,0 +1,158 @@
+package com.example.positiveonlysocial
+
+import androidx.compose.ui.test.assertExists
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.example.positiveonlysocial.di.DependencyProvider
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.UUID
+
+/**
+ * Android counterpart to the iOS `testAutomaticLoginAfterRememberMe` UI test
+ * (Positive Only SocialUITests). After logging in with "Remember Me" on, killing
+ * and relaunching the app should land the user straight on Home without
+ * re-entering credentials — the WelcomeScreen reads the persisted Remember Me
+ * tokens and silently refreshes the session.
+ *
+ * Uses [createEmptyComposeRule] (instead of `createAndroidComposeRule`) so the
+ * test owns the [ActivityScenario] lifecycle and can launch a genuinely fresh
+ * Activity for the "relaunch". Recreating the existing Activity would restore the
+ * saved Navigation back stack straight to Home and never exercise the auto-login.
+ */
+@RunWith(AndroidJUnit4::class)
+class RememberMeLoginTest {
+
+    @get:Rule
+    val composeTestRule = createEmptyComposeRule()
+
+    private val testUsername = "remember_user_${UUID.randomUUID().toString().take(5)}"
+    private val strongPassword = "StrongPassword123@"
+
+    // Matches the identifiers used by WelcomeScreen / AuthenticationManager.
+    private val keychainService = "positive-only-social.Positive-Only-Social"
+    private val rememberMeAccount = "userRememberMeTokens"
+    private val sessionAccount = "userSessionToken"
+
+    private var scenario: ActivityScenario<MainActivity>? = null
+
+    @Before
+    fun clearPersistedAuth() = clearKeychain()
+
+    @After
+    fun tearDown() {
+        scenario?.close()
+        // Don't leak a logged-in session into other tests running in this process.
+        clearKeychain()
+    }
+
+    private fun clearKeychain() {
+        val keychain = DependencyProvider.keychainHelper
+        keychain.delete(keychainService, rememberMeAccount)
+        keychain.delete(keychainService, sessionAccount)
+    }
+
+    @Test
+    fun testAutomaticLoginAfterRememberMe() {
+        // First launch: register, log out, then log back in with Remember Me on.
+        scenario = ActivityScenario.launch(MainActivity::class.java)
+
+        registerUser(testUsername, strongPassword)
+        logoutUserFromHome()
+        loginWithRememberMe(testUsername, strongPassword)
+        assertOnHomeView()
+
+        // Simulate killing and relaunching the app: a brand-new Activity with no
+        // saved navigation state starts at the Welcome screen, whose auto-login
+        // reads the persisted Remember Me tokens and signs us straight in.
+        scenario?.close()
+        scenario = ActivityScenario.launch(MainActivity::class.java)
+
+        // If the tokens were not persisted at login we'd be stuck on the Welcome
+        // screen, so waiting for the Home tabs proves the auto-login happened.
+        composeTestRule.waitUntil(timeoutMillis = 10_000) {
+            composeTestRule.onAllNodesWithText("Settings").fetchSemanticsNodes().isNotEmpty()
+        }
+        assertOnHomeView()
+    }
+
+    // MARK: Helpers (mirrored from PositiveOnlySocialIntegrationTests)
+
+    private fun assertOnRegisterView() {
+        composeTestRule.onNodeWithText("Create Account").assertExists()
+        composeTestRule.onNodeWithText("Username").assertExists()
+        composeTestRule.onNodeWithText("Email").assertExists()
+        composeTestRule.onNodeWithText("Password").assertExists()
+        composeTestRule.onNodeWithText("Confirm Password").assertExists()
+        composeTestRule.onNodeWithText("Register").assertExists()
+    }
+
+    private fun assertOnLoginView() {
+        composeTestRule.onNodeWithText("Username or Email").assertExists()
+        composeTestRule.onNodeWithText("Password").assertExists()
+        composeTestRule.onNodeWithText("Login").assertExists()
+        composeTestRule.onNodeWithText("Remember Me").assertExists()
+        composeTestRule.onNodeWithText("Forgot Password?").assertExists()
+    }
+
+    private fun assertOnHomeView() {
+        composeTestRule.onNodeWithText("Home").assertExists()
+        composeTestRule.onNodeWithText("Feed").assertExists()
+        composeTestRule.onNodeWithText("Post").assertExists()
+        composeTestRule.onNodeWithText("Settings").assertExists()
+    }
+
+    private fun assertOnSettingsView() {
+        composeTestRule.onNodeWithText("Logout").assertExists()
+        composeTestRule.onNodeWithText("Delete Account").assertExists()
+    }
+
+    private fun registerUser(username: String, password: String) {
+        composeTestRule.onNodeWithText("Register").performClick()
+        assertOnRegisterView()
+
+        composeTestRule.onNodeWithText("Username").performTextInput(username)
+        composeTestRule.onNodeWithText("Email").performTextInput("$username@test.com")
+        composeTestRule.onNodeWithText("Date of Birth (YYYY-MM-DD)").performTextInput("1970-01-01")
+        composeTestRule.onNodeWithText("Password").performTextInput(password)
+        composeTestRule.onNodeWithText("Confirm Password").performTextInput(password)
+
+        composeTestRule.onNodeWithText("Register").performClick()
+
+        // Privacy Policy dialog.
+        composeTestRule.onNodeWithText("Privacy Policy").assertExists()
+        composeTestRule.onNodeWithText("Ok").performClick()
+
+        assertOnHomeView()
+    }
+
+    private fun logoutUserFromHome() {
+        composeTestRule.onNodeWithText("Settings").performClick()
+        assertOnSettingsView()
+
+        composeTestRule.onNodeWithText("Logout").performClick()
+        composeTestRule.onNodeWithText("Confirm").performClick()
+
+        assertOnLoginView()
+    }
+
+    private fun loginWithRememberMe(username: String, password: String) {
+        // logoutUserFromHome leaves us on the Login screen.
+        assertOnLoginView()
+
+        composeTestRule.onNodeWithText("Username or Email").performTextInput(username)
+        composeTestRule.onNodeWithText("Password").performTextInput(password)
+        composeTestRule.onNodeWithText("Remember Me").performClick()
+
+        composeTestRule.onNodeWithText("Login").performClick()
+        assertOnHomeView()
+    }
+}

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/model/Models.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/model/Models.kt
@@ -169,6 +169,15 @@ data class UserSession(
     val loginCookieToken: String? = null
 )
 
+/**
+ * "Remember Me" tokens persisted to the keychain after a successful login so the
+ * app can silently re-authenticate via the remember-me endpoint on next launch.
+ *
+ * The field names are part of the persisted (gson) format and are read back in
+ * [com.example.positiveonlysocial.ui.auth.WelcomeScreen] — keep them in sync.
+ */
+data class RememberMeTokens(val seriesId: String, val cookieToken: String)
+
 // --- View Data Models (Matching Swift) ---
 
 data class PostDisplayData(

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/auth/LoginScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/auth/LoginScreen.kt
@@ -25,6 +25,7 @@ import com.example.positiveonlysocial.api.PositiveOnlySocialAPI
 import com.example.positiveonlysocial.data.auth.AuthenticationManager
 import com.example.positiveonlysocial.data.constants.Constants
 import com.example.positiveonlysocial.data.model.LoginRequest
+import com.example.positiveonlysocial.data.model.RememberMeTokens
 import com.example.positiveonlysocial.data.model.UserSession
 import com.example.positiveonlysocial.data.security.KeychainHelperProtocol
 import com.example.positiveonlysocial.ui.dismissKeyboardOnTap
@@ -49,6 +50,11 @@ fun LoginScreen(
 
         val scope = rememberCoroutineScope()
         val focusManager = LocalFocusManager.current
+
+        // Keychain identifiers, matching WelcomeScreen's auto-login reader and
+        // AuthenticationManager's session store.
+        val keychainService = "positive-only-social.Positive-Only-Social"
+        val rememberMeAccount = "userRememberMeTokens"
 
         if (showingErrorAlert) {
             AlertDialog(
@@ -144,6 +150,27 @@ fun LoginScreen(
                                             isIdentityVerified = false
                                         )
                                         authManager.login(session)
+
+                                        // Persist (or clear) the remember-me tokens so
+                                        // WelcomeScreen can silently re-authenticate on the
+                                        // next launch. Mirrors iOS LoginView. Best-effort:
+                                        // a storage failure must not block this session's login.
+                                        try {
+                                            val seriesId = body.seriesIdentifier
+                                            val cookieToken = body.loginCookieToken
+                                            if (rememberMe && seriesId != null && cookieToken != null) {
+                                                keychainHelper.save(
+                                                    RememberMeTokens(seriesId, cookieToken),
+                                                    keychainService,
+                                                    rememberMeAccount
+                                                )
+                                            } else {
+                                                keychainHelper.delete(keychainService, rememberMeAccount)
+                                            }
+                                        } catch (e: Exception) {
+                                            // Ignore: the user is still logged in for this session.
+                                        }
+
                                         navController.navigate(Screen.Home.route) {
                                             popUpTo(Screen.Login.route) { inclusive = true }
                                         }

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/auth/LoginScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/auth/LoginScreen.kt
@@ -172,7 +172,11 @@ fun LoginScreen(
                                                 keychainHelper.delete(keychainService, rememberMeAccount)
                                             }
                                         } catch (e: Exception) {
-                                            // Ignore: the user is still logged in for this session.
+                                            android.util.Log.w(
+                                                "LoginScreen",
+                                                "Failed to persist/clear remember-me tokens; continuing without auto-login.",
+                                                e,
+                                            )
                                         }
 
                                         navController.navigate(Screen.Home.route) {

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/auth/LoginScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/auth/LoginScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
@@ -113,7 +114,10 @@ fun LoginScreen(
                 Spacer(modifier = Modifier.weight(1f))
                 Switch(
                     checked = rememberMe,
-                    onCheckedChange = { rememberMe = it }
+                    onCheckedChange = { rememberMe = it },
+                    // Tag the actual toggle so tests flip it directly. Clicking the
+                    // "Remember Me" label does nothing — it's a sibling, not the switch.
+                    modifier = Modifier.testTag("RememberMeToggle")
                 )
             }
 

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/auth/WelcomeScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/auth/WelcomeScreen.kt
@@ -62,9 +62,22 @@ fun WelcomeScreen(
 
             // Call the API to log in with the tokens
             try {
+                // Load the persisted session first: the backend requires the
+                // original session_management_token (which must belong to the
+                // cookie's user) for the remember-me refresh, so we pass it in
+                // rather than an empty string.
+                val existingSession = authManager.session.value
+                    ?: keychainHelper.load(UserSession::class.java, keychainService, sessionAccount)
+                if (existingSession == null) {
+                    throw Exception("No existing session found for remember-me refresh.")
+                }
+                if (existingSession.userId.isEmpty()) {
+                    throw Exception("Stored session has no valid user ID. Please log in again.")
+                }
+
                 val response = api.loginUserWithRememberMe(
                     TokenRefreshRequest(
-                        sessionToken = "",
+                        sessionToken = existingSession.sessionToken,
                         seriesIdentifier = tokens.seriesId,
                         loginCookieToken = tokens.cookieToken,
                         ip = "127.0.0.1",
@@ -73,14 +86,6 @@ fun WelcomeScreen(
 
                 if (response.isSuccessful && response.body() != null) {
                     val loginDetails = response.body()!!
-                    val existingSession = authManager.session.value
-                        ?: keychainHelper.load(UserSession::class.java, keychainService, sessionAccount)
-                    if (existingSession == null) {
-                        throw Exception("No existing session found for remember-me refresh.")
-                    }
-                    if (existingSession.userId.isEmpty()) {
-                        throw Exception("Stored session has no valid user ID. Please log in again.")
-                    }
                     val userSession = UserSession(
                         sessionToken = loginDetails.newSessionToken,
                         username = existingSession.username,

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/auth/WelcomeScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/auth/WelcomeScreen.kt
@@ -14,6 +14,7 @@ import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.example.positiveonlysocial.api.PositiveOnlySocialAPI
 import com.example.positiveonlysocial.data.auth.AuthenticationManager
+import com.example.positiveonlysocial.data.model.RememberMeTokens
 import com.example.positiveonlysocial.data.model.TokenRefreshRequest
 import com.example.positiveonlysocial.data.model.UserSession
 import com.example.positiveonlysocial.data.security.KeychainHelperProtocol
@@ -27,8 +28,6 @@ private const val TAG = "WelcomeScreen"
 private enum class AuthState {
     Checking, NeedsAuth, Authenticated
 }
-
-private data class RememberMeTokens(val seriesId: String, val cookieToken: String)
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/auth/WelcomeScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/auth/WelcomeScreen.kt
@@ -69,7 +69,7 @@ fun WelcomeScreen(
                 val existingSession = authManager.session.value
                     ?: keychainHelper.load(UserSession::class.java, keychainService, sessionAccount)
                 if (existingSession == null) {
-                    throw Exception("No existing session found for remember-me refresh.")
+                    throw Exception("Automatic sign-in failed. Please log in again.")
                 }
                 if (existingSession.userId.isEmpty()) {
                     throw Exception("Automatic sign-in failed. Please log in again.")

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/auth/WelcomeScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/auth/WelcomeScreen.kt
@@ -72,7 +72,7 @@ fun WelcomeScreen(
                     throw Exception("No existing session found for remember-me refresh.")
                 }
                 if (existingSession.userId.isEmpty()) {
-                    throw Exception("Stored session has no valid user ID. Please log in again.")
+                    throw Exception("Automatic sign-in failed. Please log in again.")
                 }
 
                 val response = api.loginUserWithRememberMe(

--- a/website/src/api/session.ts
+++ b/website/src/api/session.ts
@@ -1,22 +1,94 @@
 // Small helpers around the locally-persisted session, mirroring how the native
 // clients read the signed-in user out of the keychain. The session token itself
-// lives on the ApiClient (and in localStorage for reload survival); these helpers
-// expose the current username/user id and clear everything on logout.
+// lives on the ApiClient; these helpers expose the current username/user id and
+// clear everything on logout.
+//
+// Where the session is persisted depends on the "Remember Me" choice:
+//   - remembered  -> localStorage   (survives browser restarts)
+//   - not         -> sessionStorage (cleared when the tab/window closes, so the
+//                                     session is ephemeral)
+// Reads check both stores so callers don't need to know which one was used.
 
 import { apiClient } from './client'
 
+const SESSION_KEYS = ['session_token', 'user_id', 'username'] as const
+
+function readSessionValue(key: string): string | null {
+  return localStorage.getItem(key) ?? sessionStorage.getItem(key)
+}
+
+/**
+ * Persists the signed-in session. When `rememberMe` is true the session is kept
+ * in localStorage (survives browser restarts); otherwise it lives in
+ * sessionStorage and is dropped when the tab/window closes. The session is
+ * written to exactly one store so a previous choice can't linger.
+ */
+export function persistSession(
+  session: { session_management_token: string; user_id: string; username?: string },
+  rememberMe: boolean,
+): void {
+  const store = rememberMe ? localStorage : sessionStorage
+  const other = rememberMe ? sessionStorage : localStorage
+  store.setItem('session_token', session.session_management_token)
+  store.setItem('user_id', session.user_id)
+  if (session.username) {
+    store.setItem('username', session.username)
+  }
+  SESSION_KEYS.forEach(key => other.removeItem(key))
+}
+
+export function getStoredSessionToken(): string | null {
+  return readSessionValue('session_token')
+}
+
 export function getCurrentUsername(): string | null {
-  return localStorage.getItem('username')
+  return readSessionValue('username')
 }
 
 export function getCurrentUserId(): string | null {
-  return localStorage.getItem('user_id')
+  return readSessionValue('user_id')
 }
 
 /** Clears the persisted session and the in-memory token (used by logout/delete). */
 export function clearSession(): void {
   apiClient.setToken(null)
-  localStorage.removeItem('session_token')
-  localStorage.removeItem('user_id')
-  localStorage.removeItem('username')
+  SESSION_KEYS.forEach(key => {
+    localStorage.removeItem(key)
+    sessionStorage.removeItem(key)
+  })
+  clearRememberMeTokens()
+}
+
+// "Remember Me" tokens persisted across browser restarts so the app can rotate
+// the session via the remember endpoint on startup (mirrors the native clients'
+// WelcomeScreen auto-login).
+//
+// NOTE: localStorage matches the existing session-token storage but is readable
+// by any script on the page (XSS-exposed). The hardened alternative is an
+// httpOnly+Secure+SameSite cookie set by the backend, so JS can never read these
+// long-lived credentials — that requires backend changes (the remember endpoint
+// would read the cookie instead of the JSON body, plus CSRF protection).
+const SERIES_IDENTIFIER_KEY = 'series_identifier'
+const LOGIN_COOKIE_TOKEN_KEY = 'login_cookie_token'
+
+export interface RememberMeTokens {
+  seriesIdentifier: string
+  loginCookieToken: string
+}
+
+export function saveRememberMeTokens(tokens: RememberMeTokens): void {
+  localStorage.setItem(SERIES_IDENTIFIER_KEY, tokens.seriesIdentifier)
+  localStorage.setItem(LOGIN_COOKIE_TOKEN_KEY, tokens.loginCookieToken)
+}
+
+export function loadRememberMeTokens(): RememberMeTokens | null {
+  const seriesIdentifier = localStorage.getItem(SERIES_IDENTIFIER_KEY)
+  const loginCookieToken = localStorage.getItem(LOGIN_COOKIE_TOKEN_KEY)
+  if (!seriesIdentifier || !loginCookieToken) return null
+  return { seriesIdentifier, loginCookieToken }
+}
+
+export function clearRememberMeTokens(): void {
+  localStorage.removeItem(SERIES_IDENTIFIER_KEY)
+  localStorage.removeItem(LOGIN_COOKIE_TOKEN_KEY)
 }

--- a/website/src/api/session.ts
+++ b/website/src/api/session.ts
@@ -33,6 +33,9 @@ export function persistSession(
   store.setItem('user_id', session.user_id)
   if (session.username) {
     store.setItem('username', session.username)
+  } else {
+    // Don't let a username from a previous session linger in this store.
+    store.removeItem('username')
   }
   SESSION_KEYS.forEach(key => other.removeItem(key))
 }

--- a/website/src/api/session.ts
+++ b/website/src/api/session.ts
@@ -87,7 +87,11 @@ export function saveRememberMeTokens(tokens: RememberMeTokens): void {
 export function loadRememberMeTokens(): RememberMeTokens | null {
   const seriesIdentifier = localStorage.getItem(SERIES_IDENTIFIER_KEY)
   const loginCookieToken = localStorage.getItem(LOGIN_COOKIE_TOKEN_KEY)
-  if (!seriesIdentifier || !loginCookieToken) return null
+  if (!seriesIdentifier || !loginCookieToken) {
+    // If either key is missing, treat any partial state as stale.
+    clearRememberMeTokens()
+    return null
+  }
   return { seriesIdentifier, loginCookieToken }
 }
 

--- a/website/src/main.tsx
+++ b/website/src/main.tsx
@@ -23,20 +23,31 @@ if (storedToken) {
 
 // If the user chose "Remember Me", rotate the session + cookie tokens on startup
 // so the login survives across browser restarts (parity with the native clients'
-// WelcomeScreen auto-login). The remember endpoint requires the original session
-// token, so this only runs alongside a stored session. Best-effort and
-// non-blocking: on failure we drop the stale remember-me tokens and fall back to
-// the existing session.
+// WelcomeScreen auto-login). Remember-me tokens only ever accompany a persistent
+// (localStorage) session, so we read the session token straight from localStorage
+// — never from an ephemeral sessionStorage session, which we must not silently
+// upgrade to persistent. Best-effort and non-blocking: on any inconsistency or
+// failure we drop the stale remember-me tokens and fall back to the existing
+// session.
 async function refreshRememberMeSession(): Promise<void> {
   const tokens = loadRememberMeTokens()
-  if (!storedToken || !tokens) return
+  if (!tokens) return
+  const rememberedToken = localStorage.getItem('session_token')
+  if (!rememberedToken) {
+    // Tokens with no matching persistent session — stale, so drop them.
+    clearRememberMeTokens()
+    return
+  }
   try {
     const result = await apiClient.loginWithRememberMe({
-      session_management_token: storedToken,
+      session_management_token: rememberedToken,
       series_identifier: tokens.seriesIdentifier,
       login_cookie_token: tokens.loginCookieToken,
     })
     localStorage.setItem('session_token', result.session_management_token)
+    // The remembered session lives only in localStorage; make sure a stray
+    // ephemeral copy can't shadow it.
+    sessionStorage.removeItem('session_token')
     saveRememberMeTokens({
       seriesIdentifier: tokens.seriesIdentifier,
       loginCookieToken: result.login_cookie_token,

--- a/website/src/main.tsx
+++ b/website/src/main.tsx
@@ -3,15 +3,49 @@ import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import App from './App'
 import { apiClient } from './api/client'
-import { clearSession } from './api/session'
+import {
+  clearRememberMeTokens,
+  clearSession,
+  getStoredSessionToken,
+  loadRememberMeTokens,
+  saveRememberMeTokens,
+} from './api/session'
 import './index.css'
 
 // Restore the session token persisted at login so a page reload keeps the user
-// authenticated (the ApiClient otherwise only holds the token in memory).
-const storedToken = localStorage.getItem('session_token')
+// authenticated (the ApiClient otherwise only holds the token in memory). The
+// token lives in localStorage for "remember me" sessions and sessionStorage
+// otherwise; getStoredSessionToken checks both.
+const storedToken = getStoredSessionToken()
 if (storedToken) {
   apiClient.setToken(storedToken)
 }
+
+// If the user chose "Remember Me", rotate the session + cookie tokens on startup
+// so the login survives across browser restarts (parity with the native clients'
+// WelcomeScreen auto-login). The remember endpoint requires the original session
+// token, so this only runs alongside a stored session. Best-effort and
+// non-blocking: on failure we drop the stale remember-me tokens and fall back to
+// the existing session.
+async function refreshRememberMeSession(): Promise<void> {
+  const tokens = loadRememberMeTokens()
+  if (!storedToken || !tokens) return
+  try {
+    const result = await apiClient.loginWithRememberMe({
+      session_management_token: storedToken,
+      series_identifier: tokens.seriesIdentifier,
+      login_cookie_token: tokens.loginCookieToken,
+    })
+    localStorage.setItem('session_token', result.session_management_token)
+    saveRememberMeTokens({
+      seriesIdentifier: tokens.seriesIdentifier,
+      loginCookieToken: result.login_cookie_token,
+    })
+  } catch {
+    clearRememberMeTokens()
+  }
+}
+void refreshRememberMeSession()
 
 // A banned account has its sessions revoked server-side; drop the local
 // session and land on the login page, which explains the suspension.

--- a/website/src/main.tsx
+++ b/website/src/main.tsx
@@ -45,9 +45,11 @@ async function refreshRememberMeSession(): Promise<void> {
       login_cookie_token: tokens.loginCookieToken,
     })
     localStorage.setItem('session_token', result.session_management_token)
-    // The remembered session lives only in localStorage; make sure a stray
-    // ephemeral copy can't shadow it.
+    // The remembered session lives only in localStorage; make sure no stray
+    // ephemeral copies can shadow it.
     sessionStorage.removeItem('session_token')
+    sessionStorage.removeItem('user_id')
+    sessionStorage.removeItem('username')
     saveRememberMeTokens({
       seriesIdentifier: tokens.seriesIdentifier,
       loginCookieToken: result.login_cookie_token,

--- a/website/src/pages/LoginPage.test.tsx
+++ b/website/src/pages/LoginPage.test.tsx
@@ -135,6 +135,8 @@ test('persists the session and remember-me tokens in localStorage when remember 
   await screen.findByText('Home')
   // Remembered sessions survive browser restarts, so they live in localStorage.
   expect(localStorageMock.setItem).toHaveBeenCalledWith('session_token', 'tok')
+  expect(localStorageMock.setItem).toHaveBeenCalledWith('user_id', 'uuid-xyz')
+  expect(sessionStorageMock.setItem).not.toHaveBeenCalledWith('session_token', expect.anything())
   expect(localStorageMock.setItem).toHaveBeenCalledWith('series_identifier', 'series-1')
   expect(localStorageMock.setItem).toHaveBeenCalledWith('login_cookie_token', 'cookie-1')
 })

--- a/website/src/pages/LoginPage.test.tsx
+++ b/website/src/pages/LoginPage.test.tsx
@@ -12,7 +12,12 @@ vi.mock('../api/client', async importOriginal => {
 import { apiClient } from '../api/client'
 const mockLogin = vi.mocked(apiClient.login)
 
-let mockSetItem: ReturnType<typeof vi.fn>
+function makeStorageMock() {
+  return { setItem: vi.fn(), getItem: vi.fn(), removeItem: vi.fn(), clear: vi.fn() }
+}
+
+let localStorageMock: ReturnType<typeof makeStorageMock>
+let sessionStorageMock: ReturnType<typeof makeStorageMock>
 
 function renderLoginPage() {
   return render(
@@ -28,8 +33,10 @@ function renderLoginPage() {
 
 beforeEach(() => {
   mockLogin.mockReset()
-  mockSetItem = vi.fn()
-  vi.stubGlobal('localStorage', { setItem: mockSetItem, getItem: vi.fn(), removeItem: vi.fn(), clear: vi.fn() })
+  localStorageMock = makeStorageMock()
+  sessionStorageMock = makeStorageMock()
+  vi.stubGlobal('localStorage', localStorageMock)
+  vi.stubGlobal('sessionStorage', sessionStorageMock)
 })
 
 afterEach(() => {
@@ -95,7 +102,7 @@ test('navigates to home on successful login', async () => {
   expect(await screen.findByText('Home')).toBeInTheDocument()
 })
 
-test('stores session token and user_id in localStorage on success', async () => {
+test('stores the session in sessionStorage (ephemeral) when remember me is off', async () => {
   mockLogin.mockResolvedValueOnce({
     session_management_token: 'my-token',
     user_id: 'uuid-xyz',
@@ -106,8 +113,47 @@ test('stores session token and user_id in localStorage on success', async () => 
   await userEvent.type(screen.getByLabelText('Password'), 'pass')
   await userEvent.click(screen.getByRole('button', { name: 'Login' }))
   await screen.findByText('Home')
-  expect(mockSetItem).toHaveBeenCalledWith('session_token', 'my-token')
-  expect(mockSetItem).toHaveBeenCalledWith('user_id', 'uuid-xyz')
+  // Without remember me the session must not persist across browser restarts.
+  expect(sessionStorageMock.setItem).toHaveBeenCalledWith('session_token', 'my-token')
+  expect(sessionStorageMock.setItem).toHaveBeenCalledWith('user_id', 'uuid-xyz')
+  expect(localStorageMock.setItem).not.toHaveBeenCalledWith('session_token', 'my-token')
+})
+
+test('persists the session and remember-me tokens in localStorage when remember me is checked', async () => {
+  mockLogin.mockResolvedValueOnce({
+    session_management_token: 'tok',
+    user_id: 'uuid-xyz',
+    username: 'ada',
+    series_identifier: 'series-1',
+    login_cookie_token: 'cookie-1',
+  })
+  renderLoginPage()
+  await userEvent.type(screen.getByLabelText('Username or Email'), 'ada')
+  await userEvent.type(screen.getByLabelText('Password'), 'pass')
+  await userEvent.click(screen.getByLabelText('Remember me'))
+  await userEvent.click(screen.getByRole('button', { name: 'Login' }))
+  await screen.findByText('Home')
+  // Remembered sessions survive browser restarts, so they live in localStorage.
+  expect(localStorageMock.setItem).toHaveBeenCalledWith('session_token', 'tok')
+  expect(localStorageMock.setItem).toHaveBeenCalledWith('series_identifier', 'series-1')
+  expect(localStorageMock.setItem).toHaveBeenCalledWith('login_cookie_token', 'cookie-1')
+})
+
+test('does not persist remember-me tokens when remember me is unchecked', async () => {
+  mockLogin.mockResolvedValueOnce({
+    session_management_token: 'tok',
+    user_id: 'uuid-xyz',
+    username: 'ada',
+    series_identifier: 'series-1',
+    login_cookie_token: 'cookie-1',
+  })
+  renderLoginPage()
+  await userEvent.type(screen.getByLabelText('Username or Email'), 'ada')
+  await userEvent.type(screen.getByLabelText('Password'), 'pass')
+  await userEvent.click(screen.getByRole('button', { name: 'Login' }))
+  await screen.findByText('Home')
+  expect(localStorageMock.setItem).not.toHaveBeenCalledWith('series_identifier', expect.anything())
+  expect(localStorageMock.setItem).not.toHaveBeenCalledWith('login_cookie_token', expect.anything())
 })
 
 test('Forgot Password link navigates to /request-reset', async () => {

--- a/website/src/pages/LoginPage.tsx
+++ b/website/src/pages/LoginPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom'
 import Logo from '../components/Logo'
 import { ACCOUNT_BANNED, ACCOUNT_SUSPENDED_MESSAGE, apiClient } from '../api/client'
 import type { ApiError } from '../api/client'
+import { clearRememberMeTokens, persistSession, saveRememberMeTokens } from '../api/session'
 import './LoginPage.css'
 
 function LoginPage() {
@@ -30,10 +31,19 @@ function LoginPage() {
         password,
         remember_me: rememberMe,
       })
-      localStorage.setItem('session_token', response.session_management_token)
-      localStorage.setItem('user_id', response.user_id)
-      if (response.username) {
-        localStorage.setItem('username', response.username)
+      // When "Remember Me" is off the session goes to sessionStorage and is
+      // cleared when the browser/tab closes; when on it persists in localStorage.
+      persistSession(response, rememberMe)
+      // Persist the remember-me tokens (only returned when remember_me was
+      // requested) so the session can be rotated on the next browser start;
+      // otherwise drop any stale tokens from a previous "remember me" login.
+      if (rememberMe && response.series_identifier && response.login_cookie_token) {
+        saveRememberMeTokens({
+          seriesIdentifier: response.series_identifier,
+          loginCookieToken: response.login_cookie_token,
+        })
+      } else {
+        clearRememberMeTokens()
       }
       navigate('/home')
     } catch (err) {


### PR DESCRIPTION
## What & why

Remember Me only actually worked on iOS. The backend (`backend/user_system/views.py`) returns `series_identifier` + `login_cookie_token` on login when `remember_me` is set, and the client must **persist** those tokens to silently re-authenticate via `login_user_with_remember_me` on the next launch. iOS did both halves; **Android persisted nothing** (despite having the consumer side in `WelcomeScreen`), and the **website** persisted nothing *and* never called its own `loginWithRememberMe`.

## Changes

### Android
- `LoginScreen` now saves the returned tokens to the keychain after a successful login (or clears stale ones when the toggle is off), mirroring iOS `LoginView`. This is the actual bug fix — the consumer (`WelcomeScreen` auto-login) already existed but never found tokens.
- `RememberMeTokens` promoted from a private dupe in `WelcomeScreen` to a shared model so producer/consumer can't drift.

### Website
- Persist `series_identifier` + `login_cookie_token` on a remembered login, and rotate the session via `loginWithRememberMe` on startup (`main.tsx`) — the client method existed but was never called.
- **Remember Me is now meaningful:** off → session stored in `sessionStorage` (ephemeral, cleared when the tab/window closes); on → `localStorage` (survives restarts). Centralized in `persistSession` in `api/session.ts`; readers and `clearSession` handle both stores.
- `RegisterPage`/`ResetPasswordPage` are intentionally unchanged (still persistent) — they don't expose a Remember Me toggle.

### Tests
- `LoginPage.test.tsx`: assert persistent-vs-ephemeral session placement and remember-me token persistence.
- New `RememberMeLoginTest.kt`: Android instrumented test mirroring iOS `testAutomaticLoginAfterRememberMe` (register → logout → login with Remember Me → relaunch → lands on Home). Uses `createEmptyComposeRule` + manual `ActivityScenario` so the relaunch is a genuinely fresh Activity (`recreate()` would restore the nav back stack to Home and never exercise auto-login).
- Added a keychain-clearing `@Before` to the existing instrumented suite — the now-persistent auto-login would otherwise leak a session across test methods (same process) and skip the Welcome screen.

## Reviewer notes
- **Not run in CI sandbox:** I couldn't execute the suites locally (no Node for the website, no JVM/Android SDK). Please run `npm test` (website) and `./gradlew connectedAndroidTest` (Android) — the Compose relaunch test especially benefits from a real device run.
- **Security follow-up:** website tokens use `localStorage` to match the existing pattern; the hardened path is an httpOnly+Secure+SameSite cookie set by the backend (keeps these long-lived credentials out of JS reach), which is a backend-coordinated change left out of this client-only fix. A code comment flags this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)