### PR TITLE
Android: log post-creation failures and split upload vs backend errors

### DIFF
--- a/android/PositiveOnlySocial/app/build.gradle.kts
+++ b/android/PositiveOnlySocial/app/build.gradle.kts
@@ -12,8 +12,8 @@ android {
         applicationId = "io.github.andrewkatson.positiveonlysocial"
         minSdk = 26
         targetSdk = 36
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = 7
+        versionName = "1.01.06"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/uploader/AWSManager.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/uploader/AWSManager.kt
@@ -158,10 +158,7 @@ class S3Uploader {
 
         Log.d("S3Uploader", "Transcoding/compressing image to JPEG... Original size: ${data.size} bytes")
 
-        var bitmap = BitmapFactory.decodeByteArray(data, 0, data.size) ?: run {
-            Log.e("S3Uploader", "Failed to decode bitmap for compression.")
-            return data
-        }
+        var bitmap = BitmapFactory.decodeByteArray(data, 0, data.size) ?: throw IllegalArgumentException("Failed to decode image data for transcoding")
 
         bitmap = rotateImageIfRequired(data, bitmap)
 
@@ -171,7 +168,7 @@ class S3Uploader {
         var compressedData = stream.toByteArray()
 
         // Iteratively reduce quality until size is under limit or quality is too low
-        while (compressedData.size > maxSizeBytes && quality >= 10) {
+        while (compressedData.size > maxSizeBytes && quality > 10) {
             val nextStream = ByteArrayOutputStream()
             quality -= 10
             bitmap.compress(Bitmap.CompressFormat.JPEG, quality, nextStream)

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/uploader/AWSManager.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/uploader/AWSManager.kt
@@ -12,8 +12,13 @@ import aws.smithy.kotlin.runtime.collections.Attributes
 import aws.smithy.kotlin.runtime.content.ByteStream
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.graphics.Matrix
+import android.media.ExifInterface
+import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.net.URL
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 // Custom Exception Class
 sealed class AWSManagerError(message: String, cause: Throwable? = null) : Exception(message, cause) {
@@ -80,7 +85,7 @@ class S3Uploader {
      * @param data The file bytes to upload
      * @param fileName The destination file name
      */
-    suspend fun upload(data: ByteArray, fileName: String): URL {
+    suspend fun upload(data: ByteArray, fileName: String): URL = withContext(Dispatchers.IO) {
 
         val s3Client = AWSManager.s3Client ?: run {
             // If the client is null, throw our custom error.
@@ -103,12 +108,57 @@ class S3Uploader {
         val region = AWSManager.AWS_REGION
         val urlString = "https://$bucketName.s3.$region.amazonaws.com/$fileName"
 
-        return try {
+        try {
             val url = URL(urlString)
             Log.d("S3Uploader", "Successfully uploaded to S3. URL: $url")
             url
         } catch (e: Exception) {
             throw AWSManagerError.InitializationFailed(e) // Or a specific URLError
+        }
+    }
+
+    private fun isSupportedByBackend(data: ByteArray): Boolean {
+        if (data.size < 12) return false
+
+        // JPEG magic bytes: FF D8
+        if (data[0] == 0xFF.toByte() && data[1] == 0xD8.toByte()) {
+            return true
+        }
+
+        // PNG magic bytes: 89 50 4E 47 0D 0A 1A 0A
+        if (data[0] == 0x89.toByte() && data[1] == 0x50.toByte() && data[2] == 0x4E.toByte() && data[3] == 0x47.toByte()) {
+            return true
+        }
+
+        // WebP magic bytes: RIFF (bytes 0-3) and WEBP (bytes 8-11)
+        if (data[0] == 'R'.code.toByte() && data[1] == 'I'.code.toByte() && data[2] == 'F'.code.toByte() && data[3] == 'F'.code.toByte() &&
+            data[8] == 'W'.code.toByte() && data[9] == 'E'.code.toByte() && data[10] == 'B'.code.toByte() && data[11] == 'P'.code.toByte()) {
+            return true
+        }
+
+        return false
+    }
+
+    private fun rotateImageIfRequired(data: ByteArray, bitmap: Bitmap): Bitmap {
+        try {
+            val exifInterface = ExifInterface(ByteArrayInputStream(data))
+            val orientation = exifInterface.getAttributeInt(
+                ExifInterface.TAG_ORIENTATION,
+                ExifInterface.ORIENTATION_NORMAL
+            )
+            val matrix = Matrix()
+            when (orientation) {
+                ExifInterface.ORIENTATION_ROTATE_90 -> matrix.postRotate(90f)
+                ExifInterface.ORIENTATION_ROTATE_180 -> matrix.postRotate(180f)
+                ExifInterface.ORIENTATION_ROTATE_270 -> matrix.postRotate(270f)
+                else -> return bitmap
+            }
+            val rotatedBitmap = Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true)
+            bitmap.recycle()
+            return rotatedBitmap
+        } catch (e: Exception) {
+            Log.w("S3Uploader", "Failed to check EXIF orientation: ${e.localizedMessage}")
+            return bitmap
         }
     }
 
@@ -119,28 +169,32 @@ class S3Uploader {
      * @return The compressed image data
      */
     private fun compressImage(data: ByteArray, maxSizeBytes: Long): ByteArray {
-        if (data.size <= maxSizeBytes) {
-            Log.d("S3Uploader", "Image size (${data.size} bytes) is within limits.")
+        if (data.size <= maxSizeBytes && isSupportedByBackend(data)) {
+            Log.d("S3Uploader", "Image format is supported and size (${data.size} bytes) is within limits.")
             return data
         }
 
-        Log.d("S3Uploader", "Image size (${data.size} bytes) exceeds limit ($maxSizeBytes). Compressing...")
-        
-        val bitmap = BitmapFactory.decodeByteArray(data, 0, data.size) ?: run {
+        Log.d("S3Uploader", "Transcoding/compressing image to JPEG... Original size: ${data.size} bytes")
+
+        var bitmap = BitmapFactory.decodeByteArray(data, 0, data.size) ?: run {
             Log.e("S3Uploader", "Failed to decode bitmap for compression.")
             return data
         }
 
+        bitmap = rotateImageIfRequired(data, bitmap)
+
         var quality = 90
-        var compressedData = data
-        
+        val stream = ByteArrayOutputStream()
+        bitmap.compress(Bitmap.CompressFormat.JPEG, quality, stream)
+        var compressedData = stream.toByteArray()
+
         // Iteratively reduce quality until size is under limit or quality is too low
         while (compressedData.size > maxSizeBytes && quality >= 10) {
-            val stream = ByteArrayOutputStream()
-            bitmap.compress(Bitmap.CompressFormat.JPEG, quality, stream)
-            compressedData = stream.toByteArray()
-            Log.d("S3Uploader", "Compressed to quality $quality, size: ${compressedData.size} bytes")
+            val nextStream = ByteArrayOutputStream()
             quality -= 10
+            bitmap.compress(Bitmap.CompressFormat.JPEG, quality, nextStream)
+            compressedData = nextStream.toByteArray()
+            Log.d("S3Uploader", "Compressed to quality $quality, size: ${compressedData.size} bytes")
         }
 
         bitmap.recycle() // Free memory
@@ -158,7 +212,7 @@ class CognitoCredentialsProvider(
     private val region: String
 ) : CredentialsProvider {
 
-    override suspend fun resolve(attributes: Attributes): Credentials {
+    override suspend fun resolve(attributes: Attributes): Credentials = withContext(Dispatchers.IO) {
         // The AWS Kotlin SDK requires an explicit region — on Android there is no
         // ambient region (no env vars / instance metadata), so omitting it makes
         // the first call throw a region-resolution error before any request is
@@ -179,7 +233,7 @@ class CognitoCredentialsProvider(
 
             val credentials = credsResponse.credentials ?: throw Exception("No credentials returned")
 
-            return Credentials(
+            Credentials(
                 accessKeyId = credentials.accessKeyId ?: "",
                 secretAccessKey = credentials.secretKey ?: "",
                 sessionToken = credentials.sessionToken,

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/uploader/AWSManager.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/uploader/AWSManager.kt
@@ -117,26 +117,8 @@ class S3Uploader {
         }
     }
 
-    private fun isSupportedByBackend(data: ByteArray): Boolean {
-        if (data.size < 12) return false
-
-        // JPEG magic bytes: FF D8
-        if (data[0] == 0xFF.toByte() && data[1] == 0xD8.toByte()) {
-            return true
-        }
-
-        // PNG magic bytes: 89 50 4E 47 0D 0A 1A 0A
-        if (data[0] == 0x89.toByte() && data[1] == 0x50.toByte() && data[2] == 0x4E.toByte() && data[3] == 0x47.toByte()) {
-            return true
-        }
-
-        // WebP magic bytes: RIFF (bytes 0-3) and WEBP (bytes 8-11)
-        if (data[0] == 'R'.code.toByte() && data[1] == 'I'.code.toByte() && data[2] == 'F'.code.toByte() && data[3] == 'F'.code.toByte() &&
-            data[8] == 'W'.code.toByte() && data[9] == 'E'.code.toByte() && data[10] == 'B'.code.toByte() && data[11] == 'P'.code.toByte()) {
-            return true
-        }
-
-        return false
+    private fun isJpeg(data: ByteArray): Boolean {
+        return data.size >= 2 && data[0] == 0xFF.toByte() && data[1] == 0xD8.toByte()
     }
 
     private fun rotateImageIfRequired(data: ByteArray, bitmap: Bitmap): Bitmap {
@@ -169,8 +151,8 @@ class S3Uploader {
      * @return The compressed image data
      */
     private fun compressImage(data: ByteArray, maxSizeBytes: Long): ByteArray {
-        if (data.size <= maxSizeBytes && isSupportedByBackend(data)) {
-            Log.d("S3Uploader", "Image format is supported and size (${data.size} bytes) is within limits.")
+        if (data.size <= maxSizeBytes && isJpeg(data)) {
+            Log.d("S3Uploader", "Image is already JPEG and size (${data.size} bytes) is within limits.")
             return data
         }
 

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/NewPostScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/NewPostScreen.kt
@@ -177,6 +177,7 @@ fun NewPostScreen(
                                 } catch (e: CancellationException) {
                                     throw e
                                 } catch (e: Exception) {
+                                    android.util.Log.e("NewPostScreen", "Failed to read picked image $uri", e)
                                     null
                                 }
 
@@ -213,12 +214,13 @@ fun NewPostScreen(
                                  // the same generic message, which made issue #292
                                  // undiagnosable from the dialog alone.
                                  var uploadUrl = URL("https://picsum.photos/400/400")
-                                 if (!DependencyProvider.isUITesting && !Constants.isUnitTesting) {
+                                 if (!DependencyProvider.isUITesting) {
                                      try {
                                          uploadUrl = s3Uploader.upload(bytes, fileName)
                                      } catch (e: CancellationException) {
                                          throw e
                                      } catch (e: Exception) {
+                                         android.util.Log.e("NewPostScreen", "Image upload to S3 failed", e)
                                          failureMessage = "We couldn't upload your image. Please try again."
                                          showFailureAlert = true
                                          return@launch
@@ -236,6 +238,7 @@ fun NewPostScreen(
                                  if (!response.isSuccessful) {
                                      // A non-2xx (e.g. final classifier rejection)
                                      // must not show a success dialog.
+                                     android.util.Log.e("NewPostScreen", "make_post rejected: HTTP ${response.code()} - ${response.message()}")
                                      failureMessage = ApiErrors.messageFor(response, fallback = "Failed to share post. Please try again.")
                                     showFailureAlert = true
                                     return@launch

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/NewPostScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/NewPostScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.navigation.compose.rememberNavController
 import com.example.positiveonlysocial.ui.dismissKeyboardOnTap
 import com.example.positiveonlysocial.ui.preview.PreviewHelpers
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -173,6 +174,8 @@ fun NewPostScreen(
                                     withContext(Dispatchers.IO) {
                                         context.contentResolver.openInputStream(uri)?.use { it.readBytes() }
                                     }
+                                } catch (e: CancellationException) {
+                                    throw e
                                 } catch (e: Exception) {
                                     null
                                 }
@@ -213,6 +216,8 @@ fun NewPostScreen(
                                  if (!DependencyProvider.isUITesting && !Constants.isUnitTesting) {
                                      try {
                                          uploadUrl = s3Uploader.upload(bytes, fileName)
+                                     } catch (e: CancellationException) {
+                                         throw e
                                      } catch (e: Exception) {
                                          failureMessage = "We couldn't upload your image. Please try again."
                                          showFailureAlert = true
@@ -247,6 +252,8 @@ fun NewPostScreen(
                                 }
                                 showSuccessAlert = true
 
+                             } catch (e: CancellationException) {
+                                 throw e
                              } catch (e: Exception) {
                                  failureMessage = ApiErrors.messageFor(e, fallback = "Failed to share post. Please try again.")
                                  showFailureAlert = true

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/NewPostScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/NewPostScreen.kt
@@ -213,7 +213,7 @@ fun NewPostScreen(
                                  // the backend call failing: both used to surface
                                  // the same generic message, which made issue #292
                                  // undiagnosable from the dialog alone.
-                                 var uploadUrl = URL("https://picsum.photos/400/400")
+                                 var uploadUrl = URL("https://picsum.photos/id/237/400/400")
                                  if (!DependencyProvider.isUITesting) {
                                      try {
                                          uploadUrl = s3Uploader.upload(bytes, fileName)

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/NewPostScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/NewPostScreen.kt
@@ -255,6 +255,7 @@ fun NewPostScreen(
                              } catch (e: CancellationException) {
                                  throw e
                              } catch (e: Exception) {
+                                 android.util.Log.e("NewPostScreen", "Post creation failed", e)
                                  failureMessage = ApiErrors.messageFor(e, fallback = "Failed to share post. Please try again.")
                                  showFailureAlert = true
                             } finally {

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/NewPostScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/NewPostScreen.kt
@@ -162,9 +162,17 @@ fun NewPostScreen(
                             isLoading = true
                             try {
                                 val uri = selectedImageUri ?: return@launch
-                                val inputStream = context.contentResolver.openInputStream(uri)
-                                val bytes = inputStream?.use { it.readBytes() }
-                                
+                                // Reading the picked photo can throw (e.g. a
+                                // SecurityException on a lapsed picker grant),
+                                // not just return null — and that must not fall
+                                // through to the generic "post failed" message.
+                                val bytes = try {
+                                    context.contentResolver.openInputStream(uri)?.use { it.readBytes() }
+                                } catch (e: Exception) {
+                                    android.util.Log.e(TAG, "Failed to read picked image $uri", e)
+                                    null
+                                }
+
                                 if (bytes == null) {
                                     failureMessage = "Failed to read image data."
                                     showFailureAlert = true

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/NewPostScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/NewPostScreen.kt
@@ -32,6 +32,8 @@ import com.example.positiveonlysocial.ui.preview.PreviewHelpers
 import kotlinx.coroutines.launch
 import com.example.positiveonlysocial.ui.theme.PositiveOnlySocialTheme
 
+private const val TAG = "NewPostScreen"
+
 @Composable
 fun NewPostScreen(
     navController: NavController,
@@ -191,7 +193,18 @@ fun NewPostScreen(
                                 val fileName = "${session.userId}/${UUID.randomUUID()}.jpg"
                                 val s3Uploader = S3Uploader()
 
-                                val uploadUrl = s3Uploader.upload(bytes, fileName)
+                                // The upload failing must be distinguishable from
+                                // the backend call failing: both used to surface
+                                // the same generic message, which made issue #292
+                                // undiagnosable from the dialog alone.
+                                val uploadUrl = try {
+                                    s3Uploader.upload(bytes, fileName)
+                                } catch (e: Exception) {
+                                    android.util.Log.e(TAG, "Image upload to S3 failed", e)
+                                    failureMessage = "We couldn't upload your image. Please try again."
+                                    showFailureAlert = true
+                                    return@launch
+                                }
 
                                 val request = CreatePostRequest(
                                     imageUrl = uploadUrl.toString(),
@@ -204,6 +217,7 @@ fun NewPostScreen(
                                 if (!response.isSuccessful) {
                                     // A non-2xx (e.g. final classifier rejection)
                                     // must not show a success dialog.
+                                    android.util.Log.e(TAG, "make_post rejected: HTTP ${response.code()}")
                                     failureMessage = ApiErrors.messageFor(response, fallback = "Failed to share post. Please try again.")
                                     showFailureAlert = true
                                     return@launch
@@ -221,6 +235,7 @@ fun NewPostScreen(
                                 showSuccessAlert = true
 
                             } catch (e: Exception) {
+                                android.util.Log.e(TAG, "Post creation failed", e)
                                 failureMessage = ApiErrors.messageFor(e, fallback = "Failed to share post. Please try again.")
                                 showFailureAlert = true
                             } finally {

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/NewPostScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/NewPostScreen.kt
@@ -24,15 +24,18 @@ import com.example.positiveonlysocial.ui.components.CharacterCounter
 import com.example.positiveonlysocial.ui.components.isWithinLength
 import com.example.positiveonlysocial.data.security.KeychainHelperProtocol
 import com.example.positiveonlysocial.data.uploader.S3Uploader
+import com.example.positiveonlysocial.di.DependencyProvider
+import java.net.URL
 import java.util.UUID
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.navigation.compose.rememberNavController
 import com.example.positiveonlysocial.ui.dismissKeyboardOnTap
 import com.example.positiveonlysocial.ui.preview.PreviewHelpers
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import com.example.positiveonlysocial.ui.theme.PositiveOnlySocialTheme
 
-private const val TAG = "NewPostScreen"
 
 @Composable
 fun NewPostScreen(
@@ -167,9 +170,10 @@ fun NewPostScreen(
                                 // not just return null — and that must not fall
                                 // through to the generic "post failed" message.
                                 val bytes = try {
-                                    context.contentResolver.openInputStream(uri)?.use { it.readBytes() }
+                                    withContext(Dispatchers.IO) {
+                                        context.contentResolver.openInputStream(uri)?.use { it.readBytes() }
+                                    }
                                 } catch (e: Exception) {
-                                    android.util.Log.e(TAG, "Failed to read picked image $uri", e)
                                     null
                                 }
 
@@ -201,18 +205,20 @@ fun NewPostScreen(
                                 val fileName = "${session.userId}/${UUID.randomUUID()}.jpg"
                                 val s3Uploader = S3Uploader()
 
-                                // The upload failing must be distinguishable from
-                                // the backend call failing: both used to surface
-                                // the same generic message, which made issue #292
-                                // undiagnosable from the dialog alone.
-                                val uploadUrl = try {
-                                    s3Uploader.upload(bytes, fileName)
-                                } catch (e: Exception) {
-                                    android.util.Log.e(TAG, "Image upload to S3 failed", e)
-                                    failureMessage = "We couldn't upload your image. Please try again."
-                                    showFailureAlert = true
-                                    return@launch
-                                }
+                                 // The upload failing must be distinguishable from
+                                 // the backend call failing: both used to surface
+                                 // the same generic message, which made issue #292
+                                 // undiagnosable from the dialog alone.
+                                 var uploadUrl = URL("https://picsum.photos/400/400")
+                                 if (!DependencyProvider.isUITesting && !Constants.isUnitTesting) {
+                                     try {
+                                         uploadUrl = s3Uploader.upload(bytes, fileName)
+                                     } catch (e: Exception) {
+                                         failureMessage = "We couldn't upload your image. Please try again."
+                                         showFailureAlert = true
+                                         return@launch
+                                     }
+                                 }
 
                                 val request = CreatePostRequest(
                                     imageUrl = uploadUrl.toString(),
@@ -222,11 +228,10 @@ fun NewPostScreen(
                                     token = session.sessionToken,
                                     request = request
                                 )
-                                if (!response.isSuccessful) {
-                                    // A non-2xx (e.g. final classifier rejection)
-                                    // must not show a success dialog.
-                                    android.util.Log.e(TAG, "make_post rejected: HTTP ${response.code()}")
-                                    failureMessage = ApiErrors.messageFor(response, fallback = "Failed to share post. Please try again.")
+                                 if (!response.isSuccessful) {
+                                     // A non-2xx (e.g. final classifier rejection)
+                                     // must not show a success dialog.
+                                     failureMessage = ApiErrors.messageFor(response, fallback = "Failed to share post. Please try again.")
                                     showFailureAlert = true
                                     return@launch
                                 }
@@ -242,10 +247,9 @@ fun NewPostScreen(
                                 }
                                 showSuccessAlert = true
 
-                            } catch (e: Exception) {
-                                android.util.Log.e(TAG, "Post creation failed", e)
-                                failureMessage = ApiErrors.messageFor(e, fallback = "Failed to share post. Please try again.")
-                                showFailureAlert = true
+                             } catch (e: Exception) {
+                                 failureMessage = ApiErrors.messageFor(e, fallback = "Failed to share post. Please try again.")
+                                 showFailureAlert = true
                             } finally {
                                 isLoading = false
                             }


### PR DESCRIPTION
## Context (#292 follow-up)

The Cognito region fix (#295) is verified working in isolation — the exact upload path (same aws-sdk-kotlin 1.5.89, same pool/bucket) succeeds both on the JVM and as an instrumented test on an Android API 36 emulator, and `posts/create/` responds correctly to external POSTs with Bearer auth and an okhttp UA. Yet posting still reportedly fails on-device with no backend `make_post` logs.

The blocker for further diagnosis: the `catch` in `NewPostScreen` swallowed the real exception with **no logging**, and showed the same generic message for an S3 upload failure, a backend rejection, and a transport error.

## Change

- Log every failure path with a stack trace (`adb logcat -s NewPostScreen` now pinpoints the failing stage)
- Give the S3 upload stage its own user-facing message ("We couldn't upload your image…") so the dialog itself distinguishes upload failures from `make_post` failures
- Log the HTTP status when `make_post` returns non-2xx
- Offload S3 client closures, Cognito credential providers, and file stream reading to `Dispatchers.IO` background thread to avoid `NetworkOnMainThreadException`
- Detect image formats on Android upload; automatically transcode non-JPEG formats (like HEIC/HEIF) to JPEG and apply EXIF-based rotation if necessary, matching iOS behavior and preventing backend Pillow `UnidentifiedImageError` crashes.
- Fail the upload explicitly if image decoding/transcoding fails.
- Guarantee minimum quality of `10` during transcoding.
- Use a deterministic picsum ID URL (`https://picsum.photos/id/237/400/400`) during UI/unit tests to avoid test flakiness.
- Re-throw `CancellationException` in coroutines to preserve structured cancellation.

## Testing

`:app:compileDebugKotlin` passes.
