### PR TITLE
Upgrade Gemini classifier model to gemini-3.5-flash

### DIFF
--- a/backend/user_system/classifiers/classifier_constants.py
+++ b/backend/user_system/classifiers/classifier_constants.py
@@ -4,7 +4,7 @@ POSITIVE_IMAGE_URL = f'https://test-bucket.s3.amazonaws.com/{POSITIVE_IMAGE_FILE
 NEGATIVE_IMAGE_URL = f'https://test-bucket.s3.amazonaws.com/{NEGATIVE_IMAGE_FILENAME}'
 POSITIVE_TEXT = 'positive'
 NEGATIVE_TEXT = 'negative'
-GEMINI_MODEL = 'gemini-2.5-flash'
+GEMINI_MODEL = 'gemini-3.5-flash'
 CLAUDE_MODEL = 'claude-haiku-4-5-20251001'
 OPENAI_MODEL = 'gpt-4o-mini'
 


### PR DESCRIPTION
## Summary
- Bumps the Gemini model used by the positivity classifiers from `gemini-2.5-flash` to `gemini-3.5-flash`, Google's most recent GA model (their "most intelligent model" per the [Gemini API models docs](https://ai.google.dev/gemini-api/docs/models)). The only model above it, Gemini 3.1 Pro, is still preview-only, so the GA Flash model is the safer choice for the production filter.
- Claude and OpenAI models are intentionally left unchanged.

The model ID lives in a single constant (`GEMINI_MODEL` in `backend/user_system/classifiers/classifier_constants.py`), so both the text and image classification paths pick it up.

## Testing
- `python manage.py test user_system.tests.test_classifiers` — 39 tests pass locally.

Fixes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)