### PR TITLE
Sanitize backend error messages across Android, iOS, and Web clients

### DIFF
--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/api/ApiErrors.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/api/ApiErrors.kt
@@ -45,7 +45,8 @@ object ApiErrors {
         } catch (e: Exception) {
             null
         }
-        return backendError ?: statusMessage(response.code(), fallback)
+        val sanitizedError = backendError?.let { sanitizeErrorMessage(it) }
+        return sanitizedError ?: statusMessage(response.code(), fallback)
     }
 
     /**
@@ -69,5 +70,95 @@ object ApiErrors {
         502, 503, 504 -> "The server is taking too long to respond. Please try again in a moment."
         in 500..599 -> "The server ran into a problem. Please try again in a moment."
         else -> fallback
+    }
+
+    /**
+     * Sanitizes backend raw token error messages into human-legible sentences.
+     */
+    fun sanitizeErrorMessage(message: String): String {
+        val invalidFieldsPrefix = "Invalid fields"
+        val invalidPrefix = "Invalid "
+        
+        val suffix: String
+        val isInvalidFields: Boolean
+        
+        if (message.startsWith(invalidFieldsPrefix)) {
+            suffix = message.substring(invalidFieldsPrefix.length)
+            isInvalidFields = true
+        } else if (message.startsWith(invalidPrefix)) {
+            suffix = message.substring(invalidPrefix.length)
+            isInvalidFields = false
+            val cleaned = suffix.replace(Regex("[\\[\\]'\"]"), "").trim()
+            if (cleaned.contains(" ")) {
+                return message
+            }
+        } else {
+            return message
+        }
+        
+        val regex = Regex("[a-zA-Z0-9_]+")
+        val tokens = regex.findAll(suffix).map { it.value }.toList()
+        if (tokens.isEmpty()) {
+            return if (isInvalidFields) "Some fields are incorrect" else message
+        }
+        
+        val tokenMap = mapOf(
+            "USERNAME" to "Username",
+            "EMAIL" to "Email",
+            "PASSWORD" to "Password",
+            "USERNAME_OR_EMAIL" to "Username or email",
+            "USER_ID" to "User ID",
+            "IMAGE_URL" to "Image URL",
+            "COMMENT" to "Comment",
+            "RESET_TOKEN" to "Reset token",
+            "VERIFICATION_TOKEN" to "Verification token",
+            "IP" to "IP address",
+            "SESSION_MANAGEMENT_TOKEN" to "Session token",
+            "SERIES_IDENTIFIER" to "Series identifier",
+            "LOGIN_COOKIE_TOKEN" to "Cookie token",
+            "REMEMBER_ME" to "Remember me flag",
+            "CAPTION" to "Caption",
+            "POST_IDENTIFIER" to "Post identifier",
+            "REASON" to "Reason",
+            "COMMENT_TEXT" to "Comment text",
+            "COMMENT_THREAD_IDENTIFIER" to "Comment thread identifier",
+            "COMMENT_IDENTIFIER" to "Comment identifier",
+            "USERNAME_FRAGMENT" to "Username fragment",
+            "DATE_OF_BIRTH" to "Date of birth",
+            "TARGET_TYPE" to "Target type",
+            "TARGET_IDENTIFIER" to "Target identifier"
+        )
+        
+        val friendlyNames = mutableListOf<String>()
+        for (token in tokens) {
+            val upperToken = token.uppercase()
+            val name = tokenMap[upperToken] ?: run {
+                val parts = token.split("_")
+                parts.mapIndexed { index, part ->
+                    val partLower = part.lowercase()
+                    if (index == 0) {
+                        partLower.replaceFirstChar { it.uppercase() }
+                    } else {
+                        partLower
+                    }
+                }.joinToString(" ")
+            }
+            if (name.isNotEmpty() && !friendlyNames.contains(name)) {
+                friendlyNames.add(name)
+            }
+        }
+        
+        if (friendlyNames.isEmpty()) {
+            return if (isInvalidFields) "Some fields are incorrect" else message
+        }
+        
+        return when (friendlyNames.size) {
+            1 -> "${friendlyNames[0]} is incorrect"
+            2 -> "${friendlyNames[0]} and ${friendlyNames[1]} are incorrect"
+            else -> {
+                val list = friendlyNames.dropLast(1).joinToString(", ")
+                "$list, and ${friendlyNames.last()} are incorrect"
+            }
+        }
     }
 }

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/api/ApiErrors.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/api/ApiErrors.kt
@@ -26,6 +26,36 @@ object ApiErrors {
     private val gson = Gson()
 
     /**
+     * Maps backend raw field tokens to friendly display names.
+     */
+    private val tokenMap = mapOf(
+        "USERNAME" to "Username",
+        "EMAIL" to "Email",
+        "PASSWORD" to "Password",
+        "USERNAME_OR_EMAIL" to "Username or email",
+        "USER_ID" to "User ID",
+        "IMAGE_URL" to "Image URL",
+        "COMMENT" to "Comment",
+        "RESET_TOKEN" to "Reset token",
+        "VERIFICATION_TOKEN" to "Verification token",
+        "IP" to "IP address",
+        "SESSION_MANAGEMENT_TOKEN" to "Session token",
+        "SERIES_IDENTIFIER" to "Series identifier",
+        "LOGIN_COOKIE_TOKEN" to "Cookie token",
+        "REMEMBER_ME" to "Remember me flag",
+        "CAPTION" to "Caption",
+        "POST_IDENTIFIER" to "Post identifier",
+        "REASON" to "Reason",
+        "COMMENT_TEXT" to "Comment text",
+        "COMMENT_THREAD_IDENTIFIER" to "Comment thread identifier",
+        "COMMENT_IDENTIFIER" to "Comment identifier",
+        "USERNAME_FRAGMENT" to "Username fragment",
+        "DATE_OF_BIRTH" to "Date of birth",
+        "TARGET_TYPE" to "Target type",
+        "TARGET_IDENTIFIER" to "Target identifier"
+    )
+
+    /**
      * Friendly message for an unsuccessful Retrofit [response]. Prefers the
      * backend's own `error` message; otherwise maps the HTTP status code, and
      * finally falls back to [fallback] for unmapped codes.
@@ -101,34 +131,7 @@ object ApiErrors {
         if (tokens.isEmpty()) {
             return if (isInvalidFields) "Some fields are incorrect" else message
         }
-        
-        val tokenMap = mapOf(
-            "USERNAME" to "Username",
-            "EMAIL" to "Email",
-            "PASSWORD" to "Password",
-            "USERNAME_OR_EMAIL" to "Username or email",
-            "USER_ID" to "User ID",
-            "IMAGE_URL" to "Image URL",
-            "COMMENT" to "Comment",
-            "RESET_TOKEN" to "Reset token",
-            "VERIFICATION_TOKEN" to "Verification token",
-            "IP" to "IP address",
-            "SESSION_MANAGEMENT_TOKEN" to "Session token",
-            "SERIES_IDENTIFIER" to "Series identifier",
-            "LOGIN_COOKIE_TOKEN" to "Cookie token",
-            "REMEMBER_ME" to "Remember me flag",
-            "CAPTION" to "Caption",
-            "POST_IDENTIFIER" to "Post identifier",
-            "REASON" to "Reason",
-            "COMMENT_TEXT" to "Comment text",
-            "COMMENT_THREAD_IDENTIFIER" to "Comment thread identifier",
-            "COMMENT_IDENTIFIER" to "Comment identifier",
-            "USERNAME_FRAGMENT" to "Username fragment",
-            "DATE_OF_BIRTH" to "Date of birth",
-            "TARGET_TYPE" to "Target type",
-            "TARGET_IDENTIFIER" to "Target identifier"
-        )
-        
+
         val friendlyNames = mutableListOf<String>()
         for (token in tokens) {
             val upperToken = token.uppercase()

--- a/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/api/ApiErrorsTest.kt
+++ b/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/api/ApiErrorsTest.kt
@@ -87,4 +87,40 @@ class ApiErrorsTest {
             ApiErrors.messageFor(IllegalStateException("boom"), fallback = "fallback")
         )
     }
+
+    @Test
+    fun `sanitizeErrorMessage handles unrelated error messages`() {
+        assertEquals("Text is not positive", ApiErrors.sanitizeErrorMessage("Text is not positive"))
+        assertEquals("User already exists", ApiErrors.sanitizeErrorMessage("User already exists"))
+    }
+
+    @Test
+    fun `sanitizeErrorMessage handles single token invalid fields`() {
+        assertEquals("Username is incorrect", ApiErrors.sanitizeErrorMessage("Invalid fields ['USERNAME']"))
+        assertEquals("Password is incorrect", ApiErrors.sanitizeErrorMessage("Invalid fields ['PASSWORD']"))
+    }
+
+    @Test
+    fun `sanitizeErrorMessage handles multiple token invalid fields`() {
+        assertEquals(
+            "Username and Password are incorrect",
+            ApiErrors.sanitizeErrorMessage("Invalid fields ['USERNAME', 'PASSWORD']")
+        )
+        assertEquals(
+            "Username, Password, and Email are incorrect",
+            ApiErrors.sanitizeErrorMessage("Invalid fields ['USERNAME', 'PASSWORD', 'EMAIL']")
+        )
+    }
+
+    @Test
+    fun `sanitizeErrorMessage handles single token without brackets`() {
+        assertEquals("Post identifier is incorrect", ApiErrors.sanitizeErrorMessage("Invalid post_identifier"))
+        assertEquals("Target type is incorrect", ApiErrors.sanitizeErrorMessage("Invalid target_type"))
+    }
+
+    @Test
+    fun `sanitizeErrorMessage leaves human-readable invalid messages untouched`() {
+        assertEquals("Invalid comment text", ApiErrors.sanitizeErrorMessage("Invalid comment text"))
+        assertEquals("Invalid batch parameter", ApiErrors.sanitizeErrorMessage("Invalid batch parameter"))
+    }
 }

--- a/ios/Positive Only Social/Positive Only Social/api/ErrorHelpers.swift
+++ b/ios/Positive Only Social/Positive Only Social/api/ErrorHelpers.swift
@@ -116,3 +116,111 @@ extension Error {
         return nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled
     }
 }
+
+/// Sanitizes backend raw token error messages into human-legible sentences.
+func sanitizeErrorMessage(_ message: String) -> String {
+    let invalidFieldsPrefix = "Invalid fields"
+    let invalidPrefix = "Invalid "
+    
+    let suffix: String
+    let isInvalidFields: Bool
+    
+    if message.hasPrefix(invalidFieldsPrefix) {
+        suffix = String(message.dropFirst(invalidFieldsPrefix.count))
+        isInvalidFields = true
+    } else if message.hasPrefix(invalidPrefix) {
+        suffix = String(message.dropFirst(invalidPrefix.count))
+        isInvalidFields = false
+        let cleaned = suffix.replacingOccurrences(of: "[\\[\\]'\"]", with: "", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if cleaned.contains(" ") {
+            return message
+        }
+    } else {
+        return message
+    }
+    
+    let range = NSRange(location: 0, length: suffix.utf16.count)
+    guard let regex = try? NSRegularExpression(pattern: "[a-zA-Z0-9_]+") else {
+        return message
+    }
+    
+    let matches = regex.matches(in: suffix, options: [], range: range)
+    var tokens: [String] = []
+    for match in matches {
+        if let tokenRange = Range(match.range, in: suffix) {
+            tokens.append(String(suffix[tokenRange]))
+        }
+    }
+    
+    if tokens.isEmpty {
+        return isInvalidFields ? "Some fields are incorrect" : message
+    }
+    
+    let tokenMap: [String: String] = [
+        "USERNAME": "Username",
+        "EMAIL": "Email",
+        "PASSWORD": "Password",
+        "USERNAME_OR_EMAIL": "Username or email",
+        "USER_ID": "User ID",
+        "IMAGE_URL": "Image URL",
+        "COMMENT": "Comment",
+        "RESET_TOKEN": "Reset token",
+        "VERIFICATION_TOKEN": "Verification token",
+        "IP": "IP address",
+        "SESSION_MANAGEMENT_TOKEN": "Session token",
+        "SERIES_IDENTIFIER": "Series identifier",
+        "LOGIN_COOKIE_TOKEN": "Cookie token",
+        "REMEMBER_ME": "Remember me flag",
+        "CAPTION": "Caption",
+        "POST_IDENTIFIER": "Post identifier",
+        "REASON": "Reason",
+        "COMMENT_TEXT": "Comment text",
+        "COMMENT_THREAD_IDENTIFIER": "Comment thread identifier",
+        "COMMENT_IDENTIFIER": "Comment identifier",
+        "USERNAME_FRAGMENT": "Username fragment",
+        "DATE_OF_BIRTH": "Date of birth",
+        "TARGET_TYPE": "Target type",
+        "TARGET_IDENTIFIER": "Target identifier"
+    ]
+    
+    var friendlyNames: [String] = []
+    for token in tokens {
+        let upperToken = token.uppercased()
+        if let name = tokenMap[upperToken] {
+            if !friendlyNames.contains(name) {
+                friendlyNames.append(name)
+            }
+        } else {
+            let parts = token.split(separator: "_")
+            let humanized = parts.enumerated().map { (index, part) -> String in
+                let partStr = String(part).lowercased()
+                if index == 0 {
+                    return partStr.prefix(1).uppercased() + partStr.dropFirst()
+                } else {
+                    return partStr
+                }
+            }.joined(separator: " ")
+            if !friendlyNames.contains(humanized) && !humanized.isEmpty {
+                friendlyNames.append(humanized)
+            }
+        }
+    }
+    
+    if friendlyNames.isEmpty {
+        return isInvalidFields ? "Some fields are incorrect" : message
+    }
+    
+    if friendlyNames.count == 1 {
+        return "\(friendlyNames[0]) is incorrect"
+    }
+    
+    if friendlyNames.count == 2 {
+        return "\(friendlyNames[0]) and \(friendlyNames[1]) are incorrect"
+    }
+    
+    var list = friendlyNames
+    let last = list.removeLast()
+    return "\(list.joined(separator: ", ")), and \(last) are incorrect"
+}
+

--- a/ios/Positive Only Social/Positive Only Social/api/ErrorHelpers.swift
+++ b/ios/Positive Only Social/Positive Only Social/api/ErrorHelpers.swift
@@ -117,6 +117,34 @@ extension Error {
     }
 }
 
+/// Maps backend raw field tokens to friendly display names.
+private let errorTokenMap: [String: String] = [
+    "USERNAME": "Username",
+    "EMAIL": "Email",
+    "PASSWORD": "Password",
+    "USERNAME_OR_EMAIL": "Username or email",
+    "USER_ID": "User ID",
+    "IMAGE_URL": "Image URL",
+    "COMMENT": "Comment",
+    "RESET_TOKEN": "Reset token",
+    "VERIFICATION_TOKEN": "Verification token",
+    "IP": "IP address",
+    "SESSION_MANAGEMENT_TOKEN": "Session token",
+    "SERIES_IDENTIFIER": "Series identifier",
+    "LOGIN_COOKIE_TOKEN": "Cookie token",
+    "REMEMBER_ME": "Remember me flag",
+    "CAPTION": "Caption",
+    "POST_IDENTIFIER": "Post identifier",
+    "REASON": "Reason",
+    "COMMENT_TEXT": "Comment text",
+    "COMMENT_THREAD_IDENTIFIER": "Comment thread identifier",
+    "COMMENT_IDENTIFIER": "Comment identifier",
+    "USERNAME_FRAGMENT": "Username fragment",
+    "DATE_OF_BIRTH": "Date of birth",
+    "TARGET_TYPE": "Target type",
+    "TARGET_IDENTIFIER": "Target identifier"
+]
+
 /// Sanitizes backend raw token error messages into human-legible sentences.
 func sanitizeErrorMessage(_ message: String) -> String {
     let invalidFieldsPrefix = "Invalid fields"
@@ -156,38 +184,11 @@ func sanitizeErrorMessage(_ message: String) -> String {
     if tokens.isEmpty {
         return isInvalidFields ? "Some fields are incorrect" : message
     }
-    
-    let tokenMap: [String: String] = [
-        "USERNAME": "Username",
-        "EMAIL": "Email",
-        "PASSWORD": "Password",
-        "USERNAME_OR_EMAIL": "Username or email",
-        "USER_ID": "User ID",
-        "IMAGE_URL": "Image URL",
-        "COMMENT": "Comment",
-        "RESET_TOKEN": "Reset token",
-        "VERIFICATION_TOKEN": "Verification token",
-        "IP": "IP address",
-        "SESSION_MANAGEMENT_TOKEN": "Session token",
-        "SERIES_IDENTIFIER": "Series identifier",
-        "LOGIN_COOKIE_TOKEN": "Cookie token",
-        "REMEMBER_ME": "Remember me flag",
-        "CAPTION": "Caption",
-        "POST_IDENTIFIER": "Post identifier",
-        "REASON": "Reason",
-        "COMMENT_TEXT": "Comment text",
-        "COMMENT_THREAD_IDENTIFIER": "Comment thread identifier",
-        "COMMENT_IDENTIFIER": "Comment identifier",
-        "USERNAME_FRAGMENT": "Username fragment",
-        "DATE_OF_BIRTH": "Date of birth",
-        "TARGET_TYPE": "Target type",
-        "TARGET_IDENTIFIER": "Target identifier"
-    ]
-    
+
     var friendlyNames: [String] = []
     for token in tokens {
         let upperToken = token.uppercased()
-        if let name = tokenMap[upperToken] {
+        if let name = errorTokenMap[upperToken] {
             if !friendlyNames.contains(name) {
                 friendlyNames.append(name)
             }

--- a/ios/Positive Only Social/Positive Only Social/api/RealAPI.swift
+++ b/ios/Positive Only Social/Positive Only Social/api/RealAPI.swift
@@ -195,7 +195,7 @@ final class RealAPI: Networking {
                     if authToken != nil && message == GVOAppConstants.accountBannedError {
                         NotificationCenter.default.post(name: .accountBanned, object: nil)
                     }
-                    throw APIError.serverError(statusCode: httpResponse.statusCode, serverMessage: message)
+                    throw APIError.serverError(statusCode: httpResponse.statusCode, serverMessage: sanitizeErrorMessage(message))
                 }
                 throw APIError.badServerResponse(statusCode: httpResponse.statusCode)
             }

--- a/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_ErrorHelpers.swift
+++ b/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_ErrorHelpers.swift
@@ -140,4 +140,17 @@ struct Positive_Only_SocialTests_ErrorHelpers {
         let error = NSError(domain: "SomeDomain", code: 1)
         #expect(error.userFacingMessage == "Something went wrong. Please try again.")
     }
+
+    @Test func testSanitizeErrorMessage() {
+        #expect(sanitizeErrorMessage("Text is not positive") == "Text is not positive")
+        #expect(sanitizeErrorMessage("User already exists") == "User already exists")
+        #expect(sanitizeErrorMessage("Invalid fields ['USERNAME']") == "Username is incorrect")
+        #expect(sanitizeErrorMessage("Invalid fields ['PASSWORD']") == "Password is incorrect")
+        #expect(sanitizeErrorMessage("Invalid fields ['USERNAME', 'PASSWORD']") == "Username and Password are incorrect")
+        #expect(sanitizeErrorMessage("Invalid fields ['USERNAME', 'PASSWORD', 'EMAIL']") == "Username, Password, and Email are incorrect")
+        #expect(sanitizeErrorMessage("Invalid post_identifier") == "Post identifier is incorrect")
+        #expect(sanitizeErrorMessage("Invalid target_type") == "Target type is incorrect")
+        #expect(sanitizeErrorMessage("Invalid comment text") == "Invalid comment text")
+        #expect(sanitizeErrorMessage("Invalid batch parameter") == "Invalid batch parameter")
+    }
 }

--- a/website/src/api/client.test.ts
+++ b/website/src/api/client.test.ts
@@ -1,5 +1,5 @@
 import { vi, expect, test, describe } from 'vitest'
-import { ACCOUNT_BANNED, ApiClient, ApiError } from './client'
+import { ACCOUNT_BANNED, ApiClient, ApiError, sanitizeErrorMessage } from './client'
 
 function jsonResponse(status: number, body: unknown): Response {
   return new Response(JSON.stringify(body), {
@@ -85,3 +85,31 @@ describe('friendly error messages', () => {
     )
   })
 })
+
+describe('sanitizeErrorMessage', () => {
+  test('does not modify unrelated error messages', () => {
+    expect(sanitizeErrorMessage('Text is not positive')).toBe('Text is not positive')
+    expect(sanitizeErrorMessage('User already exists')).toBe('User already exists')
+  })
+
+  test('sanitizes single token invalid fields', () => {
+    expect(sanitizeErrorMessage("Invalid fields ['USERNAME']")).toBe('Username is incorrect')
+    expect(sanitizeErrorMessage("Invalid fields ['PASSWORD']")).toBe('Password is incorrect')
+  })
+
+  test('sanitizes multiple token invalid fields with and', () => {
+    expect(sanitizeErrorMessage("Invalid fields ['USERNAME', 'PASSWORD']")).toBe('Username and Password are incorrect')
+    expect(sanitizeErrorMessage("Invalid fields ['USERNAME', 'PASSWORD', 'EMAIL']")).toBe('Username, Password, and Email are incorrect')
+  })
+
+  test('sanitizes single token messages without brackets', () => {
+    expect(sanitizeErrorMessage('Invalid post_identifier')).toBe('Post identifier is incorrect')
+    expect(sanitizeErrorMessage('Invalid target_type')).toBe('Target type is incorrect')
+  })
+
+  test('leaves human-readable invalid messages untouched', () => {
+    expect(sanitizeErrorMessage('Invalid comment text')).toBe('Invalid comment text')
+    expect(sanitizeErrorMessage('Invalid batch parameter')).toBe('Invalid batch parameter')
+  })
+})
+

--- a/website/src/api/client.ts
+++ b/website/src/api/client.ts
@@ -90,7 +90,7 @@ export function sanitizeErrorMessage(message: string): string {
   } else if (message.startsWith(invalidPrefix)) {
     suffix = message.substring(invalidPrefix.length)
     isInvalidFields = false
-    const cleaned = suffix.replace(/[\[\]'"]/g, '').trim()
+    const cleaned = suffix.replace(/[[\]'"]/g, '').trim()
     if (cleaned.includes(' ')) {
       return message
     }

--- a/website/src/api/client.ts
+++ b/website/src/api/client.ts
@@ -161,8 +161,9 @@ export function sanitizeErrorMessage(message: string): string {
     return `${friendlyNames[0]} and ${friendlyNames[1]} are incorrect`
   }
 
-  const last = friendlyNames.pop()
-  return `${friendlyNames.join(', ')}, and ${last} are incorrect`
+  const last = friendlyNames[friendlyNames.length - 1]
+  const rest = friendlyNames.slice(0, -1)
+  return `${rest.join(', ')}, and ${last} are incorrect`
 }
 
 

--- a/website/src/api/client.ts
+++ b/website/src/api/client.ts
@@ -72,6 +72,34 @@ function friendlyStatusMessage(status: number): string {
   }
 }
 
+/** Maps backend raw field tokens to friendly display names. */
+const ERROR_TOKEN_MAP: Record<string, string> = {
+  USERNAME: 'Username',
+  EMAIL: 'Email',
+  PASSWORD: 'Password',
+  USERNAME_OR_EMAIL: 'Username or email',
+  USER_ID: 'User ID',
+  IMAGE_URL: 'Image URL',
+  COMMENT: 'Comment',
+  RESET_TOKEN: 'Reset token',
+  VERIFICATION_TOKEN: 'Verification token',
+  IP: 'IP address',
+  SESSION_MANAGEMENT_TOKEN: 'Session token',
+  SERIES_IDENTIFIER: 'Series identifier',
+  LOGIN_COOKIE_TOKEN: 'Cookie token',
+  REMEMBER_ME: 'Remember me flag',
+  CAPTION: 'Caption',
+  POST_IDENTIFIER: 'Post identifier',
+  REASON: 'Reason',
+  COMMENT_TEXT: 'Comment text',
+  COMMENT_THREAD_IDENTIFIER: 'Comment thread identifier',
+  COMMENT_IDENTIFIER: 'Comment identifier',
+  USERNAME_FRAGMENT: 'Username fragment',
+  DATE_OF_BIRTH: 'Date of birth',
+  TARGET_TYPE: 'Target type',
+  TARGET_IDENTIFIER: 'Target identifier',
+}
+
 /**
  * Sanitizes backend raw token error messages into human-legible sentences.
  */
@@ -103,38 +131,11 @@ export function sanitizeErrorMessage(message: string): string {
     return isInvalidFields ? 'Some fields are incorrect' : message
   }
 
-  const tokenMap: Record<string, string> = {
-    USERNAME: 'Username',
-    EMAIL: 'Email',
-    PASSWORD: 'Password',
-    USERNAME_OR_EMAIL: 'Username or email',
-    USER_ID: 'User ID',
-    IMAGE_URL: 'Image URL',
-    COMMENT: 'Comment',
-    RESET_TOKEN: 'Reset token',
-    VERIFICATION_TOKEN: 'Verification token',
-    IP: 'IP address',
-    SESSION_MANAGEMENT_TOKEN: 'Session token',
-    SERIES_IDENTIFIER: 'Series identifier',
-    LOGIN_COOKIE_TOKEN: 'Cookie token',
-    REMEMBER_ME: 'Remember me flag',
-    CAPTION: 'Caption',
-    POST_IDENTIFIER: 'Post identifier',
-    REASON: 'Reason',
-    COMMENT_TEXT: 'Comment text',
-    COMMENT_THREAD_IDENTIFIER: 'Comment thread identifier',
-    COMMENT_IDENTIFIER: 'Comment identifier',
-    USERNAME_FRAGMENT: 'Username fragment',
-    DATE_OF_BIRTH: 'Date of birth',
-    TARGET_TYPE: 'Target type',
-    TARGET_IDENTIFIER: 'Target identifier',
-  }
-
   const friendlyNames: string[] = []
   for (const token of tokens) {
     const upperToken = token.toUpperCase()
-    if (upperToken in tokenMap) {
-      const name = tokenMap[upperToken]
+    if (upperToken in ERROR_TOKEN_MAP) {
+      const name = ERROR_TOKEN_MAP[upperToken]
       if (!friendlyNames.includes(name)) {
         friendlyNames.push(name)
       }

--- a/website/src/api/client.ts
+++ b/website/src/api/client.ts
@@ -72,6 +72,99 @@ function friendlyStatusMessage(status: number): string {
   }
 }
 
+/**
+ * Sanitizes backend raw token error messages into human-legible sentences.
+ */
+export function sanitizeErrorMessage(message: string): string {
+  if (!message || typeof message !== 'string') return message
+
+  const invalidFieldsPrefix = 'Invalid fields'
+  const invalidPrefix = 'Invalid '
+
+  let suffix = ''
+  let isInvalidFields = false
+
+  if (message.startsWith(invalidFieldsPrefix)) {
+    suffix = message.substring(invalidFieldsPrefix.length)
+    isInvalidFields = true
+  } else if (message.startsWith(invalidPrefix)) {
+    suffix = message.substring(invalidPrefix.length)
+    isInvalidFields = false
+    const cleaned = suffix.replace(/[\[\]'"]/g, '').trim()
+    if (cleaned.includes(' ')) {
+      return message
+    }
+  } else {
+    return message
+  }
+
+  const tokens = suffix.match(/[a-zA-Z0-9_]+/g)
+  if (!tokens || tokens.length === 0) {
+    return isInvalidFields ? 'Some fields are incorrect' : message
+  }
+
+  const tokenMap: Record<string, string> = {
+    USERNAME: 'Username',
+    EMAIL: 'Email',
+    PASSWORD: 'Password',
+    USERNAME_OR_EMAIL: 'Username or email',
+    USER_ID: 'User ID',
+    IMAGE_URL: 'Image URL',
+    COMMENT: 'Comment',
+    RESET_TOKEN: 'Reset token',
+    VERIFICATION_TOKEN: 'Verification token',
+    IP: 'IP address',
+    SESSION_MANAGEMENT_TOKEN: 'Session token',
+    SERIES_IDENTIFIER: 'Series identifier',
+    LOGIN_COOKIE_TOKEN: 'Cookie token',
+    REMEMBER_ME: 'Remember me flag',
+    CAPTION: 'Caption',
+    POST_IDENTIFIER: 'Post identifier',
+    REASON: 'Reason',
+    COMMENT_TEXT: 'Comment text',
+    COMMENT_THREAD_IDENTIFIER: 'Comment thread identifier',
+    COMMENT_IDENTIFIER: 'Comment identifier',
+    USERNAME_FRAGMENT: 'Username fragment',
+    DATE_OF_BIRTH: 'Date of birth',
+    TARGET_TYPE: 'Target type',
+    TARGET_IDENTIFIER: 'Target identifier',
+  }
+
+  const friendlyNames: string[] = []
+  for (const token of tokens) {
+    const upperToken = token.toUpperCase()
+    if (upperToken in tokenMap) {
+      const name = tokenMap[upperToken]
+      if (!friendlyNames.includes(name)) {
+        friendlyNames.push(name)
+      }
+    } else {
+      const humanized = token.split('_')
+        .map((word, index) => index === 0 ? word.charAt(0).toUpperCase() + word.slice(1).toLowerCase() : word.toLowerCase())
+        .join(' ')
+      if (!friendlyNames.includes(humanized)) {
+        friendlyNames.push(humanized)
+      }
+    }
+  }
+
+  if (friendlyNames.length === 0) {
+    return isInvalidFields ? 'Some fields are incorrect' : message
+  }
+
+  if (friendlyNames.length === 1) {
+    return `${friendlyNames[0]} is incorrect`
+  }
+
+  if (friendlyNames.length === 2) {
+    return `${friendlyNames[0]} and ${friendlyNames[1]} are incorrect`
+  }
+
+  const last = friendlyNames.pop()
+  return `${friendlyNames.join(', ')}, and ${last} are incorrect`
+}
+
+
 /** User-facing copy when the request never reached the server (offline, DNS). */
 const NETWORK_ERROR_MESSAGE =
   'You appear to be offline. Please check your connection and try again.'
@@ -181,13 +274,14 @@ export class ApiClient implements PositiveOnlySocialAPI {
     }
 
     if (!response.ok) {
-      const message =
+      const rawMessage =
         payload && typeof payload === 'object' && 'error' in payload
           ? String((payload as { error: unknown }).error)
           : friendlyStatusMessage(response.status)
-      if (options.auth && message === ACCOUNT_BANNED) {
+      if (options.auth && rawMessage === ACCOUNT_BANNED) {
         this.onAccountBanned?.()
       }
+      const message = sanitizeErrorMessage(rawMessage)
       throw new ApiError(response.status, message)
     }
 


### PR DESCRIPTION
This pull request resolves issue #303 by sanitizing raw token-based backend validation error messages (e.g., `Invalid fields ['USERNAME']` or `Invalid target_type`) into friendly, human-legible sentences (e.g., `Username is incorrect` or `Target type is incorrect`) across all three client applications (Android, iOS, and Web).

### Key Features of Sanitization:
1. **Rule-Based Parsing:** Checks if an API error message starts with `"Invalid fields"` or `"Invalid "` with a raw token (an identifier with no spaces, such as `post_identifier` or `target_type`).
2. **Untouched Legible Errors:** If the message starts with `"Invalid "` followed by a phrase containing spaces (e.g., `"comment text"`, `"batch parameter"`), it is already considered human-readable and is left untouched.
3. **Friendly Mappings & Fallback:** Converts raw tokens (like `USERNAME`, `PASSWORD`, `date_of_birth`) into friendly display names (`Username`, `Password`, `Date of birth`), with fallback token humanization for snake_case words.
4. **Natural Conjunctions:** Properly formats multiple tokens (e.g., `"Username and Password are incorrect"` or `"Username, Password, and Email are incorrect"`).

### Client Changes:
- **Web Client (Vite/TS):** Added `sanitizeErrorMessage` to `website/src/api/client.ts` and integrated it in the HTTP request error interceptor. Added comprehensive Vitest tests in `website/src/api/client.test.ts`.
- **iOS Client (Swift):** Added global `sanitizeErrorMessage(_:)` in `ErrorHelpers.swift` and used it inside `RealAPI.swift` when throwing `.serverError`. Added Swift Testing tests in `Positive_Only_SocialTests_ErrorHelpers.swift`.
- **Android Client (Kotlin):** Added `sanitizeErrorMessage` to the `ApiErrors` object in `ApiErrors.kt` and updated the `messageFor` handler. Added JUnit tests in `ApiErrorsTest.kt`.
