### PR TITLE
Unify comment composer, collapse threads, order comments oldest→newest

### DIFF
--- a/android/PositiveOnlySocial/app/src/androidTest/java/com/example/positiveonlysocial/PositiveOnlySocialIntegrationTests.kt
+++ b/android/PositiveOnlySocial/app/src/androidTest/java/com/example/positiveonlysocial/PositiveOnlySocialIntegrationTests.kt
@@ -446,8 +446,9 @@ class PositiveOnlySocialIntegrationTests {
 
         dismissKeyboardIfPresent()
 
-        // Reply to thread via the same composer dialog
-        composeTestRule.onNodeWithText("Reply").performClick()
+        // Reply to thread via the same composer dialog. Scroll the Reply button
+        // into view first so its tap isn't injected off-screen.
+        composeTestRule.onNodeWithText("Reply").performScrollTo().performClick()
         composeTestRule.onNodeWithText("Write a comment...").performTextInput("Comment On a Thread")
         composeTestRule.onNodeWithText("Post").performClick()
 
@@ -468,7 +469,11 @@ class PositiveOnlySocialIntegrationTests {
 
         // ======= Root comment =======
 
-        // New method: tap the heart icon on the root comment
+        // New method: tap the heart icon on the root comment. Scroll it into view
+        // first so taps aren't injected at off-screen coordinates — with the body
+        // on its own line, comments are taller and can sit below the fold on a
+        // fresh navigation.
+        composeTestRule.onNodeWithText("Comment On a Post").performScrollTo()
         composeTestRule.onAllNodesWithContentDescription("Like comment").onFirst().performClick()
         composeTestRule.onNodeWithText("1 likes").assertExists()
 
@@ -477,15 +482,17 @@ class PositiveOnlySocialIntegrationTests {
         composeTestRule.onAllNodesWithText("0 likes").assertCountEquals(3)
 
         // Old method: double-tap the root comment row
-        composeTestRule.onNodeWithText("Comment On a Post").performTouchInput { doubleClick() }
+        composeTestRule.onNodeWithText("Comment On a Post").performScrollTo().performTouchInput { doubleClick() }
         composeTestRule.onNodeWithText("1 likes").assertExists()
 
-        composeTestRule.onNodeWithText("Comment On a Post").performTouchInput { doubleClick() }
+        composeTestRule.onNodeWithText("Comment On a Post").performScrollTo().performTouchInput { doubleClick() }
         composeTestRule.onAllNodesWithText("0 likes").assertCountEquals(3)
 
         // ======= Thread reply =======
 
-        // New method: tap the heart icon on the reply (last "Like comment" node)
+        // New method: tap the heart icon on the reply (last "Like comment" node).
+        // Scroll the reply into view first, for the same off-screen reason.
+        composeTestRule.onNodeWithText("Comment On a Thread").performScrollTo()
         composeTestRule.onAllNodesWithContentDescription("Like comment").onLast().performClick()
         composeTestRule.onAllNodesWithText("1 likes").onLast().assertExists()
 
@@ -494,10 +501,10 @@ class PositiveOnlySocialIntegrationTests {
         composeTestRule.onAllNodesWithText("0 likes").assertCountEquals(3)
 
         // Old method: double-tap the reply row
-        composeTestRule.onNodeWithText("Comment On a Thread").performTouchInput { doubleClick() }
+        composeTestRule.onNodeWithText("Comment On a Thread").performScrollTo().performTouchInput { doubleClick() }
         composeTestRule.onAllNodesWithText("1 likes").onLast().assertExists()
 
-        composeTestRule.onNodeWithText("Comment On a Thread").performTouchInput { doubleClick() }
+        composeTestRule.onNodeWithText("Comment On a Thread").performScrollTo().performTouchInput { doubleClick() }
         composeTestRule.onAllNodesWithText("0 likes").assertCountEquals(3)
     }
 
@@ -540,8 +547,10 @@ class PositiveOnlySocialIntegrationTests {
         composeTestRule.onNodeWithText("Feed").performClick()
         composeTestRule.onAllNodesWithContentDescription("Post Image").onFirst().performClick()
 
-        // Long press the other user's comment; the menu offers Report.
-        composeTestRule.onNodeWithText("Comment to Report").performTouchInput { longClick() }
+        // Long press the other user's comment; the menu offers Report. Scroll it
+        // into view first so the long-press doesn't inject at off-screen
+        // coordinates when the comment sits below the fold (taller comment rows).
+        composeTestRule.onNodeWithText("Comment to Report").performScrollTo().performTouchInput { longClick() }
         composeTestRule.onNodeWithText("Report Comment").performClick()
 
         // Report Dialog
@@ -589,7 +598,11 @@ class PositiveOnlySocialIntegrationTests {
         composeTestRule.onNodeWithText("Feed").performClick()
         composeTestRule.onAllNodesWithContentDescription("Post Image").onFirst().performClick()
 
-        composeTestRule.onNodeWithText("Comment to Delete").performTouchInput { longClick() }
+        // Scroll the comment fully into view first: with the body on its own
+        // line each comment is taller, so on a fresh navigation (scrolled to the
+        // top) the comment can sit below the fold — composed but off-screen, which
+        // makes a touch inject at off-screen coordinates and fail.
+        composeTestRule.onNodeWithText("Comment to Delete").performScrollTo().performTouchInput { longClick() }
 
         // It's the user's own comment: Delete is offered, Report is not.
         composeTestRule.onNodeWithText("Report Comment").assertDoesNotExist()

--- a/android/PositiveOnlySocial/app/src/androidTest/java/com/example/positiveonlysocial/PositiveOnlySocialIntegrationTests.kt
+++ b/android/PositiveOnlySocial/app/src/androidTest/java/com/example/positiveonlysocial/PositiveOnlySocialIntegrationTests.kt
@@ -436,19 +436,20 @@ class PositiveOnlySocialIntegrationTests {
         composeTestRule.onNodeWithText("Feed").performClick()
         composeTestRule.onAllNodesWithContentDescription("Post Image").onFirst().performClick()
         
-        // Make comment
-        composeTestRule.onNodeWithText("Add a comment...").performTextInput("Comment On a Post")
+        // Make comment via the composer dialog
+        composeTestRule.onNodeWithText("Add a comment...").performClick()
+        composeTestRule.onNodeWithText("Write a comment...").performTextInput("Comment On a Post")
         composeTestRule.onNodeWithText("Post").performClick()
-        
+
         // Verify comment appears
         composeTestRule.onNodeWithText("Comment On a Post").assertExists()
 
         dismissKeyboardIfPresent()
 
-        // Reply to thread
+        // Reply to thread via the same composer dialog
         composeTestRule.onNodeWithText("Reply").performClick()
-        composeTestRule.onNodeWithText("Your reply...").performTextInput("Comment On a Thread")
-        composeTestRule.onNodeWithText("Send").performClick()
+        composeTestRule.onNodeWithText("Write a comment...").performTextInput("Comment On a Thread")
+        composeTestRule.onNodeWithText("Post").performClick()
 
         // Now we logout
         Espresso.pressBack()

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/PostDetailViewModel.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/PostDetailViewModel.kt
@@ -81,6 +81,18 @@ class PostDetailViewModel(
     private val _threadToReplyTo = MutableStateFlow<CommentThreadViewData?>(null)
     val threadToReplyTo: StateFlow<CommentThreadViewData?> = _threadToReplyTo.asStateFlow()
 
+    // Drives the "Add a comment" composer dialog for a brand new comment on the
+    // post. Both this and the reply flow go through the same dialog so the
+    // character counter is always shown and comments aren't typed inline
+    // (issues #266, #289, #290).
+    private val _showAddCommentDialog = MutableStateFlow(false)
+    val showAddCommentDialog: StateFlow<Boolean> = _showAddCommentDialog.asStateFlow()
+
+    // Ids of comments whose thread below them is collapsed. Tapping a comment's
+    // username/time header toggles its presence here (issue #243).
+    private val _collapsedCommentIds = MutableStateFlow<Set<String>>(emptySet())
+    val collapsedCommentIds: StateFlow<Set<String>> = _collapsedCommentIds.asStateFlow()
+
     // The signed-in user's username, loaded alongside the post. The backend
     // rejects liking your own post/comment, so the UI hides the like control
     // (and the like actions are guarded) for content this user authored.
@@ -99,6 +111,17 @@ class PostDetailViewModel(
 
     fun setThreadToReplyTo(thread: CommentThreadViewData?) {
         _threadToReplyTo.value = thread
+    }
+
+    fun setShowAddCommentDialog(show: Boolean) {
+        _showAddCommentDialog.value = show
+    }
+
+    /** Toggles whether the thread below the given comment is collapsed. */
+    fun toggleCommentCollapsed(commentId: String) {
+        val current = _collapsedCommentIds.value
+        _collapsedCommentIds.value =
+            if (current.contains(commentId)) current - commentId else current + commentId
     }
 
     fun setShowReportSheetForPost(show: Boolean) {
@@ -223,9 +246,11 @@ class PostDetailViewModel(
             // Filter out empty threads if needed, or keep them
             val nonEmptyThreads = loadedThreads.filter { it.comments.isNotEmpty() }
 
-            // Sort threads by their first comment's date (using dummy date for now as parsing is TODO)
-            _commentThreads.value = nonEmptyThreads
-            // .sortedBy { it.comments.firstOrNull()?.createdDate }
+            // Order threads oldest-to-newest by their first comment's date, so the
+            // post's comments always read top-to-bottom in chronological order
+            // (issue #293). Comments within each thread are already sorted oldest
+            // first above.
+            _commentThreads.value = nonEmptyThreads.sortedBy { it.comments.firstOrNull()?.createdDate }
 
         } catch (e: Exception) {
             Log.e(TAG, "Error loading post details", e)

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/PostDetailScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/PostDetailScreen.kt
@@ -75,8 +75,6 @@ fun PostDetailScreen(
         val commentToReport by viewModel.commentToReport.collectAsState()
         val threadToReplyTo by viewModel.threadToReplyTo.collectAsState()
 
-        val focusManager = LocalFocusManager.current
-
         // Long-press action menus (Report vs Delete, depending on ownership).
         val showActionSheetForPost by viewModel.showActionSheetForPost.collectAsState()
         val commentForAction by viewModel.commentForAction.collectAsState()
@@ -144,9 +142,21 @@ fun PostDetailScreen(
             )
         }
 
+        // "Add a comment" on the post and "Reply" on a thread share the same
+        // composer dialog (title aside), so the character counter is always shown
+        // and the dialog closes the moment the comment is submitted (issue #291).
+        val showAddCommentDialog by viewModel.showAddCommentDialog.collectAsState()
+        if (showAddCommentDialog) {
+            CommentComposerDialog(
+                title = "Add a comment",
+                onDismiss = { viewModel.setShowAddCommentDialog(false) },
+                onSubmit = { text -> viewModel.commentOnPost(text) }
+            )
+        }
+
         threadToReplyTo?.let { thread ->
-            ReplyDialog(
-                thread = thread,
+            CommentComposerDialog(
+                title = "Reply to ${thread.comments.firstOrNull()?.authorUsername ?: "Comment"}",
                 onDismiss = { viewModel.setThreadToReplyTo(null) },
                 onSubmit = { text -> viewModel.replyToCommentThread(thread, text) }
             )
@@ -235,31 +245,19 @@ fun PostDetailScreen(
                             }
                             
                             Divider(modifier = Modifier.padding(vertical = 16.dp))
-                            
-                            // Add Comment Section
-                            val newCommentText by viewModel.newCommentText.collectAsState()
-                            Column {
-                                Row(verticalAlignment = Alignment.CenterVertically) {
-                                    TextField(
-                                        value = newCommentText,
-                                        onValueChange = { viewModel.updateNewCommentText(it) },
-                                        placeholder = { Text("Add a comment...") },
-                                        modifier = Modifier.weight(1f),
-                                        singleLine = true,
-                                        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-                                        keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() })
-                                    )
-                                    Button(
-                                        onClick = { viewModel.commentOnPost(newCommentText) },
-                                        enabled = newCommentText.isNotEmpty() && isWithinLength(newCommentText, Constants.MAX_COMMENT_LENGTH),
-                                        modifier = Modifier.padding(start = 8.dp)
-                                    ) {
-                                        Text("Post")
-                                    }
-                                }
-                                CharacterCounter(text = newCommentText, max = Constants.MAX_COMMENT_LENGTH)
+
+                            // Add Comment Section. Tapping this opens the shared
+                            // comment composer dialog (which shows the character
+                            // counter) rather than typing inline, so commenting on
+                            // a post and replying to a thread work the same way
+                            // (issues #266, #289, #290).
+                            OutlinedButton(
+                                onClick = { viewModel.setShowAddCommentDialog(true) },
+                                modifier = Modifier.fillMaxWidth()
+                            ) {
+                                Text("Add a comment...", modifier = Modifier.weight(1f))
                             }
-                            
+
                             Spacer(modifier = Modifier.height(16.dp))
                             Text("Comments", fontWeight = FontWeight.Bold)
                         }
@@ -294,18 +292,28 @@ fun CommentThreadView(
     onAuthorClick: (String) -> Unit
 ) {
     val reportedCommentIds by viewModel.reportedCommentIds.collectAsState()
+    val collapsedCommentIds by viewModel.collapsedCommentIds.collectAsState()
+
+    // Hide every comment that sits below the first collapsed one in the thread,
+    // so tapping a comment's header folds away the comments under it (issue #243).
+    val collapseIndex = thread.comments.indexOfFirst { collapsedCommentIds.contains(it.id) }
+    val visibleComments =
+        if (collapseIndex == -1) thread.comments else thread.comments.take(collapseIndex + 1)
+
     Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
-        thread.comments.firstOrNull()?.let { rootComment ->
+        visibleComments.firstOrNull()?.let { rootComment ->
             CommentRow(
                 comment = rootComment,
                 isOwn = rootComment.authorUsername == currentUsername,
                 isReported = reportedCommentIds.contains(rootComment.id),
+                isCollapsed = collapsedCommentIds.contains(rootComment.id),
+                onToggleCollapse = { viewModel.toggleCommentCollapsed(rootComment.id) },
                 onLike = { viewModel.likeComment(rootComment, rootComment.threadId) },
                 onUnlike = { viewModel.unlikeComment(rootComment, rootComment.threadId) },
                 onLongPress = { viewModel.setCommentForAction(rootComment) },
                 onAuthorClick = onAuthorClick
             )
-            
+
             // Reply Input for Thread
             Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.padding(start = 16.dp, top = 8.dp)) {
                  TextButton(onClick = { viewModel.setThreadToReplyTo(thread) }) {
@@ -313,14 +321,16 @@ fun CommentThreadView(
                  }
             }
         }
-        
-        if (thread.comments.size > 1) {
+
+        if (visibleComments.size > 1) {
             Column(modifier = Modifier.padding(start = 32.dp)) {
-                thread.comments.drop(1).forEach { reply ->
+                visibleComments.drop(1).forEach { reply ->
                     CommentRow(
                         comment = reply,
                         isOwn = reply.authorUsername == currentUsername,
                         isReported = reportedCommentIds.contains(reply.id),
+                        isCollapsed = collapsedCommentIds.contains(reply.id),
+                        onToggleCollapse = { viewModel.toggleCommentCollapsed(reply.id) },
                         onLike = { viewModel.likeComment(reply, reply.threadId) },
                         onUnlike = { viewModel.unlikeComment(reply, reply.threadId) },
                         onLongPress = { viewModel.setCommentForAction(reply) },
@@ -338,6 +348,8 @@ fun CommentRow(
     comment: CommentViewData,
     isOwn: Boolean,
     isReported: Boolean,
+    isCollapsed: Boolean,
+    onToggleCollapse: () -> Unit,
     onLike: () -> Unit,
     onUnlike: () -> Unit,
     onLongPress: () -> Unit,
@@ -369,11 +381,19 @@ fun CommentRow(
             color = Color.Gray,
             modifier = Modifier.size(32.dp)
         ) {}
-        
+
         Spacer(modifier = Modifier.width(8.dp))
-        
-        Column {
-            Row {
+
+        Column(modifier = Modifier.weight(1f)) {
+            // Username + time header. Tapping the space around the author name
+            // collapses the thread below this comment (issue #243); tapping the
+            // name itself still opens the author's profile.
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { onToggleCollapse() }
+            ) {
                 // Tap the author's name to open their profile, same as the
                 // post author above. combinedClickable (not clickable) so the
                 // row's double-tap (like) and long-press (report/delete)
@@ -392,12 +412,15 @@ fun CommentRow(
                         onClick = { onAuthorClick(comment.authorUsername) }
                     )
                 )
-                Spacer(modifier = Modifier.width(4.dp))
-                Text(comment.body, fontSize = 14.sp)
-            }
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Text(RelativeTime.format(comment.createdDate), fontSize = 12.sp, color = Color.Gray)
                 Spacer(modifier = Modifier.width(8.dp))
+                Text(RelativeTime.format(comment.createdDate), fontSize = 12.sp, color = Color.Gray)
+                Spacer(modifier = Modifier.weight(1f))
+                // Chevron hint for the collapse state of the thread below.
+                Text(if (isCollapsed) "▸" else "▾", fontSize = 12.sp, color = Color.Gray)
+            }
+            // The comment body sits below the username/time header line.
+            Text(comment.body, fontSize = 14.sp)
+            Row(verticalAlignment = Alignment.CenterVertically) {
                 if (!isOwn) {
                     IconButton(
                         onClick = { if (comment.isLiked) onUnlike() else onLike() },
@@ -496,21 +519,28 @@ fun ReportDialog(onDismiss: () -> Unit, onSubmit: (String) -> Unit) {
     )
 }
 
+/**
+ * The shared composer dialog for writing a comment — used both for a brand new
+ * comment on the post and for replying to a thread (issues #266, #289, #290).
+ * It always shows the character counter, and submitting dismisses the dialog
+ * (and thus the keyboard) immediately while clearing the text, so tapping the
+ * confirm button repeatedly can't post the same comment twice (issue #291).
+ */
 @Composable
-fun ReplyDialog(thread: CommentThreadViewData, onDismiss: () -> Unit, onSubmit: (String) -> Unit) {
+fun CommentComposerDialog(title: String, onDismiss: () -> Unit, onSubmit: (String) -> Unit) {
     var text by remember { mutableStateOf("") }
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text("Reply to ${thread.comments.firstOrNull()?.authorUsername ?: "Comment"}") },
+        title = { Text(title) },
         text = {
-            // A reply can span multiple lines, so this stays multiline (Enter
-            // inserts a newline). The dialog's Send/Cancel buttons remain
+            // A comment can span multiple lines, so this stays multiline (Enter
+            // inserts a newline). The dialog's confirm/Cancel buttons remain
             // reachable above the keyboard, so no Done-to-dismiss is needed.
             Column {
                 TextField(
                     value = text,
                     onValueChange = { text = it },
-                    placeholder = { Text("Your reply...") }
+                    placeholder = { Text("Write a comment...") }
                 )
                 CharacterCounter(text = text, max = Constants.MAX_COMMENT_LENGTH)
             }
@@ -525,7 +555,7 @@ fun ReplyDialog(thread: CommentThreadViewData, onDismiss: () -> Unit, onSubmit: 
                 },
                 enabled = text.isNotEmpty() && isWithinLength(text, Constants.MAX_COMMENT_LENGTH)
             ) {
-                Text("Send")
+                Text("Post")
             }
         },
         dismissButton = {

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/PostDetailScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/PostDetailScreen.kt
@@ -371,7 +371,13 @@ fun CommentRow(
                     // Open the action menu (Report or Delete, by ownership).
                     onLongPress()
                 },
-                onClick = {}
+                // A single tap collapses/expands the thread below this comment
+                // (issue #243). Tapping the author's name still opens their
+                // profile — that inner handler wins over this one. This lives on
+                // the row's own combinedClickable (rather than a nested
+                // clickable) so it can't swallow the long-press that opens the
+                // action menu.
+                onClick = { onToggleCollapse() }
             ),
         verticalAlignment = Alignment.Top
     ) {
@@ -385,14 +391,13 @@ fun CommentRow(
         Spacer(modifier = Modifier.width(8.dp))
 
         Column(modifier = Modifier.weight(1f)) {
-            // Username + time header. Tapping the space around the author name
-            // collapses the thread below this comment (issue #243); tapping the
-            // name itself still opens the author's profile.
+            // Username + time header. Tapping the comment (this header or the
+            // body) collapses the thread below it (issue #243) via the row's
+            // combinedClickable above; tapping the name itself still opens the
+            // author's profile.
             Row(
                 verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable { onToggleCollapse() }
+                modifier = Modifier.fillMaxWidth()
             ) {
                 // Tap the author's name to open their profile, same as the
                 // post author above. combinedClickable (not clickable) so the

--- a/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/PostDetailViewModelTest.kt
+++ b/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/PostDetailViewModelTest.kt
@@ -143,4 +143,29 @@ class PostDetailViewModelTest {
         assertEquals("", viewModel.newCommentText.value)
         verify(api, org.mockito.kotlin.times(2)).getPostDetails("token123", postIdentifier)
     }
+
+    @Test
+    fun `toggleCommentCollapsed adds then removes the comment id`() = runTest {
+        // Starts uncollapsed.
+        assertFalse(viewModel.collapsedCommentIds.value.contains("c1"))
+
+        // First toggle collapses the thread below this comment...
+        viewModel.toggleCommentCollapsed("c1")
+        assertEquals(setOf("c1"), viewModel.collapsedCommentIds.value)
+
+        // ...and a second toggle expands it again.
+        viewModel.toggleCommentCollapsed("c1")
+        assertFalse(viewModel.collapsedCommentIds.value.contains("c1"))
+    }
+
+    @Test
+    fun `toggleCommentCollapsed tracks each comment independently`() = runTest {
+        viewModel.toggleCommentCollapsed("c1")
+        viewModel.toggleCommentCollapsed("c2")
+        assertEquals(setOf("c1", "c2"), viewModel.collapsedCommentIds.value)
+
+        // Expanding one leaves the other collapsed.
+        viewModel.toggleCommentCollapsed("c1")
+        assertEquals(setOf("c2"), viewModel.collapsedCommentIds.value)
+    }
 }

--- a/ios/Positive Only Social/Positive Only Social/VibesViewModels/PostDetailViewModel.swift
+++ b/ios/Positive Only Social/Positive Only Social/VibesViewModels/PostDetailViewModel.swift
@@ -39,9 +39,28 @@ final class PostDetailViewModel: ObservableObject {
     
     /// The text for creating a brand new comment thread
     @Published var newCommentText: String = ""
-    
+
+    /// Drives the "Add a comment" composer sheet for a brand new comment on the
+    /// post. Both this and the reply flow go through the same composer sheet so
+    /// the character counter is always shown and comments aren't typed inline
+    /// (issues #266, #289, #290).
+    @Published var showAddCommentSheet = false
+
     /// When a user taps "Reply", this is set, which triggers the reply sheet
     @Published var threadToReplyTo: CommentThreadViewData?
+
+    /// Ids of comments whose thread below them is collapsed. Tapping a comment's
+    /// username/time header toggles its presence here (issue #243).
+    @Published var collapsedCommentIds: Set<String> = []
+
+    /// Toggles whether the thread below the given comment is collapsed.
+    func toggleCommentCollapsed(_ commentId: String) {
+        if collapsedCommentIds.contains(commentId) {
+            collapsedCommentIds.remove(commentId)
+        } else {
+            collapsedCommentIds.insert(commentId)
+        }
+    }
     
     @Published var isPostReported = false
     @Published var reportedCommentIds: Set<String> = []

--- a/ios/Positive Only Social/Positive Only Social/VibesViews/CommentRowView.swift
+++ b/ios/Positive Only Social/Positive Only Social/VibesViews/CommentRowView.swift
@@ -8,6 +8,10 @@ struct CommentRowView: View {
     /// rejects liking your own comment, so the like heart is hidden and the
     /// double-tap-to-like gesture is a no-op when true.
     let isOwn: Bool
+    /// Whether the thread below this comment is currently collapsed.
+    let isCollapsed: Bool
+    /// Toggles the collapsed state of the thread below this comment.
+    let onToggleCollapse: () -> Void
     /// Actions passed from the parent
     let onLike: () -> Void
     let onUnlike: () -> Void
@@ -20,13 +24,14 @@ struct CommentRowView: View {
             Image(systemName: "person.circle.fill")
                 .font(.title)
                 .foregroundColor(.secondary)
-            
+
             VStack(alignment: .leading, spacing: 4) {
-                // Comment body with author. Tap the author's name to open
-                // their profile. A plain tap gesture (not a NavigationLink)
-                // so the row's long-press (report/delete) and double-tap
-                // (like) gestures aren't swallowed by a nested Button.
-                HStack(alignment: .firstTextBaseline, spacing: 4) {
+                // Username + time header. Tap the author's name to open their
+                // profile; tapping the space next to it collapses the thread
+                // below this comment (issue #243). A plain tap gesture (not a
+                // NavigationLink) so the row's long-press (report/delete) and
+                // double-tap (like) gestures aren't swallowed by a nested Button.
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
                     Text(comment.authorUsername)
                         .fontWeight(.bold)
                         .font(.subheadline)
@@ -38,18 +43,26 @@ struct CommentRowView: View {
                         .accessibilityAddTraits(.isButton)
                         .accessibilityHint("Opens \(comment.authorUsername)'s profile")
                         .accessibilityIdentifier("CommentAuthor")
-                    Text(comment.body)
-                        .font(.subheadline)
-                        .accessibilityIdentifier("CommentText")
-                        .accessibilityLabel(comment.body)
-                }
-                
-                // Info row
-                HStack(spacing: 16) {
                     Text(RelativeTime.string(from: comment.createdDate))
                         .font(.caption)
                         .foregroundColor(.secondary)
+                    Spacer()
+                    Image(systemName: isCollapsed ? "chevron.right" : "chevron.down")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+                .contentShape(Rectangle())
+                .onTapGesture { onToggleCollapse() }
+                .accessibilityIdentifier("CommentCollapseHeader")
 
+                // The comment body sits below the username/time header line.
+                Text(comment.body)
+                    .font(.subheadline)
+                    .accessibilityIdentifier("CommentText")
+                    .accessibilityLabel(comment.body)
+
+                // Info row
+                HStack(spacing: 16) {
                     if !isOwn {
                         Button {
                             if comment.isLiked { onUnlike() } else { onLike() }

--- a/ios/Positive Only Social/Positive Only Social/VibesViews/CommentThreadView.swift
+++ b/ios/Positive Only Social/Positive Only Social/VibesViews/CommentThreadView.swift
@@ -6,13 +6,29 @@ struct CommentThreadView: View {
        let thread: CommentThreadViewData
        let onAuthorTap: (String) -> Void
 
+       /// Hide every comment that sits below the first collapsed one in the
+       /// thread, so tapping a comment's header folds away the comments under it
+       /// (issue #243).
+       private var visibleComments: [CommentViewData] {
+           if let collapseIndex = thread.comments.firstIndex(where: {
+               viewModel.collapsedCommentIds.contains($0.id)
+           }) {
+               return Array(thread.comments.prefix(collapseIndex + 1))
+           }
+           return thread.comments
+       }
+
        var body: some View {
            VStack(alignment: .leading, spacing: 0) {
-               if let rootComment = thread.comments.first {
+               if let rootComment = visibleComments.first {
                    // Show the root comment
                    CommentRowView(comment: rootComment,
                                   isReported: viewModel.reportedCommentIds.contains(rootComment.id),
                                   isOwn: viewModel.isOwnComment(rootComment),
+                                  isCollapsed: viewModel.collapsedCommentIds.contains(rootComment.id),
+                                  onToggleCollapse: {
+                                      viewModel.toggleCommentCollapsed(rootComment.id)
+                                  },
                                   onLike: {
                                       viewModel.likeComment(rootComment)
                                   },
@@ -25,33 +41,30 @@ struct CommentThreadView: View {
                                   onAuthorTap: {
                                       onAuthorTap(rootComment.authorUsername)
                                   })
-                   Section {
-                       HStack {
-                           TextField("Add a comment...", text: $viewModel.newCommentText)
-                               .accessibilityIdentifier("AddACommentTextFieldToThread")
-
-                           Button("Reply") {
-                               // This sets the @Published var, triggering the sheet
-                               viewModel.threadToReplyTo = thread
-                           }
-                           .font(.caption)
-                           .fontWeight(.bold)
-                           .padding(.leading, 50) // Aligns with comment text
-                           .padding(.bottom, 8)
-                           .accessibilityIdentifier("ReplyToCommentThreadButton")
-                       }
+                   // Tapping "Reply" opens the shared composer sheet, the same
+                   // dialog used for a new comment on the post.
+                   Button("Reply") {
+                       viewModel.threadToReplyTo = thread
                    }
-                   .padding()
+                   .font(.caption)
+                   .fontWeight(.bold)
+                   .padding(.leading, 50) // Aligns with comment text
+                   .padding(.vertical, 8)
+                   .accessibilityIdentifier("ReplyToCommentThreadButton")
                }
-               
+
                // Show replies, if any
-               if thread.comments.count > 1 {
+               if visibleComments.count > 1 {
                    // Indent replies
                    VStack(alignment: .leading, spacing: 0) {
-                       ForEach(thread.comments.dropFirst()) { reply in
+                       ForEach(visibleComments.dropFirst()) { reply in
                            CommentRowView(comment: reply,
                                           isReported: viewModel.reportedCommentIds.contains(reply.id),
                                           isOwn: viewModel.isOwnComment(reply),
+                                          isCollapsed: viewModel.collapsedCommentIds.contains(reply.id),
+                                          onToggleCollapse: {
+                                              viewModel.toggleCommentCollapsed(reply.id)
+                                          },
                                           onLike: {
                                               viewModel.likeComment(reply)
                                           },

--- a/ios/Positive Only Social/Positive Only Social/VibesViews/PostDetailView.swift
+++ b/ios/Positive Only Social/Positive Only Social/VibesViews/PostDetailView.swift
@@ -113,19 +113,17 @@ struct PostDetailView: View {
                     Button {
                         viewModel.showAddCommentSheet = true
                     } label: {
-                        HStack {
-                            Text("Add a comment...")
-                                .foregroundColor(.secondary)
-                            Spacer()
-                        }
-                        .padding(.vertical, 8)
-                        .padding(.horizontal, 12)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 8)
-                                .stroke(Color.secondary.opacity(0.4), lineWidth: 1)
-                        )
+                        Text("Add a comment...")
+                            .foregroundColor(.secondary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.vertical, 10)
+                            .padding(.horizontal, 12)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .stroke(Color.secondary.opacity(0.4), lineWidth: 1)
+                            )
+                            .contentShape(Rectangle())
                     }
-                    .buttonStyle(.plain)
                     .accessibilityIdentifier("AddACommentButton")
                     .padding()
                     

--- a/ios/Positive Only Social/Positive Only Social/VibesViews/PostDetailView.swift
+++ b/ios/Positive Only Social/Positive Only Social/VibesViews/PostDetailView.swift
@@ -106,21 +106,27 @@ struct PostDetailView: View {
                     }
                     .padding(.horizontal)
                     Divider()
-                    Section {
-                        VStack(alignment: .leading) {
-                            HStack {
-                                TextField("Add a comment...", text: $viewModel.newCommentText)
-                                    .accessibilityIdentifier("AddACommentTextFieldToPost")
-                                
-                                Button("Post") {
-                                    viewModel.commentOnPost(commentText: viewModel.newCommentText)
-                                }
-                                .disabled(viewModel.newCommentText.isEmpty || !isWithinLength(viewModel.newCommentText, max: GVOAppConstants.maxCommentLength))
-                                .accessibilityIdentifier("PostCommentButton")
-                            }
-                            CharacterCounter(text: viewModel.newCommentText, max: GVOAppConstants.maxCommentLength)
+                    // Tapping this opens the shared comment composer sheet (which
+                    // shows the character counter) rather than typing inline, so
+                    // commenting on a post and replying to a thread work the same
+                    // way (issues #266, #289, #290).
+                    Button {
+                        viewModel.showAddCommentSheet = true
+                    } label: {
+                        HStack {
+                            Text("Add a comment...")
+                                .foregroundColor(.secondary)
+                            Spacer()
                         }
+                        .padding(.vertical, 8)
+                        .padding(.horizontal, 12)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8)
+                                .stroke(Color.secondary.opacity(0.4), lineWidth: 1)
+                        )
                     }
+                    .buttonStyle(.plain)
+                    .accessibilityIdentifier("AddACommentButton")
                     .padding()
                     
                     Text("Comments")
@@ -211,9 +217,15 @@ struct PostDetailView: View {
                 viewModel.reportComment(comment, reason: reason)
             }
         }
+        // The "Add a comment" composer for a brand new comment on the post.
+        .sheet(isPresented: $viewModel.showAddCommentSheet) {
+            CommentComposerView(title: "Add Comment") { commentText in
+                viewModel.commentOnPost(commentText: commentText)
+            }
+        }
+        // The same composer, reused for replying to an existing thread.
         .sheet(item: $viewModel.threadToReplyTo) { thread in
-            ReplyView(thread: thread) { commentText in
-                // This is the action that gets called when "Send" is tapped
+            CommentComposerView(title: "Post Reply") { commentText in
                 viewModel.replyToCommentThread(thread: thread, commentText: commentText)
             }
         }

--- a/ios/Positive Only Social/Positive Only Social/VibesViews/ReplyView.swift
+++ b/ios/Positive Only Social/Positive Only Social/VibesViews/ReplyView.swift
@@ -1,29 +1,34 @@
 
 import SwiftUI
 
-/// A view presented as a sheet for replying to a comment thread.
-struct ReplyView: View {
+/// The shared composer sheet for writing a comment — used both for a brand new
+/// comment on the post and for replying to a thread (issues #266, #289, #290).
+/// It always shows the character counter, and submitting dismisses the sheet
+/// (and thus the keyboard) immediately, so tapping the confirm button repeatedly
+/// can't post the same comment twice (issue #291).
+struct CommentComposerView: View {
       @Environment(\.dismiss) var dismiss
-      
-      /// The thread being replied to (passed in).
-      let thread: CommentThreadViewData
-      
-      /// The action to perform when "Send" is tapped.
+
+      /// The sheet's title — e.g. "Add Comment" or "Post Reply".
+      let title: String
+
+      /// The action to perform when the confirm button is tapped.
       let onSubmit: (String) -> Void
-      
+
       /// Local state to hold the text being typed.
-      @State private var replyText: String = ""
-      
+      @State private var text: String = ""
+
       var body: some View {
           NavigationView {
               Form {
-                  Section(header: Text("Replying to \(thread.comments.first?.authorUsername ?? "Comment")")) {
-                      TextEditor(text: $replyText)
+                  Section {
+                      TextEditor(text: $text)
                           .frame(minHeight: 150)
-                      CharacterCounter(text: replyText, max: GVOAppConstants.maxCommentLength)
+                          .accessibilityIdentifier("CommentComposerTextEditor")
+                      CharacterCounter(text: text, max: GVOAppConstants.maxCommentLength)
                   }
               }
-              .navigationTitle("Post Reply")
+              .navigationTitle(title)
               .navigationBarTitleDisplayMode(.inline)
               .scrollDismissesKeyboard(.immediately)
               .toolbar {
@@ -33,14 +38,14 @@ struct ReplyView: View {
                       }
                   }
                   ToolbarItem(placement: .confirmationAction) {
-                      Button("Send") {
-                          onSubmit(replyText)
+                      Button("Post") {
+                          onSubmit(text)
                           dismiss()
                       }
-                      .disabled(replyText.isEmpty || !isWithinLength(replyText, max: GVOAppConstants.maxCommentLength))
+                      .disabled(text.isEmpty || !isWithinLength(text, max: GVOAppConstants.maxCommentLength))
+                      .accessibilityIdentifier("PostCommentButton")
                   }
               }
           }
       }
   }
-

--- a/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_PostDetailViewModel.swift
+++ b/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_PostDetailViewModel.swift
@@ -451,4 +451,33 @@ struct Positive_Only_SocialTests_PostDetailViewModel {
         #expect(sut.commentThreads.first?.comments.count == 2, "Thread should still have 2 comments")
         #expect(sut.alertMessage == nil, "No alert should be shown for an empty guard")
     }
+
+    @Test func testToggleCommentCollapsed_AddsThenRemovesId() async throws {
+        // Given: A fully loaded SUT
+        let (sut, _, _, _) = try await setupTestEnvironment(account: "collapse_account")
+
+        // Starts uncollapsed.
+        #expect(!sut.collapsedCommentIds.contains("c1"))
+
+        // First toggle collapses the thread below this comment...
+        sut.toggleCommentCollapsed("c1")
+        #expect(sut.collapsedCommentIds == ["c1"])
+
+        // ...and a second toggle expands it again.
+        sut.toggleCommentCollapsed("c1")
+        #expect(!sut.collapsedCommentIds.contains("c1"))
+    }
+
+    @Test func testToggleCommentCollapsed_TracksEachCommentIndependently() async throws {
+        // Given: A fully loaded SUT
+        let (sut, _, _, _) = try await setupTestEnvironment(account: "collapseIndependent_account")
+
+        sut.toggleCommentCollapsed("c1")
+        sut.toggleCommentCollapsed("c2")
+        #expect(sut.collapsedCommentIds == ["c1", "c2"])
+
+        // Expanding one leaves the other collapsed.
+        sut.toggleCommentCollapsed("c1")
+        #expect(sut.collapsedCommentIds == ["c2"])
+    }
 }

--- a/ios/Positive Only Social/Positive Only SocialUITests/Positive_Only_SocialUITests.swift
+++ b/ios/Positive Only Social/Positive Only SocialUITests/Positive_Only_SocialUITests.swift
@@ -205,9 +205,8 @@ final class Positive_Only_SocialUITests: XCTestCase {
     }
     
     private func assertOnPostDetailView(app: XCUIApplication) {
-        XCTAssertTrue(app.buttons["PostCommentButton"].waitForExistence(timeout: TestConstants.shortTimeout), "Post comment button not present")
         XCTAssertTrue(app.buttons["PostImage"].waitForExistence(timeout: TestConstants.shortTimeout), "Post image not present in time")
-        XCTAssertTrue(app.textFields["AddACommentTextFieldToPost"].waitForExistence(timeout: TestConstants.shortTimeout), "Add a comment text field not present")
+        XCTAssertTrue(app.buttons["AddACommentButton"].waitForExistence(timeout: TestConstants.shortTimeout), "Add a comment button not present")
     }
     
     private func ifOnHomeDeleteAccount(app: XCUIApplication) throws {
@@ -447,11 +446,19 @@ final class Positive_Only_SocialUITests: XCTestCase {
     /// Types and posts a comment on the currently open PostDetailView, then
     /// waits for it to appear as the only comment.
     private func addCommentToOpenPost(app: XCUIApplication, commentText: String) {
-        let addACommentTextField = app.textFields["AddACommentTextFieldToPost"]
-        XCTAssertTrue(addACommentTextField.waitForExistence(timeout: TestConstants.shortTimeout))
-        addACommentTextField.tap()
-        typeText(element: addACommentTextField, text: commentText)
+        // Open the shared comment composer sheet.
+        let addACommentButton = app.buttons["AddACommentButton"]
+        XCTAssertTrue(addACommentButton.waitForExistence(timeout: TestConstants.shortTimeout))
+        addACommentButton.tap()
 
+        // The composer presents a TextEditor, which is a textView in the
+        // accessibility hierarchy.
+        let commentTextEditor = app.textViews.firstMatch
+        XCTAssertTrue(commentTextEditor.waitForExistence(timeout: TestConstants.shortTimeout))
+        commentTextEditor.tap()
+        typeText(element: commentTextEditor, text: commentText)
+
+        // Submitting dismisses the sheet immediately.
         let postCommentButton = app.buttons["PostCommentButton"]
         XCTAssertTrue(postCommentButton.waitForExistence(timeout: TestConstants.shortTimeout))
         postCommentButton.tap()
@@ -507,12 +514,12 @@ final class Positive_Only_SocialUITests: XCTestCase {
         // Tap and type the reply
         replyTextEditor.tap()
         typeText(element: replyTextEditor, text: commentText)
-        
-        // Tap the Send button
-        let sendButton = app.buttons["Send"]
-        XCTAssertTrue(sendButton.waitForExistence(timeout: TestConstants.shortTimeout))
-        XCTAssertTrue(sendButton.isEnabled)
-        sendButton.tap()
+
+        // Tap the Post button (the shared composer's confirm action)
+        let postButton = app.buttons["PostCommentButton"]
+        XCTAssertTrue(postButton.waitForExistence(timeout: TestConstants.shortTimeout))
+        XCTAssertTrue(postButton.isEnabled)
+        postButton.tap()
         
         // Should be two comments total
         let commentElements = app.staticTexts.matching(identifier: "CommentText")
@@ -1439,8 +1446,8 @@ final class Positive_Only_SocialUITests: XCTestCase {
         // Deleting pops the Post Detail view back to the Home grid it was
         // opened from. The deletion round-trips through the API before the
         // pop, so wait for the view to go away rather than asserting instantly.
-        let commentField = app.textFields["AddACommentTextFieldToPost"]
-        expectation(for: NSPredicate(format: "exists == false"), evaluatedWith: commentField, handler: nil)
+        let commentButton = app.buttons["AddACommentButton"]
+        expectation(for: NSPredicate(format: "exists == false"), evaluatedWith: commentButton, handler: nil)
         waitForExpectations(timeout: TestConstants.timeout, handler: nil)
 
         assertOnHomeView(app: app)

--- a/ios/Positive Only Social/Positive Only SocialUITests/Positive_Only_SocialUITests.swift
+++ b/ios/Positive Only Social/Positive Only SocialUITests/Positive_Only_SocialUITests.swift
@@ -451,9 +451,9 @@ final class Positive_Only_SocialUITests: XCTestCase {
         XCTAssertTrue(addACommentButton.waitForExistence(timeout: TestConstants.shortTimeout))
         addACommentButton.tap()
 
-        // The composer presents a TextEditor, which is a textView in the
-        // accessibility hierarchy.
-        let commentTextEditor = app.textViews.firstMatch
+        // The composer presents a TextEditor (a textView in the accessibility
+        // hierarchy), queried by its identifier so it can't match a stray textView.
+        let commentTextEditor = app.textViews["CommentComposerTextEditor"]
         XCTAssertTrue(commentTextEditor.waitForExistence(timeout: TestConstants.shortTimeout))
         commentTextEditor.tap()
         typeText(element: commentTextEditor, text: commentText)
@@ -506,9 +506,9 @@ final class Positive_Only_SocialUITests: XCTestCase {
         let replySheet = app.navigationBars["Post Reply"]
         XCTAssertTrue(replySheet.waitForExistence(timeout: TestConstants.shortTimeout))
         
-        // Find the TextEditor in the sheet
-        // TextEditor appears as a textView in the accessibility hierarchy
-        let replyTextEditor = app.textViews.firstMatch
+        // Find the TextEditor in the sheet, queried by its identifier so it
+        // can't match a stray textView elsewhere on screen.
+        let replyTextEditor = app.textViews["CommentComposerTextEditor"]
         XCTAssertTrue(replyTextEditor.waitForExistence(timeout: TestConstants.shortTimeout))
         
         // Tap and type the reply

--- a/website/src/pages/MainApp.css
+++ b/website/src/pages/MainApp.css
@@ -789,8 +789,17 @@
 
 .comment-row__collapse {
   margin-left: auto;
+  background: none;
+  border: none;
+  padding: 0 0.25rem;
   font-size: 0.75rem;
+  line-height: 1;
   color: rgba(255, 255, 255, 0.5);
+  cursor: pointer;
+}
+
+.comment-row__collapse:hover {
+  color: rgba(255, 255, 255, 0.85);
 }
 
 .comment-row__body {

--- a/website/src/pages/MainApp.css
+++ b/website/src/pages/MainApp.css
@@ -692,6 +692,23 @@
   margin: 1rem 0;
 }
 
+/* Tappable field-styled button that opens the comment composer dialog. */
+.comment-compose-trigger {
+  flex: 1;
+  text-align: left;
+  background: #1a1a1a;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 10px;
+  color: rgba(255, 255, 255, 0.5);
+  padding: 0.6rem 0.9rem;
+  font-size: 0.95rem;
+  cursor: pointer;
+}
+
+.comment-compose-trigger:hover {
+  border-color: #5ba4dc;
+}
+
 /* ---- Character-limit counter ---- */
 
 .char-counter {
@@ -746,14 +763,39 @@
   color: rgba(255, 255, 255, 0.5);
 }
 
+.comment-row__main {
+  flex: 1;
+  min-width: 0;
+}
+
+/* Username + time band. Tapping it collapses the thread below (issue #243). */
+.comment-row__header {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  cursor: pointer;
+}
+
 .comment-row__author {
   font-weight: 700;
   font-size: 0.9rem;
   margin-right: 0.35rem;
 }
 
+.comment-row__time {
+  font-size: 0.78rem;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.comment-row__collapse {
+  margin-left: auto;
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.5);
+}
+
 .comment-row__body {
   font-size: 0.9rem;
+  margin: 0.2rem 0 0;
 }
 
 .comment-row__info {

--- a/website/src/pages/PostDetailPage.test.tsx
+++ b/website/src/pages/PostDetailPage.test.tsx
@@ -131,12 +131,45 @@ test('renders comment threads', async () => {
   expect(screen.getByText('bob')).toBeInTheDocument()
 })
 
-test('posting a comment calls the API and reloads', async () => {
+test('posting a comment opens the dialog, calls the API, and dismisses', async () => {
   renderDetail()
   await screen.findByText('sunshine')
-  await userEvent.type(screen.getByLabelText('Add a comment'), 'nice!')
+  await userEvent.click(screen.getByRole('button', { name: 'Add a comment...' }))
+  await userEvent.type(screen.getByLabelText('Comment text'), 'nice!')
   await userEvent.click(screen.getByRole('button', { name: 'Post' }))
   await waitFor(() => expect(mockCommentOnPost).toHaveBeenCalledWith('p1', 'nice!'))
+  // The dialog closes immediately on submit so repeated taps can't double-post.
+  expect(screen.queryByRole('dialog', { name: 'Add comment' })).not.toBeInTheDocument()
+})
+
+test('collapsing a comment hides the replies below it, expanding restores them', async () => {
+  const reply: Comment = {
+    comment_identifier: 'c2',
+    body: 'totally agree',
+    author_username: 'cara',
+    creation_time: '2024-01-02T00:00:00.000Z',
+    updated_time: '2024-01-02T00:00:00.000Z',
+    comment_likes: 0,
+  }
+  mockGetThreadRefs.mockResolvedValue([{ comment_thread_identifier: 't1' }])
+  mockGetThreadComments.mockResolvedValue([comment, reply])
+  renderDetail()
+
+  // The root comment and its reply are both visible to start.
+  expect(await screen.findByText('love this')).toBeInTheDocument()
+  expect(screen.getByText('totally agree')).toBeInTheDocument()
+
+  // Tapping the root comment's header collapses the thread below it.
+  const collapseHeaders = screen.getAllByRole('button', { name: 'Collapse thread' })
+  await userEvent.click(collapseHeaders[0])
+  expect(screen.queryByText('totally agree')).not.toBeInTheDocument()
+  // The root stays put and its header flips to an expand affordance.
+  expect(screen.getByText('love this')).toBeInTheDocument()
+  expect(screen.getByRole('button', { name: 'Expand thread' })).toBeInTheDocument()
+
+  // Tapping it again expands the thread and the reply comes back.
+  await userEvent.click(screen.getByRole('button', { name: 'Expand thread' }))
+  expect(await screen.findByText('totally agree')).toBeInTheDocument()
 })
 
 test('refresh reloads the post and comments', async () => {
@@ -169,7 +202,8 @@ test('refresh during an in-flight load is coalesced into one follow-up load', as
   await screen.findByText('sunshine') // initial load done
 
   // Post a comment -> triggers loadAll, which parks on the 2nd getPostDetails.
-  await userEvent.type(screen.getByLabelText('Add a comment'), 'hi')
+  await userEvent.click(screen.getByRole('button', { name: 'Add a comment...' }))
+  await userEvent.type(screen.getByLabelText('Comment text'), 'hi')
   await userEvent.click(screen.getByRole('button', { name: 'Post' }))
   await waitFor(() => expect(mockGetDetails).toHaveBeenCalledTimes(2))
 

--- a/website/src/pages/PostDetailPage.tsx
+++ b/website/src/pages/PostDetailPage.tsx
@@ -690,23 +690,13 @@ function CommentRow({
         ◍
       </span>
       <div className="comment-row__main">
-        {/* The username + time form a header band. Tapping the space around the
-            author name collapses the thread below this comment (issue #243);
-            tapping the name itself still opens the profile. */}
-        <div
-          className="comment-row__header"
-          role="button"
-          tabIndex={0}
-          aria-expanded={!isCollapsed}
-          aria-label={isCollapsed ? 'Expand thread' : 'Collapse thread'}
-          onClick={onToggleCollapse}
-          onKeyDown={e => {
-            if (e.key === 'Enter' || e.key === ' ') {
-              e.preventDefault()
-              onToggleCollapse()
-            }
-          }}
-        >
+        {/* The username + time form a header band. The chevron is the real,
+            keyboard-accessible collapse control; the surrounding band also
+            toggles on click as a mouse convenience (issue #243). The author name
+            and chevron are sibling <button>s — never nested inside an interactive
+            role — and each stops click propagation so activating one doesn't also
+            trigger the band's collapse. */}
+        <div className="comment-row__header" onClick={onToggleCollapse}>
           <button
             type="button"
             className="feed-post__author"
@@ -719,9 +709,18 @@ function CommentRow({
             <span className="comment-row__author">{comment.authorUsername}</span>
           </button>
           <span className="comment-row__time">{formatRelativeTime(comment.createdTime)}</span>
-          <span className="comment-row__collapse" aria-hidden="true">
+          <button
+            type="button"
+            className="comment-row__collapse"
+            aria-expanded={!isCollapsed}
+            aria-label={isCollapsed ? 'Expand thread' : 'Collapse thread'}
+            onClick={e => {
+              e.stopPropagation()
+              onToggleCollapse()
+            }}
+          >
             {isCollapsed ? '▸' : '▾'}
-          </span>
+          </button>
         </div>
         {/* The comment body sits below the username/time header line. */}
         <p className="comment-row__body">{comment.body}</p>

--- a/website/src/pages/PostDetailPage.tsx
+++ b/website/src/pages/PostDetailPage.tsx
@@ -30,6 +30,9 @@ interface ThreadView {
 
 type ReportTarget = { type: 'post' } | { type: 'comment'; comment: CommentView }
 type DeleteTarget = { type: 'post' } | { type: 'comment'; comment: CommentView }
+// The comment composer is shared between a brand-new post comment and a reply
+// to an existing thread, so both go through the same character-limit dialog.
+type ComposerTarget = { type: 'post' } | { type: 'reply'; thread: ThreadView }
 
 /**
  * Full post view: image, like count, caption, and threaded comments with
@@ -77,13 +80,27 @@ function PostDetailView({ postId }: { postId: string }) {
   const [isRefreshing, setIsRefreshing] = useState(false)
   const [notFound, setNotFound] = useState(false)
 
-  const [newComment, setNewComment] = useState('')
-  const [replyText, setReplyText] = useState('')
-  const [replyTarget, setReplyTarget] = useState<ThreadView | null>(null)
+  // A single composer dialog drives both new post comments and thread replies,
+  // so both surfaces show the same character-limit popup instead of an inline
+  // field duplicated in every thread (issues #266, #289, #290).
+  const [composer, setComposer] = useState<ComposerTarget | null>(null)
+  const [composerText, setComposerText] = useState('')
   const [reportTarget, setReportTarget] = useState<ReportTarget | null>(null)
   const [reportReason, setReportReason] = useState('')
   const [deleteTarget, setDeleteTarget] = useState<DeleteTarget | null>(null)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  // Ids of comments whose thread below them is collapsed. Tapping a comment's
+  // username/time header toggles it (issue #243).
+  const [collapsedIds, setCollapsedIds] = useState<Set<string>>(new Set())
+
+  function toggleCollapsed(id: string) {
+    setCollapsedIds(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
 
   // Local like/report state, kept in refs so the in-app reload after posting a
   // comment/reply doesn't drop it (the API only returns server-side counts,
@@ -263,28 +280,30 @@ function PostDetailView({ postId }: { postId: string }) {
     }
   }
 
-  async function submitComment() {
-    const text = newComment.trim()
-    if (!text) return
-    try {
-      await apiClient.commentOnPost(postId, text)
-      setNewComment('')
-      await loadAll()
-    } catch (err) {
-      setErrorMessage((err as Error).message ?? 'Failed to post comment.')
-    }
+  function openComposer(target: ComposerTarget) {
+    setComposerText('')
+    setComposer(target)
   }
 
-  async function submitReply() {
-    const text = replyText.trim()
-    if (!text || !replyTarget) return
+  // Submitting closes the dialog immediately and clears the text before the
+  // request is sent, so repeated taps can't post the same comment twice and the
+  // keyboard/dialog disappear at once (issue #291).
+  async function submitComposer() {
+    const text = composerText.trim()
+    const target = composer
+    if (!text || !target) return
+    setComposer(null)
+    setComposerText('')
     try {
-      await apiClient.replyToCommentThread(postId, replyTarget.threadId, text)
-      setReplyText('')
-      setReplyTarget(null)
+      if (target.type === 'reply') {
+        await apiClient.replyToCommentThread(postId, target.thread.threadId, text)
+      } else {
+        await apiClient.commentOnPost(postId, text)
+      }
       await loadAll()
     } catch (err) {
-      setErrorMessage((err as Error).message ?? 'Failed to post reply.')
+      const verb = target.type === 'reply' ? 'reply' : 'comment'
+      setErrorMessage((err as Error).message ?? `Failed to post ${verb}.`)
     }
   }
 
@@ -443,25 +462,14 @@ function PostDetailView({ postId }: { postId: string }) {
         </p>
 
         <div className="comment-form">
-          <input
-            type="text"
-            placeholder="Add a comment..."
-            aria-label="Add a comment"
-            value={newComment}
-            onChange={e => setNewComment(e.target.value)}
-          />
           <button
             type="button"
-            className="btn btn-primary"
-            disabled={
-              newComment.trim().length === 0 || !isWithinLimit(newComment, MAX_COMMENT_LENGTH)
-            }
-            onClick={submitComment}
+            className="comment-compose-trigger"
+            onClick={() => openComposer({ type: 'post' })}
           >
-            Post
+            Add a comment...
           </button>
         </div>
-        <CharacterCounter value={newComment} max={MAX_COMMENT_LENGTH} />
 
         <h2 className="app-bar__title" style={{ fontSize: '1rem' }}>
           Comments
@@ -481,12 +489,20 @@ function PostDetailView({ postId }: { postId: string }) {
           <p className="muted">No comments yet. Be the first!</p>
         ) : (
           threads.map(thread => {
-            const [root, ...replies] = thread.comments
+            // Hide every comment that sits below the first collapsed one in the
+            // thread, so tapping a comment's header folds away the replies under
+            // it (issue #243).
+            const collapseAt = thread.comments.findIndex(c => collapsedIds.has(c.id))
+            const visible =
+              collapseAt === -1 ? thread.comments : thread.comments.slice(0, collapseAt + 1)
+            const [root, ...replies] = visible
             return (
               <div key={thread.threadId} className="comment-thread">
                 {root && (
                   <CommentRow
                     comment={root}
+                    isCollapsed={collapsedIds.has(root.id)}
+                    onToggleCollapse={() => toggleCollapsed(root.id)}
                     onToggleLike={() => toggleCommentLike(root)}
                     onReport={() => {
                       setReportReason('')
@@ -501,10 +517,7 @@ function PostDetailView({ postId }: { postId: string }) {
                 <button
                   type="button"
                   className="comment-reply-btn"
-                  onClick={() => {
-                    setReplyText('')
-                    setReplyTarget(thread)
-                  }}
+                  onClick={() => openComposer({ type: 'reply', thread })}
                 >
                   Reply
                 </button>
@@ -514,6 +527,8 @@ function PostDetailView({ postId }: { postId: string }) {
                       <CommentRow
                         key={reply.id}
                         comment={reply}
+                        isCollapsed={collapsedIds.has(reply.id)}
+                        onToggleCollapse={() => toggleCollapsed(reply.id)}
                         onToggleLike={() => toggleCommentLike(reply)}
                         onReport={() => {
                           setReportReason('')
@@ -533,27 +548,30 @@ function PostDetailView({ postId }: { postId: string }) {
         )}
       </main>
 
-      {replyTarget && (
+      {composer && (
         <div className="modal-overlay">
-          <div className="modal" role="dialog" aria-modal="true" aria-label="Post reply">
+          <div className="modal" role="dialog" aria-modal="true" aria-label="Add comment">
             <h2 className="modal__title">
-              Replying to {replyTarget.comments[0]?.authorUsername ?? 'comment'}
+              {composer.type === 'reply'
+                ? `Replying to ${composer.thread.comments[0]?.authorUsername ?? 'comment'}`
+                : 'Add a comment'}
             </h2>
             <textarea
               className="text-area"
               rows={4}
-              aria-label="Reply text"
-              value={replyText}
-              onChange={e => setReplyText(e.target.value)}
+              aria-label="Comment text"
+              autoFocus
+              value={composerText}
+              onChange={e => setComposerText(e.target.value)}
             />
-            <CharacterCounter value={replyText} max={MAX_COMMENT_LENGTH} />
+            <CharacterCounter value={composerText} max={MAX_COMMENT_LENGTH} />
             <div className="modal__actions">
               <button
                 type="button"
                 className="modal__cancel"
                 onClick={() => {
-                  setReplyTarget(null)
-                  setReplyText('')
+                  setComposer(null)
+                  setComposerText('')
                 }}
               >
                 Cancel
@@ -562,11 +580,12 @@ function PostDetailView({ postId }: { postId: string }) {
                 type="button"
                 className="modal__confirm"
                 disabled={
-                  replyText.trim().length === 0 || !isWithinLimit(replyText, MAX_COMMENT_LENGTH)
+                  composerText.trim().length === 0 ||
+                  !isWithinLimit(composerText, MAX_COMMENT_LENGTH)
                 }
-                onClick={submitReply}
+                onClick={submitComposer}
               >
-                Send
+                {composer.type === 'reply' ? 'Send' : 'Post'}
               </button>
             </div>
           </div>
@@ -648,32 +667,65 @@ function DetailBar({ onBack }: { onBack: () => void }) {
 
 interface CommentRowProps {
   comment: CommentView
+  isCollapsed: boolean
+  onToggleCollapse: () => void
   onToggleLike: () => void
   onReport: () => void
   onDelete: () => void
   onNavigate: () => void
 }
 
-function CommentRow({ comment, onToggleLike, onReport, onDelete, onNavigate }: CommentRowProps) {
+function CommentRow({
+  comment,
+  isCollapsed,
+  onToggleCollapse,
+  onToggleLike,
+  onReport,
+  onDelete,
+  onNavigate,
+}: CommentRowProps) {
   return (
     <div className="comment-row">
       <span className="comment-row__avatar" aria-hidden="true">
         ◍
       </span>
-      <div>
-        <span>
+      <div className="comment-row__main">
+        {/* The username + time form a header band. Tapping the space around the
+            author name collapses the thread below this comment (issue #243);
+            tapping the name itself still opens the profile. */}
+        <div
+          className="comment-row__header"
+          role="button"
+          tabIndex={0}
+          aria-expanded={!isCollapsed}
+          aria-label={isCollapsed ? 'Expand thread' : 'Collapse thread'}
+          onClick={onToggleCollapse}
+          onKeyDown={e => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault()
+              onToggleCollapse()
+            }
+          }}
+        >
           <button
             type="button"
             className="feed-post__author"
             style={{ display: 'inline', padding: 0 }}
-            onClick={onNavigate}
+            onClick={e => {
+              e.stopPropagation()
+              onNavigate()
+            }}
           >
             <span className="comment-row__author">{comment.authorUsername}</span>
           </button>
-          <span className="comment-row__body">{comment.body}</span>
-        </span>
+          <span className="comment-row__time">{formatRelativeTime(comment.createdTime)}</span>
+          <span className="comment-row__collapse" aria-hidden="true">
+            {isCollapsed ? '▸' : '▾'}
+          </span>
+        </div>
+        {/* The comment body sits below the username/time header line. */}
+        <p className="comment-row__body">{comment.body}</p>
         <div className="comment-row__info">
-          <span>{formatRelativeTime(comment.createdTime)}</span>
           {!comment.isOwn && (
             <button
               type="button"


### PR DESCRIPTION
Fixes #291, #290, #289, #266, #293, #243.

Reworks commenting consistently across **Android**, **iOS**, and **website**.

## What changed

### Unified comment composer (#266, #289, #290)
Commenting on a post and replying to a thread now both go through **one shared composer dialog/sheet** that always shows the character counter, instead of an inline text field duplicated inside every thread. The post shows an "Add a comment…" button that opens the same dialog used by "Reply".

### Posting reflects immediately (#291)
Submitting **closes the dialog and clears the text synchronously, before the network request fires**, so tapping the button repeatedly can't create duplicate comments, and the keyboard dismisses with the dialog.

### Collapse threads + layout (#243)
The comment body now sits **below** the username/time header line. Tapping the space next to the username/time **collapses every comment below that one in the thread** (chevron affordance, toggleable). Tapping the username itself still opens the author's profile. Collapse state lives in the view model so it survives reloads.

### Oldest → newest ordering (#293)
Threads are ordered oldest→newest by their first comment (comments within a thread were already oldest-first). Android's previously commented-out thread sort is re-enabled; iOS/web already did this.

## Tests
- **Website**: new DOM test that collapses a root comment, asserts the reply hides and the header flips to "Expand thread", then expands and asserts it returns. Updated the comment/reply flow tests to drive the new composer dialog.
- **Android**: view-model tests for `toggleCommentCollapsed` (add/remove + independent tracking); updated the instrumented comment/reply flow.
- **iOS**: view-model tests for `toggleCommentCollapsed`; updated XCUITest comment/reply flow to use the composer sheet (`AddACommentButton`, `PostCommentButton`).

> Note: I could not run the suites locally (no Node, Java, or Xcode in the dev environment), so they rely on the Android/iOS/Website CI workflows for validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)