### PR TITLE
Android: set region on Cognito client so posting works

### DIFF
--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/uploader/AWSManager.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/uploader/AWSManager.kt
@@ -159,24 +159,32 @@ class CognitoCredentialsProvider(
 ) : CredentialsProvider {
 
     override suspend fun resolve(attributes: Attributes): Credentials {
-        // 1. Get ID
-        val identityClient = CognitoIdentityClient { }
-        val idResponse = identityClient.getId {
-            identityPoolId = this@CognitoCredentialsProvider.identityPoolId
+        // The AWS Kotlin SDK requires an explicit region — on Android there is no
+        // ambient region (no env vars / instance metadata), so omitting it makes
+        // the first call throw a region-resolution error before any request is
+        // sent, which surfaced as posts "failing immediately" (issue #292).
+        val identityClient = CognitoIdentityClient {
+            region = this@CognitoCredentialsProvider.region
         }
+        identityClient.use { client ->
+            // 1. Get ID
+            val idResponse = client.getId {
+                identityPoolId = this@CognitoCredentialsProvider.identityPoolId
+            }
 
-        // 2. Get Credentials for ID
-        val credsResponse = identityClient.getCredentialsForIdentity {
-            identityId = idResponse.identityId
+            // 2. Get Credentials for ID
+            val credsResponse = client.getCredentialsForIdentity {
+                identityId = idResponse.identityId
+            }
+
+            val credentials = credsResponse.credentials ?: throw Exception("No credentials returned")
+
+            return Credentials(
+                accessKeyId = credentials.accessKeyId ?: "",
+                secretAccessKey = credentials.secretKey ?: "",
+                sessionToken = credentials.sessionToken,
+                expiration = credentials.expiration
+            )
         }
-
-        val credentials = credsResponse.credentials ?: throw Exception("No credentials returned")
-
-        return Credentials(
-            accessKeyId = credentials.accessKeyId ?: "",
-            secretAccessKey = credentials.secretKey ?: "",
-            sessionToken = credentials.sessionToken,
-            expiration = credentials.expiration
-        )
     }
 }


### PR DESCRIPTION
## Problem

On Android, posting is completely broken (#292): every post fails instantly with the generic *"Failed to share post. Please try again."*, and the backend never logs a `make_post` request.

## Root cause

In `CognitoCredentialsProvider.resolve()` (`AWSManager.kt`), the `CognitoIdentityClient` was built with **no region**, even though the provider already received a `region` constructor argument and never used it. The AWS Kotlin SDK requires an explicit region, and Android has no ambient region source (no env vars / instance metadata), so the first credential call (`getId`) threw a region-resolution error **immediately**.

Because the S3 upload runs *before* `api.makePost()`:
- the throw short-circuits the flow, so the backend never receives a `make_post` request (no logs);
- the error isn't an `IOException`, so `ApiErrors.messageFor` returns the generic fallback — "failed immediately. Nothing else.";
- login/feed kept working because they use Retrofit/OkHttp, not the AWS Kotlin SDK.

## Fix

Pass the region into `CognitoIdentityClient`, and wrap it in `use {}` so the client is closed instead of leaking a new one on every upload.

## Testing

No Android SDK is configured in the dev environment, so this was not built locally. The change is minimal: `region` is the same builder field already used successfully for `S3Client` in the same file.

Fixes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)