### PR TITLE
Android: require the account password when confirming TOTP enrollment

### DIFF
--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/api/StatefulStubbedAPI.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/api/StatefulStubbedAPI.kt
@@ -321,6 +321,9 @@ class StatefulStubbedAPI : PositiveOnlySocialAPI {
         if (user.totpSecret == null) {
             return errorGeneric(400, "Two-factor setup has not been started")
         }
+        if (user.passwordHash != request.password) {
+            return errorGeneric(400, "Invalid password")
+        }
         if (request.totpCode != STUB_TOTP_CODE) {
             return errorGeneric(400, "Invalid two-factor code")
         }

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/model/Models.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/model/Models.kt
@@ -66,7 +66,13 @@ data class TotpSetupResponse(
     @SerializedName("otpauth_uri") val otpauthUri: String
 )
 
+/**
+ * Confirming requires the password as well as the code: a stolen session alone
+ * must not be able to bind an attacker's authenticator, which would hand them
+ * the recovery codes and lock the real owner out for good.
+ */
 data class ConfirmTotpRequest(
+    @SerializedName("password") val password: String,
     @SerializedName("totp_code") val totpCode: String
 )
 

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/SettingsViewModel.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/SettingsViewModel.kt
@@ -171,6 +171,16 @@ class SettingsViewModel(
      * binding an attacker's authenticator and locking the real owner out.
      */
     fun confirmTotp(password: String, code: String) {
+        // Ignore a duplicate submission while one is already running. Disabling
+        // the Verify button is the first line of defence, but that only takes
+        // effect on the next recomposition, so a fast double-tap can call this
+        // twice before the button goes grey. Both calls would share the
+        // generation below, so the first to finish would clear the in-flight
+        // flag in its `finally` while the second is still running — re-enabling
+        // Verify/dismissal and reopening the very race this guards. The flag is
+        // set synchronously here, before the coroutine is launched, so the
+        // second synchronous call on the main thread sees it and bails.
+        if (_isConfirmingTotp.value) return
         // Share the enrollment generation with setup: a confirm response that
         // lands after the dialog was cancelled (or a newer attempt started) is
         // discarded, so it can't repopulate recoveryCodes for an abandoned run.

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/SettingsViewModel.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/SettingsViewModel.kt
@@ -53,6 +53,11 @@ class SettingsViewModel(
     private val _recoveryCodes = MutableStateFlow<List<String>?>(null)
     val recoveryCodes: StateFlow<List<String>?> = _recoveryCodes.asStateFlow()
 
+    // True while a confirm request is in flight, so the UI can stop a second
+    // submission racing the first.
+    private val _isConfirmingTotp = MutableStateFlow(false)
+    val isConfirmingTotp: StateFlow<Boolean> = _isConfirmingTotp.asStateFlow()
+
     private val _twoFactorStatusMessage = MutableStateFlow<String?>(null)
     val twoFactorStatusMessage: StateFlow<String?> = _twoFactorStatusMessage.asStateFlow()
 
@@ -170,6 +175,7 @@ class SettingsViewModel(
         // lands after the dialog was cancelled (or a newer attempt started) is
         // discarded, so it can't repopulate recoveryCodes for an abandoned run.
         val generation = totpSetupGeneration
+        _isConfirmingTotp.value = true
         viewModelScope.launch {
             try {
                 val userSession = keychainHelper.load(UserSession::class.java, service, account)
@@ -200,6 +206,10 @@ class SettingsViewModel(
                     _errorMessage.value = ApiErrors.messageFor(e, fallback = "Verification failed. Please try again.")
                     _showingErrorAlert.value = true
                 }
+            } finally {
+                // Only the newest attempt owns the flag; an older one finishing
+                // late must not re-enable Verify for the current attempt.
+                if (generation == totpSetupGeneration) _isConfirmingTotp.value = false
             }
         }
     }
@@ -209,6 +219,11 @@ class SettingsViewModel(
         // Only report success if confirm actually produced recovery codes, so an
         // accidental call while still mid-enrollment can't fake an enabled state.
         val wasEnrolled = _recoveryCodes.value != null
+        // Bump the generation so a still-in-flight confirm is ignored, and clear
+        // the in-flight flag here: the bump means that request's own `finally`
+        // no longer matches, so it would otherwise leave Verify stuck disabled.
+        totpSetupGeneration++
+        _isConfirmingTotp.value = false
         _totpSetup.value = null
         _recoveryCodes.value = null
         if (wasEnrolled) {
@@ -221,6 +236,7 @@ class SettingsViewModel(
         // Invalidate any in-flight setup so its late response is ignored and a
         // quick reopen isn't left stuck waiting on the abandoned request.
         totpSetupGeneration++
+        _isConfirmingTotp.value = false
         _totpSetup.value = null
         _recoveryCodes.value = null
     }

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/SettingsViewModel.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/SettingsViewModel.kt
@@ -160,10 +160,12 @@ class SettingsViewModel(
     }
 
     /**
-     * Finishes TOTP enrollment by verifying one code from the authenticator.
-     * On success `recoveryCodes` is populated for the one-time display.
+     * Finishes TOTP enrollment by verifying the account password and one code
+     * from the authenticator. On success `recoveryCodes` is populated for the
+     * one-time display. The password is what stops a stolen session from
+     * binding an attacker's authenticator and locking the real owner out.
      */
-    fun confirmTotp(code: String) {
+    fun confirmTotp(password: String, code: String) {
         // Share the enrollment generation with setup: a confirm response that
         // lands after the dialog was cancelled (or a newer attempt started) is
         // discarded, so it can't repopulate recoveryCodes for an abandoned run.
@@ -178,7 +180,7 @@ class SettingsViewModel(
                     }
                     return@launch
                 }
-                val response = api.confirmTotp(userSession.sessionToken, ConfirmTotpRequest(code))
+                val response = api.confirmTotp(userSession.sessionToken, ConfirmTotpRequest(password, code))
                 if (generation != totpSetupGeneration) return@launch
                 val codes = response.body()?.recoveryCodes
                 if (response.isSuccessful && !codes.isNullOrEmpty()) {

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/SettingsScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/SettingsScreen.kt
@@ -100,6 +100,7 @@ fun SettingsScreen(
 
         val totpSetup by viewModel.totpSetup.collectAsState()
         val recoveryCodes by viewModel.recoveryCodes.collectAsState()
+        val isConfirmingTotp by viewModel.isConfirmingTotp.collectAsState()
         val twoFactorStatusMessage by viewModel.twoFactorStatusMessage.collectAsState()
         val clipboardManager = LocalClipboardManager.current
 
@@ -124,6 +125,7 @@ fun SettingsScreen(
                 onConfirmCodeChange = { twoFactorConfirmCode = it },
                 confirmPassword = twoFactorConfirmPassword,
                 onConfirmPasswordChange = { twoFactorConfirmPassword = it },
+                isConfirming = isConfirmingTotp,
                 onVerify = { viewModel.confirmTotp(twoFactorConfirmPassword, twoFactorConfirmCode.trim()) },
                 onCopySecret = { secret ->
                     clipboardManager.setText(AnnotatedString(secret))
@@ -133,10 +135,16 @@ fun SettingsScreen(
                 },
                 onDone = {
                     showingEnrollTwoFactor = false
+                    // Don't leave the account password sitting in composition state
+                    // once the flow is over.
+                    twoFactorConfirmCode = ""
+                    twoFactorConfirmPassword = ""
                     viewModel.finishTotpEnrollment()
                 },
                 onCancel = {
                     showingEnrollTwoFactor = false
+                    twoFactorConfirmCode = ""
+                    twoFactorConfirmPassword = ""
                     viewModel.cancelTotpEnrollment()
                 }
             )
@@ -481,6 +489,7 @@ private fun EnrollTwoFactorDialog(
     onConfirmCodeChange: (String) -> Unit,
     confirmPassword: String,
     onConfirmPasswordChange: (String) -> Unit,
+    isConfirming: Boolean,
     onVerify: () -> Unit,
     onCopySecret: (String) -> Unit,
     onCopyRecoveryCodes: (List<String>) -> Unit,
@@ -490,16 +499,21 @@ private fun EnrollTwoFactorDialog(
     val isConfirmCodeValid = confirmCode.trim().length == 6 && confirmCode.trim().all { it.isDigit() }
     // The password is required too: without it a stolen session could enrol its
     // own authenticator and lock the real owner out permanently.
-    val canConfirm = isConfirmCodeValid && confirmPassword.isNotEmpty()
+    // Also blocked while a confirm is in flight: a second tap would enqueue
+    // another enrollment, and a later failure ("already enabled") would raise an
+    // error alert over the recovery codes the first one just produced.
+    val canConfirm = isConfirmCodeValid && confirmPassword.isNotEmpty() && !isConfirming
 
     AlertDialog(
         // Recovery codes are shown exactly once and the backend can't re-issue
         // them, so on that step the dialog can't be dismissed by a back press or
         // a tap outside — the user has to choose Copy All / Done deliberately.
-        // Before codes exist, dismissing simply abandons the pending enrollment.
+        // It's also sealed while a confirm is in flight: enrollment may already
+        // have succeeded, and dismissing would drop the response carrying the
+        // only copy of the codes. Otherwise dismissing abandons a pending setup.
         properties = DialogProperties(
-            dismissOnBackPress = recoveryCodes == null,
-            dismissOnClickOutside = recoveryCodes == null,
+            dismissOnBackPress = recoveryCodes == null && !isConfirming,
+            dismissOnClickOutside = recoveryCodes == null && !isConfirming,
         ),
         // Defensive: if a dismissal ever does get through on the codes step, 2FA
         // is already enabled server-side, so report it rather than cancelling.
@@ -600,7 +614,11 @@ private fun EnrollTwoFactorDialog(
         },
         dismissButton = {
             if (recoveryCodes == null) {
-                Button(onClick = onCancel) { Text("Cancel") }
+                // Disabled mid-confirm for the same reason the dialog can't be
+                // dismissed then: enrollment may already have succeeded, and
+                // tearing the dialog down discards the response carrying the only
+                // copy of the recovery codes.
+                Button(onClick = onCancel, enabled = !isConfirming) { Text("Cancel") }
             }
         }
     )

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/SettingsScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/SettingsScreen.kt
@@ -93,6 +93,7 @@ fun SettingsScreen(
         var showingEnrollTwoFactor by remember { mutableStateOf(false) }
         var showingDisableTwoFactor by remember { mutableStateOf(false) }
         var twoFactorConfirmCode by remember { mutableStateOf("") }
+        var twoFactorConfirmPassword by remember { mutableStateOf("") }
         var disablePassword by remember { mutableStateOf("") }
         var disableCode by remember { mutableStateOf("") }
         var disableUsesRecoveryCode by remember { mutableStateOf(false) }
@@ -121,7 +122,9 @@ fun SettingsScreen(
                 recoveryCodes = recoveryCodes,
                 confirmCode = twoFactorConfirmCode,
                 onConfirmCodeChange = { twoFactorConfirmCode = it },
-                onVerify = { viewModel.confirmTotp(twoFactorConfirmCode.trim()) },
+                confirmPassword = twoFactorConfirmPassword,
+                onConfirmPasswordChange = { twoFactorConfirmPassword = it },
+                onVerify = { viewModel.confirmTotp(twoFactorConfirmPassword, twoFactorConfirmCode.trim()) },
                 onCopySecret = { secret ->
                     clipboardManager.setText(AnnotatedString(secret))
                 },
@@ -418,6 +421,7 @@ fun SettingsScreen(
 
             ListListItem(text = "Enable Two-Factor Authentication", textColor = Color.Blue) {
                 twoFactorConfirmCode = ""
+                twoFactorConfirmPassword = ""
                 viewModel.startTotpSetup()
                 showingEnrollTwoFactor = true
             }
@@ -475,6 +479,8 @@ private fun EnrollTwoFactorDialog(
     recoveryCodes: List<String>?,
     confirmCode: String,
     onConfirmCodeChange: (String) -> Unit,
+    confirmPassword: String,
+    onConfirmPasswordChange: (String) -> Unit,
     onVerify: () -> Unit,
     onCopySecret: (String) -> Unit,
     onCopyRecoveryCodes: (List<String>) -> Unit,
@@ -482,6 +488,9 @@ private fun EnrollTwoFactorDialog(
     onCancel: () -> Unit
 ) {
     val isConfirmCodeValid = confirmCode.trim().length == 6 && confirmCode.trim().all { it.isDigit() }
+    // The password is required too: without it a stolen session could enrol its
+    // own authenticator and lock the real owner out permanently.
+    val canConfirm = isConfirmCodeValid && confirmPassword.isNotEmpty()
 
     AlertDialog(
         // Recovery codes are shown exactly once and the backend can't re-issue
@@ -552,6 +561,16 @@ private fun EnrollTwoFactorDialog(
                             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword),
                             modifier = Modifier.testTag("TwoFactorConfirmCodeField")
                         )
+                        Spacer(modifier = Modifier.height(12.dp))
+                        TextField(
+                            value = confirmPassword,
+                            onValueChange = onConfirmPasswordChange,
+                            label = { Text("Account password") },
+                            singleLine = true,
+                            visualTransformation = PasswordVisualTransformation(),
+                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                            modifier = Modifier.testTag("TwoFactorConfirmPasswordField")
+                        )
                     }
                     else -> {
                         CircularProgressIndicator()
@@ -573,7 +592,7 @@ private fun EnrollTwoFactorDialog(
                     }
                 }
                 totpSetup != null -> {
-                    Button(onClick = onVerify, enabled = isConfirmCodeValid, modifier = Modifier.testTag("ConfirmTwoFactorButton")) {
+                    Button(onClick = onVerify, enabled = canConfirm, modifier = Modifier.testTag("ConfirmTwoFactorButton")) {
                         Text("Verify")
                     }
                 }

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/SettingsScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/SettingsScreen.kt
@@ -502,7 +502,12 @@ private fun EnrollTwoFactorDialog(
     // Also blocked while a confirm is in flight: a second tap would enqueue
     // another enrollment, and a later failure ("already enabled") would raise an
     // error alert over the recovery codes the first one just produced.
-    val canConfirm = isConfirmCodeValid && confirmPassword.isNotEmpty() && !isConfirming
+    // isNotBlank, not isNotEmpty: a whitespace-only password can never be valid
+    // (the backend password pattern forbids whitespace), so it must not enable
+    // Verify. The password is sent verbatim otherwise — login and the disable
+    // dialog don't trim either, and trimming only here would let enrollment
+    // accept a password the subsequent login would reject.
+    val canConfirm = isConfirmCodeValid && confirmPassword.isNotBlank() && !isConfirming
 
     AlertDialog(
         // Recovery codes are shown exactly once and the backend can't re-issue

--- a/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/api/StatefulStubbedApiTwoFactorTest.kt
+++ b/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/api/StatefulStubbedApiTwoFactorTest.kt
@@ -27,8 +27,26 @@ class StatefulStubbedApiTwoFactorTest {
             RegisterRequest(username, "$username@test.com", "pw12345", "false", "127.0.0.1", "1970-01-01")
         ).body()!!.sessionToken
         api.setupTotp(token)
-        val confirm = api.confirmTotp(token, ConfirmTotpRequest(StatefulStubbedAPI.STUB_TOTP_CODE))
+        val confirm = api.confirmTotp(token, ConfirmTotpRequest("pw12345", StatefulStubbedAPI.STUB_TOTP_CODE))
         return token to confirm.body()!!.recoveryCodes
+    }
+
+    @Test
+    fun `confirm rejects a wrong password so a stolen session cannot enrol`() = runTest {
+        // Enrolling with a session alone would let a session thief bind their own
+        // authenticator, read the recovery codes, and lock the owner out for good.
+        val api = StatefulStubbedAPI()
+        val token = api.register(
+            RegisterRequest("grace", "grace@test.com", "pw12345", "false", "127.0.0.1", "1970-01-01")
+        ).body()!!.sessionToken
+        api.setupTotp(token)
+
+        val wrong = api.confirmTotp(token, ConfirmTotpRequest("wrong", StatefulStubbedAPI.STUB_TOTP_CODE))
+        assertEquals(400, wrong.code())
+
+        val right = api.confirmTotp(token, ConfirmTotpRequest("pw12345", StatefulStubbedAPI.STUB_TOTP_CODE))
+        assertEquals(200, right.code())
+        assertEquals(10, right.body()!!.recoveryCodes.size)
     }
 
     @Test

--- a/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/SettingsViewModelTest.kt
+++ b/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/SettingsViewModelTest.kt
@@ -6,7 +6,9 @@ import com.example.positiveonlysocial.data.auth.AuthenticationManager
 import com.example.positiveonlysocial.data.model.GenericResponse
 import com.example.positiveonlysocial.data.model.UserSession
 import com.example.positiveonlysocial.data.security.KeychainHelperProtocol
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.Assert.assertEquals
@@ -15,7 +17,10 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.stub
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import com.example.positiveonlysocial.data.model.IdentityVerificationRequest
@@ -140,6 +145,30 @@ class SettingsViewModelTest {
         // The in-flight flag is cleared once the request settles, so the UI can
         // block a duplicate submission while it runs and re-enable Verify after.
         assertEquals(false, viewModel.isConfirmingTotp.value)
+    }
+
+    @Test
+    fun `confirmTotp ignores a duplicate submission while one is in flight`() = runTest {
+        // Disabling the Verify button only takes effect on the next Compose
+        // recomposition, so a fast double-tap can reach the view model twice.
+        // Park the first call inside its API request so it is genuinely in
+        // flight, then confirm the second is dropped rather than racing it.
+        val gate = CompletableDeferred<Unit>()
+        api.stub {
+            onBlocking { confirmTotp(any(), any()) } doSuspendableAnswer {
+                gate.await()
+                Response.success(ConfirmTotpResponse(totpEnabled = true, recoveryCodes = listOf("a")))
+            }
+        }
+
+        viewModel.confirmTotp("pw12345", "123456") // suspends at the gate, in flight
+        viewModel.confirmTotp("pw12345", "123456") // must be ignored by the guard
+
+        gate.complete(Unit)
+        advanceUntilIdle()
+
+        verify(api, times(1)).confirmTotp(any(), any())
+        assertEquals(1, viewModel.recoveryCodes.value?.size)
     }
 
     @Test

--- a/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/SettingsViewModelTest.kt
+++ b/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/SettingsViewModelTest.kt
@@ -137,6 +137,21 @@ class SettingsViewModelTest {
 
         verify(api).confirmTotp("token123", ConfirmTotpRequest("pw12345", "123456"))
         assertEquals(10, viewModel.recoveryCodes.value?.size)
+        // The in-flight flag is cleared once the request settles, so the UI can
+        // block a duplicate submission while it runs and re-enable Verify after.
+        assertEquals(false, viewModel.isConfirmingTotp.value)
+    }
+
+    @Test
+    fun `confirmTotp failure clears the in-flight confirm flag`() = runTest {
+        whenever(api.confirmTotp(any(), any())).thenReturn(
+            Response.error(400, "{\"error\":\"Invalid password\"}".toResponseBody())
+        )
+
+        viewModel.confirmTotp("wrongpw", "123456")
+
+        // A failed confirm must not leave Verify stuck disabled on retry.
+        assertEquals(false, viewModel.isConfirmingTotp.value)
     }
 
     @Test

--- a/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/SettingsViewModelTest.kt
+++ b/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/SettingsViewModelTest.kt
@@ -129,23 +129,23 @@ class SettingsViewModelTest {
     @Test
     fun `confirmTotp success exposes recovery codes`() = runTest {
         val codes = (0 until 10).map { "code$it" }
-        whenever(api.confirmTotp("token123", ConfirmTotpRequest("123456"))).thenReturn(
+        whenever(api.confirmTotp("token123", ConfirmTotpRequest("pw12345", "123456"))).thenReturn(
             Response.success(ConfirmTotpResponse(totpEnabled = true, recoveryCodes = codes))
         )
 
-        viewModel.confirmTotp("123456")
+        viewModel.confirmTotp("pw12345", "123456")
 
-        verify(api).confirmTotp("token123", ConfirmTotpRequest("123456"))
+        verify(api).confirmTotp("token123", ConfirmTotpRequest("pw12345", "123456"))
         assertEquals(10, viewModel.recoveryCodes.value?.size)
     }
 
     @Test
     fun `confirmTotp failure surfaces error and no codes`() = runTest {
-        whenever(api.confirmTotp("token123", ConfirmTotpRequest("000000"))).thenReturn(
+        whenever(api.confirmTotp("token123", ConfirmTotpRequest("pw12345", "000000"))).thenReturn(
             Response.error(400, "{\"error\":\"Invalid two-factor code\"}".toResponseBody())
         )
 
-        viewModel.confirmTotp("000000")
+        viewModel.confirmTotp("pw12345", "000000")
 
         assertNull(viewModel.recoveryCodes.value)
         assertTrue(viewModel.showingErrorAlert.value)
@@ -156,13 +156,13 @@ class SettingsViewModelTest {
         whenever(api.setupTotp("token123")).thenReturn(
             Response.success(TotpSetupResponse("SECRET", "otpauth://totp/x"))
         )
-        whenever(api.confirmTotp("token123", ConfirmTotpRequest("123456"))).thenReturn(
+        whenever(api.confirmTotp("token123", ConfirmTotpRequest("pw12345", "123456"))).thenReturn(
             Response.success(ConfirmTotpResponse(totpEnabled = true, recoveryCodes = listOf("a", "b")))
         )
         // Enroll fully so recovery codes exist — finishTotpEnrollment only
         // reports success when confirm actually produced them.
         viewModel.startTotpSetup()
-        viewModel.confirmTotp("123456")
+        viewModel.confirmTotp("pw12345", "123456")
 
         viewModel.finishTotpEnrollment()
 


### PR DESCRIPTION
Follows the backend change in [#355](https://github.com/andrewkatson/pos/pull/355), which makes `2fa/totp/confirm/` require the account password. The Android 2FA work merged in #359 sends only the code, so without this change enrollment breaks against the new backend.

### Why the backend now requires it

`confirm_totp` previously accepted a session alone. Someone holding a stolen session could bind **their own** authenticator to the account, read the one-time recovery codes straight off the response, and lock the real owner out permanently — turning off 2FA afterwards requires a code only the attacker has. `disable_totp` already required the password; enrollment was the weaker half, and it is the more dangerous one.

### Changes

- `Models.kt` — `ConfirmTotpRequest` gains a required `password`.
- `SettingsScreen.kt` — the enrollment dialog adds an account-password field (`PasswordVisualTransformation`, test tag `TwoFactorConfirmPasswordField`) and keeps **Verify** disabled until both the 6-digit code and a password are present. The field is cleared when the dialog is opened, alongside the code.
- `SettingsViewModel.kt` — `confirmTotp(password, code)`.
- `StatefulStubbedAPI.kt` — the stub rejects a wrong password with `Invalid password`, mirroring the real endpoint and `disableTotp`.
- Tests updated in `SettingsViewModelTest.kt` and `StatefulStubbedApiTwoFactorTest.kt`, plus a new stub-level regression test asserting a wrong password is refused and the right one still enrolls.

### Verification

No Android toolchain on this machine, so the unit and instrumented suites run in CI on this PR rather than locally. No instrumented test drives the enrollment dialog, so no androidTest changes were needed.

### Merge order

Land [#355](https://github.com/andrewkatson/pos/pull/355) with (or before) this — together they change one contract on both sides. The matching website change is [#364](https://github.com/andrewkatson/pos/pull/364) and iOS is in [#358](https://github.com/andrewkatson/pos/pull/358).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
