### PR TITLE
Show post caption underneath the photo in the feeds (#378)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,11 @@ profile grid, and the Feed — without opening the post first:
 - **Retract report**, which shows the reason you originally gave.
 - **Delete**, offered only on your own posts.
 
-Each feed row additionally shows the author, how long ago the post was made, and
-a comment count that opens the post when tapped. The square profile tiles omit
-those two — there is no room for them.
+Each feed row additionally shows the author, the caption under the photo, how
+long ago the post was made, and a comment count that opens the post when tapped.
+The square profile tiles omit these — there is no room for them. A text-only
+post already renders its caption as the tile in place of a photo, so the caption
+is not repeated beneath it.
 
 The post listing endpoints (`get_posts_in_feed`, `get_posts_for_followed_users`,
 `get_posts_for_user`) therefore return `post_likes`, `is_liked`, `is_reported`,

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/FeedScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/FeedScreen.kt
@@ -217,6 +217,13 @@ fun PostItem(
                 }
         )
 
+        // The caption under the photo (issue #378). Text-only posts (#307)
+        // already render their caption as the tile above, so it isn't repeated
+        // for them.
+        if (post.imageUrl != null) {
+            Text(text = post.caption)
+        }
+
         // Like / comment count / report / retract / delete without leaving the
         // feed (issues #267, #249). A sibling of the image, so it can't swallow
         // the tap that opens the post.

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/FeedScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/FeedScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -221,7 +222,7 @@ fun PostItem(
         // already render their caption as the tile above, so it isn't repeated
         // for them.
         if (post.imageUrl != null) {
-            Text(text = post.caption)
+            Text(text = post.caption, modifier = Modifier.testTag("PostCaption"))
         }
 
         // Like / comment count / report / retract / delete without leaving the

--- a/ios/Positive Only Social/Positive Only Social/VibesViews/FeedView.swift
+++ b/ios/Positive Only Social/Positive Only Social/VibesViews/FeedView.swift
@@ -135,6 +135,15 @@ struct ForYouFeedView: View {
                         }
                         .accessibilityIdentifier("ForYouPostImage")
 
+                        // The caption under the photo (issue #378). Text-only
+                        // posts (#307) already render their caption as the tile
+                        // above, so it isn't repeated for them.
+                        if post.imageUrl != nil {
+                            Text(post.caption)
+                                .padding(.horizontal)
+                                .accessibilityIdentifier("PostCaption")
+                        }
+
                         // Like / report / delete, the comment count and the
                         // post's age (issues #267 and #249).
                         PostActionBar(post: post, postActions: postActions, showsPostDetails: true)
@@ -212,6 +221,15 @@ struct FollowingFeedView: View {
                             }
                         }
                         .accessibilityIdentifier("FollowingPostImage")
+
+                        // The caption under the photo (issue #378). Text-only
+                        // posts (#307) already render their caption as the tile
+                        // above, so it isn't repeated for them.
+                        if post.imageUrl != nil {
+                            Text(post.caption)
+                                .padding(.horizontal)
+                                .accessibilityIdentifier("PostCaption")
+                        }
 
                         // Like / report / delete, the comment count and the
                         // post's age (issues #267 and #249).

--- a/website/src/components/FeedTab.test.tsx
+++ b/website/src/components/FeedTab.test.tsx
@@ -79,6 +79,30 @@ test('renders a text-only post as a caption tile instead of an image (#307)', as
   expect(tile).toHaveTextContent('words only')
 })
 
+test('shows the caption under the photo for an image post (#378)', async () => {
+  mockGetFeed.mockResolvedValue([
+    { post_identifier: 'p1', image_url: 'http://img/1.jpg', author_username: 'ada', caption: 'a lovely day' },
+  ])
+  mockGetFollowed.mockResolvedValue([])
+  const { container } = renderTab()
+
+  await screen.findByRole('button', { name: 'Open post by ada' })
+  const caption = container.querySelector('.feed-post__caption')
+  expect(caption).toHaveTextContent('a lovely day')
+})
+
+test('does not repeat the caption below a text-only post (#378)', async () => {
+  // The tile above already shows it; a second copy underneath would be redundant.
+  mockGetFeed.mockResolvedValue([
+    { post_identifier: 'p1', image_url: null, author_username: 'ada', caption: 'words only' },
+  ])
+  mockGetFollowed.mockResolvedValue([])
+  const { container } = renderTab()
+
+  await screen.findByRole('img', { name: 'words only' })
+  expect(container.querySelector('.feed-post__caption')).toBeNull()
+})
+
 test('switches to the Following feed', async () => {
   mockGetFeed.mockResolvedValue([])
   mockGetFollowed.mockResolvedValue([

--- a/website/src/components/FeedTab.tsx
+++ b/website/src/components/FeedTab.tsx
@@ -163,6 +163,12 @@ function FeedTab() {
               >
                 <PostThumbnail post={post} />
               </button>
+              {/* The caption under the photo (issue #378). Text-only posts (#307)
+                  already render their caption as the tile above, so it isn't
+                  repeated for them. */}
+              {post.image_url !== null && (
+                <p className="feed-post__caption">{post.caption}</p>
+              )}
               {/* Comment count and post time only appear here: feed rows have
                   the width for them, the square profile tiles don't (#249). */}
               <PostActionBar

--- a/website/src/pages/MainApp.css
+++ b/website/src/pages/MainApp.css
@@ -387,6 +387,14 @@
   display: block;
 }
 
+/* The caption shown under the feed photo (issue #378). */
+.feed-post__caption {
+  margin: 0.5rem 0 0;
+  line-height: 1.4;
+  color: #ffffff;
+  word-break: break-word;
+}
+
 /* ---- Generic helpers ---- */
 
 .muted {


### PR DESCRIPTION
Closes #378.

## What

The feed rows now show a post's caption **underneath the photo** in both the For You and Following feeds, across the website, iOS, and Android clients. Previously the caption was only visible after opening a post (or, for text-only posts, as the stand-in tile).

## Why

Issue #378 (release blocking): "The feeds should show the caption underneath the photo."

## Details

- **Website** — `FeedTab.tsx` renders `<p class="feed-post__caption">` between the image and the action bar when `image_url !== null`; new `.feed-post__caption` style in `MainApp.css`.
- **iOS** — `FeedView.swift` adds `Text(post.caption)` under the image in both `ForYouFeedView` and `FollowingFeedView`, gated on `imageUrl != nil`, with a `PostCaption` accessibility id.
- **Android** — `FeedScreen.kt` adds `Text(post.caption)` in `PostItem` when `imageUrl != null`.
- **Spec** — `README.md` updated to document the feed caption.

Text-only posts (#307) already render their caption as the tile in place of a photo, so the caption is intentionally **not** repeated beneath them — matching this in all three clients.

## Tests

- Added two `FeedTab.test.tsx` tests: caption shown under an image post; caption not duplicated below a text-only post.
- iOS/Android changes are view-only mirrors of the same conditional; no new UI tests were added since they can't be run/verified in this environment and a fragile one risks breaking CI. The mobile caption elements carry accessibility ids for future coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)