### PR TITLE
Website: require the account password when confirming TOTP enrollment

### DIFF
--- a/website/src/api/StatefulStubbedAPI.test.ts
+++ b/website/src/api/StatefulStubbedAPI.test.ts
@@ -327,7 +327,7 @@ test('rejects an invalid appeal target type', async () => {
 
 async function enableTwoFactor(api: StatefulStubbedAPI) {
   await api.setupTotp()
-  return api.confirmTotp({ totp_code: STUB_TOTP_CODE })
+  return api.confirmTotp({ password: 'password123', totp_code: STUB_TOTP_CODE })
 }
 
 test('totp setup returns a secret and provisioning uri', async () => {
@@ -355,9 +355,9 @@ test('confirming with a wrong code fails and 2fa stays off', async () => {
   await register(api, 'ada')
   await api.setupTotp()
 
-  await expect(api.confirmTotp({ totp_code: '000000' })).rejects.toThrow(
-    'Invalid two-factor code',
-  )
+  await expect(
+    api.confirmTotp({ password: 'password123', totp_code: '000000' }),
+  ).rejects.toThrow('Invalid two-factor code')
 
   // Login still single-step.
   const login = await api.login({ username_or_email: 'ada', password: 'password123' })

--- a/website/src/api/StatefulStubbedAPI.ts
+++ b/website/src/api/StatefulStubbedAPI.ts
@@ -462,6 +462,9 @@ export class StatefulStubbedAPI implements PositiveOnlySocialAPI {
     if (!user.totpSecret) {
       throw new ApiError(400, 'Two-factor setup has not been started')
     }
+    if (user.passwordHash !== body.password) {
+      throw new ApiError(400, 'Invalid password')
+    }
     if (body.totp_code !== STUB_TOTP_CODE) {
       throw new ApiError(400, 'Invalid two-factor code')
     }

--- a/website/src/api/client.test.ts
+++ b/website/src/api/client.test.ts
@@ -222,7 +222,7 @@ describe('two-factor authentication endpoints', () => {
     const client = new ApiClient({ baseUrl: 'https://api.test', token: 'sometoken', fetchFn })
 
     await client.setupTotp()
-    await client.confirmTotp({ totp_code: '123456' })
+    await client.confirmTotp({ password: 'MyPassword1-', totp_code: '123456' })
 
     const [setupUrl, setupInit] = fetchFn.mock.calls[0]
     expect(setupUrl).toBe('https://api.test/2fa/totp/setup/')

--- a/website/src/api/types.ts
+++ b/website/src/api/types.ts
@@ -63,6 +63,10 @@ export interface TwoFactorSetupResponse {
 }
 
 export interface ConfirmTotpRequest {
+  /** Required: a stolen session alone must not be able to enrol an
+   * authenticator, which would hand the thief the recovery codes and lock the
+   * real owner out for good. */
+  password: string
   totp_code: string
 }
 

--- a/website/src/components/SettingsTab.test.tsx
+++ b/website/src/components/SettingsTab.test.tsx
@@ -117,9 +117,16 @@ test('enabling 2fa walks through scan, confirm, and recovery codes', async () =>
   const codeInput = screen.getByLabelText('Authenticator code')
   expect(screen.getByRole('button', { name: 'Verify' })).toBeDisabled()
   await userEvent.type(codeInput, '123456')
+  // The code alone is not enough: confirming also takes the account password,
+  // so a stolen session cannot enrol an authenticator and lock the owner out.
+  expect(screen.getByRole('button', { name: 'Verify' })).toBeDisabled()
+  await userEvent.type(screen.getByLabelText('Account password'), 'MyPassword1-')
   await userEvent.click(screen.getByRole('button', { name: 'Verify' }))
 
-  expect(mockConfirmTotp).toHaveBeenCalledWith({ totp_code: '123456' })
+  expect(mockConfirmTotp).toHaveBeenCalledWith({
+    password: 'MyPassword1-',
+    totp_code: '123456',
+  })
 
   // Recovery codes are displayed once.
   expect(await screen.findByText('aaaaaaaaaa')).toBeInTheDocument()
@@ -138,6 +145,7 @@ test('a wrong confirmation code surfaces the error and stays open', async () => 
   await screen.findByText('STUBSECRETBASE32')
   await userEvent.click(screen.getByRole('button', { name: 'Next' }))
   await userEvent.type(screen.getByLabelText('Authenticator code'), '000000')
+  await userEvent.type(screen.getByLabelText('Account password'), 'MyPassword1-')
   await userEvent.click(screen.getByRole('button', { name: 'Verify' }))
 
   expect(await screen.findByRole('alert')).toHaveTextContent('Invalid two-factor code')

--- a/website/src/components/TwoFactorAuthModals.tsx
+++ b/website/src/components/TwoFactorAuthModals.tsx
@@ -38,6 +38,7 @@ export function EnableTwoFactorModal({ onClose, onEnabled }: EnableTwoFactorModa
   const [secret, setSecret] = useState('')
   const [otpauthUri, setOtpauthUri] = useState('')
   const [code, setCode] = useState('')
+  const [password, setPassword] = useState('')
   const [recoveryCodes, setRecoveryCodes] = useState<string[]>([])
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   // Separate copy state per button so copying the secret on the scan step
@@ -66,13 +67,14 @@ export function EnableTwoFactorModal({ onClose, onEnabled }: EnableTwoFactorModa
   }, [])
 
   const isCodeValid = /^\d{6}$/.test(code.trim())
+  const canConfirm = isCodeValid && password.length > 0
 
   async function handleConfirm() {
-    if (!isCodeValid || isBusy) return
+    if (!canConfirm || isBusy) return
     setIsBusy(true)
     setErrorMessage(null)
     try {
-      const response = await apiClient.confirmTotp({ totp_code: code.trim() })
+      const response = await apiClient.confirmTotp({ password, totp_code: code.trim() })
       setRecoveryCodes(response.recovery_codes)
       setStep('codes')
     } catch (err) {
@@ -136,7 +138,11 @@ export function EnableTwoFactorModal({ onClose, onEnabled }: EnableTwoFactorModa
 
       {step === 'confirm' && (
         <>
-          <p className="modal__body">Enter the 6-digit code your authenticator app shows now.</p>
+          <p className="modal__body">
+            Enter the 6-digit code your authenticator app shows now, and your account password.
+            The password is required so that someone who gets hold of your session cannot turn on
+            two-factor authentication with their own app and lock you out.
+          </p>
           <input
             className="search-bar"
             type="text"
@@ -148,6 +154,15 @@ export function EnableTwoFactorModal({ onClose, onEnabled }: EnableTwoFactorModa
             onChange={e => setCode(e.target.value)}
             disabled={isBusy}
           />
+          <input
+            className="search-bar"
+            type="password"
+            autoComplete="current-password"
+            aria-label="Account password"
+            value={password}
+            onChange={e => setPassword(e.target.value)}
+            disabled={isBusy}
+          />
           <div className="modal__actions">
             <button type="button" className="modal__cancel" onClick={onClose} disabled={isBusy}>
               Cancel
@@ -155,7 +170,7 @@ export function EnableTwoFactorModal({ onClose, onEnabled }: EnableTwoFactorModa
             <button
               type="button"
               className="modal__confirm"
-              disabled={!isCodeValid || isBusy}
+              disabled={!canConfirm || isBusy}
               onClick={handleConfirm}
             >
               Verify


### PR DESCRIPTION
Follows the backend change in [#355](https://github.com/andrewkatson/pos/pull/355), which makes `2fa/totp/confirm/` require the account password. The website 2FA work merged in #357 sends only the code, so without this change enrollment breaks against the new backend.

### Why the backend now requires it

`confirm_totp` previously accepted a session alone. Someone holding a stolen session could bind **their own** authenticator to the account, read the one-time recovery codes straight off the response, and lock the real owner out permanently — turning off 2FA afterwards requires a code only the attacker has. `disable_totp` already required the password; enrollment was the weaker half, and it is the more dangerous one.

### Changes

- `types.ts` — `ConfirmTotpRequest` gains a required `password`.
- `TwoFactorAuthModals.tsx` — the confirm step adds an account-password input, explains why it is being asked, and keeps **Verify** disabled until both the 6-digit code and a password are present.
- `StatefulStubbedAPI.ts` — the stub rejects a wrong password with `Invalid password`, mirroring the real endpoint and `disableTotp`.
- Tests updated across `SettingsTab.test.tsx`, `client.test.ts`, and `StatefulStubbedAPI.test.ts`; the enrollment walkthrough now asserts Verify stays disabled with the code alone.

### Verification

No Node toolchain on this machine, so `npm run lint`, `npx tsc -b --noEmit`, `npm test`, and `npm run build` all run in CI on this PR rather than locally.

### Merge order

Land [#355](https://github.com/andrewkatson/pos/pull/355) with (or before) this — together they change one contract on both sides. The matching iOS change is in [#358](https://github.com/andrewkatson/pos/pull/358), and Android is in a sibling PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
