### PR TITLE
iOS: suppress Automatic Strong Password panel in UI tests

### DIFF
--- a/ios/Positive Only Social/Positive Only Social/VibesViews/LoginView.swift
+++ b/ios/Positive Only Social/Positive Only Social/VibesViews/LoginView.swift
@@ -34,10 +34,13 @@ struct LoginView: View {
                 // Let taps on this decorative icon fall through to the
                 // container's dismiss-keyboard gesture (issue #205).
                 .allowsHitTesting(false)
-            TextField("Username or Email", text: $usernameOrEmail).padding().background(Color(.systemGray6)).cornerRadius(10).textContentType(.username).autocapitalization(.none).keyboardType(.emailAddress)
+            // Under UI testing, drop the credential content types on both fields:
+            // a `.username`/`.password` pairing makes iOS surface the AutoFill /
+            // strong-password QuickType panel, which steals focus and breaks typing.
+            TextField("Username or Email", text: $usernameOrEmail).padding().background(Color(.systemGray6)).cornerRadius(10).textContentType(isUITesting() ? nil : .username).autocapitalization(.none).keyboardType(.emailAddress)
                 .focused($focusedField, equals: .usernameOrEmail)
                 .accessibilityIdentifier("UsernameOrEmailTextField")
-            SecureField("Password", text: $password).padding().background(Color(.systemGray6)).cornerRadius(10).textContentType(.password)
+            SecureField("Password", text: $password).padding().background(Color(.systemGray6)).cornerRadius(10).textContentType(isUITesting() ? nil : .password)
                 .focused($focusedField, equals: .password)
                 .accessibilityIdentifier("PasswordSecureField")
             Toggle("Remember Me", isOn: $rememberMe)

--- a/ios/Positive Only Social/Positive Only Social/VibesViews/RegisterView.swift
+++ b/ios/Positive Only Social/Positive Only Social/VibesViews/RegisterView.swift
@@ -72,7 +72,13 @@ struct RegisterView: View {
                 .padding()
                 .background(Color(.systemGray6))
                 .cornerRadius(10)
-                .textContentType(.username)
+                // Under UI testing, drop the credential content types (here and on
+                // the password fields below). iOS offers "Automatic Strong Passwords"
+                // when it recognizes a credential form — a `.username` field followed
+                // by a secure field — and that floating QuickType panel steals focus
+                // and breaks typing in the UI tests. Nulling `.username` stops iOS
+                // from classifying the screen as a sign-up form at all.
+                .textContentType(isUITesting() ? nil : .username)
                 .autocapitalization(.none)
                 .focused($focusedField, equals: .username)
                 .accessibilityIdentifier("UsernameTextField")


### PR DESCRIPTION
## Problem

The **"Suggest a Strong Password"** QuickType panel kept interrupting the iOS UI test suite. On iOS 17+/26 it renders as an **in-process floating panel above the keyboard** (not a SpringBoard alert), so `addUIInterruptionMonitor` can't reliably catch it — hence the racy manual `dismissStrongPasswordIfPresent()` in the tests. When the panel appears it steals keyboard focus and typing into the field fails.

## Root cause

iOS offers Automatic Strong Passwords whenever it recognizes a **credential form** — a field marked `.textContentType(.username)` followed by a `SecureField`. Previously only the *password* fields' `.newPassword` type was nulled under UI testing:

- `RegisterView`/`ResetPasswordView`: `.textContentType(isUITesting() ? nil : .newPassword)` ✅
- But `RegisterView` and `LoginView` still set `.textContentType(.username)` **unconditionally**, and `LoginView`'s password field used `.password` unconditionally.

So even with the password half suppressed, the `.username` field still made iOS classify the screen as a sign-up/login form and surface the panel.

## Fix

Gate the remaining credential content types behind `isUITesting()`:

- **RegisterView**: `.username` on the username field
- **LoginView**: `.username` and `.password` on the username/password fields

Nulling `.username` is the key — it stops iOS from classifying the screen as a credential form at all (Apple's documented opt-out for Automatic Strong Passwords). Real users are unaffected; they still get full AutoFill.

`ResetPasswordView` needs no change — its identifier fields never set `.username`, and its password fields already null `.newPassword` under test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)