### PR TITLE
Trigger CI workflows on pushes to dev

### DIFF
--- a/.github/workflows/android-tests.yml
+++ b/.github/workflows/android-tests.yml
@@ -2,7 +2,7 @@ name: Android Tests
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "dev" ]
     paths:
       - 'android/**'
       - '.github/workflows/android-tests.yml'

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -2,7 +2,7 @@ name: Backend Tests
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "dev" ]
     paths:
       - 'backend/**'
       - '.github/workflows/backend-tests.yml'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "dev" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "dev" ]
   schedule:
     - cron: '30 5 * * 1'
 

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -1,7 +1,7 @@
 name: iOS Tests
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "dev" ]
     paths:
       - 'ios/**'
       - '.github/workflows/ios-tests.yml'

--- a/.github/workflows/website-tests.yml
+++ b/.github/workflows/website-tests.yml
@@ -2,7 +2,7 @@ name: Website Tests
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "dev" ]
     paths:
       - 'website/**'
       - '.github/workflows/website-tests.yml'


### PR DESCRIPTION
## Summary
- Adds `dev` to the `push` trigger branches in all five workflows (backend, website, iOS, Android, CodeQL) so merges into `dev` get CI coverage, matching the new dev-based PR workflow
- Also adds `dev` to CodeQL's `pull_request` branch filter — it was restricted to PRs targeting `main`, so PRs against `dev` would otherwise skip CodeQL entirely (the four test workflows have no PR branch filter and already run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)