### PR TITLE
Web: send auth token when fetching post details

### DIFF
--- a/website/src/api/client.ts
+++ b/website/src/api/client.ts
@@ -444,7 +444,7 @@ export class ApiClient implements PositiveOnlySocialAPI {
   }
 
   getPostDetails(postIdentifier: string): Promise<PostDetails> {
-    return this.request<PostDetails>('GET', `/posts/${postIdentifier}/details/`)
+    return this.request<PostDetails>('GET', `/posts/${postIdentifier}/details/`, { auth: true })
   }
 
   // ===========================================================================


### PR DESCRIPTION
## Problem
Two symptoms reported on the live site:
1. Clicking a photo → the post image doesn't render.
2. Backend logs `Unauthorized: /user_index/posts/<id>/details/`.

## Root cause (single bug)
Auth is token-based (`Authorization: Bearer <session_management_token>`). `getPostDetails` in `website/src/api/client.ts` was the **only** client method that omitted `{ auth: true }`, so it never sent the token. The backend `get_post_details` view is `@api_login_required`, so it returned **401 Unauthorized** — which both produced the log and made `PostDetailPage` fail its `getPostDetails` fetch, so `setPost` never ran and the image (rendered from that response) never appeared.

## Fix
Pass `{ auth: true }` so the token is sent, like every other authenticated endpoint. One line.

## Verification
- Backend `get_post_details` is `@api_login_required @require_GET` — auth is required by design (the response includes per-user `is_liked`/`is_reported`).
- The existing `getPostDetails` test (client.test.ts) sets a token, so it still passes. Full web suite runs in CI.
- After merge, redeploy the SPA (`website/deploy-web.sh`) for the fix to reach the live site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)