### PR TITLE
Release: follow-list + post-detail fixes (#397, #398, #404, #405)

### DIFF
--- a/backend/user_system/tests/test_get_followers_view.py
+++ b/backend/user_system/tests/test_get_followers_view.py
@@ -1,6 +1,8 @@
+from django.contrib.auth import get_user_model
 from django.urls import reverse
 from .test_parent_case import PositiveOnlySocialTestCase
-from ..constants import Fields
+from ..constants import BAN_TYPE_SHADOW, Fields
+from ..models import UserBan
 from ..views import get_user_with_username
 
 class GetFollowersViewTests(PositiveOnlySocialTestCase):
@@ -62,6 +64,36 @@ class GetFollowersViewTests(PositiveOnlySocialTestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), [])
+
+    def test_shadow_banned_follower_excluded(self):
+        """A shadow-banned follower is hidden from the list (issue #398) — its
+        profile can't be opened, so listing it is a dead end."""
+        self.user_b.following.add(self.user_a)
+        self.user_c.following.add(self.user_a)
+        UserBan.objects.create(user=self.user_b, ban_type=BAN_TYPE_SHADOW)
+
+        response = self.client.get(self.url, **self.user_a_header)
+
+        self.assertEqual(response.status_code, 200)
+        usernames = [user[Fields.username] for user in response.json()]
+        self.assertEqual(usernames, [self.user_c_username])
+
+    def test_cross_age_band_follower_excluded(self):
+        """A follower outside the requester's age band is hidden (issue #398):
+        cross-band accounts are mutually invisible and their profiles are
+        unopenable, so the list must not surface one."""
+        # user_a keeps the registration default (unverified => general band).
+        # Make user_b a verified minor => the other band; user_c stays same-band.
+        get_user_model().objects.filter(pk=self.user_b.pk).update(
+            identity_is_verified=True, is_adult=False)
+        self.user_b.following.add(self.user_a)
+        self.user_c.following.add(self.user_a)
+
+        response = self.client.get(self.url, **self.user_a_header)
+
+        self.assertEqual(response.status_code, 200)
+        usernames = [user[Fields.username] for user in response.json()]
+        self.assertEqual(usernames, [self.user_c_username])
 
     def test_requires_authentication(self):
         """The endpoint rejects unauthenticated requests."""

--- a/backend/user_system/tests/test_get_followers_view.py
+++ b/backend/user_system/tests/test_get_followers_view.py
@@ -66,8 +66,9 @@ class GetFollowersViewTests(PositiveOnlySocialTestCase):
         self.assertEqual(response.json(), [])
 
     def test_shadow_banned_follower_excluded(self):
-        """A shadow-banned follower is hidden from the list (issue #398) — its
-        profile can't be opened, so listing it is a dead end."""
+        """A shadow-banned follower is excluded from the list (issue #398):
+        shadow-ban semantics hide the account from everyone else, so it's dropped
+        here just as user search drops it (the profile itself still opens)."""
         self.user_b.following.add(self.user_a)
         self.user_c.following.add(self.user_a)
         UserBan.objects.create(user=self.user_b, ban_type=BAN_TYPE_SHADOW)

--- a/backend/user_system/tests/test_get_following_view.py
+++ b/backend/user_system/tests/test_get_following_view.py
@@ -1,6 +1,8 @@
+from django.contrib.auth import get_user_model
 from django.urls import reverse
 from .test_parent_case import PositiveOnlySocialTestCase
-from ..constants import Fields
+from ..constants import BAN_TYPE_SHADOW, Fields
+from ..models import UserBan
 from ..views import get_user_with_username
 
 class GetFollowingViewTests(PositiveOnlySocialTestCase):
@@ -74,6 +76,36 @@ class GetFollowingViewTests(PositiveOnlySocialTestCase):
         response = self.client.get(self.url, **self.user_a_header)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), [])
+
+    def test_shadow_banned_following_excluded(self):
+        """A shadow-banned account the requester follows is hidden from the list
+        (issue #398) — its profile can't be opened, so listing it is a dead end."""
+        self.user_a.following.add(self.user_b)
+        self.user_a.following.add(self.user_c)
+        UserBan.objects.create(user=self.user_b, ban_type=BAN_TYPE_SHADOW)
+
+        response = self.client.get(self.url, **self.user_a_header)
+
+        self.assertEqual(response.status_code, 200)
+        usernames = [user[Fields.username] for user in response.json()]
+        self.assertEqual(usernames, [self.user_c_username])
+
+    def test_cross_age_band_following_excluded(self):
+        """A followed account outside the requester's age band is hidden (issue
+        #398): cross-band profiles are unopenable and mutually invisible, so the
+        follow list must not surface one."""
+        # user_a keeps the registration default (unverified => general band).
+        # Make user_b a verified minor => the other band; user_c stays same-band.
+        get_user_model().objects.filter(pk=self.user_b.pk).update(
+            identity_is_verified=True, is_adult=False)
+        self.user_a.following.add(self.user_b)
+        self.user_a.following.add(self.user_c)
+
+        response = self.client.get(self.url, **self.user_a_header)
+
+        self.assertEqual(response.status_code, 200)
+        usernames = [user[Fields.username] for user in response.json()]
+        self.assertEqual(usernames, [self.user_c_username])
 
     def test_requires_authentication(self):
         """The endpoint rejects unauthenticated requests."""

--- a/backend/user_system/tests/test_get_following_view.py
+++ b/backend/user_system/tests/test_get_following_view.py
@@ -78,8 +78,10 @@ class GetFollowingViewTests(PositiveOnlySocialTestCase):
         self.assertEqual(response.json(), [])
 
     def test_shadow_banned_following_excluded(self):
-        """A shadow-banned account the requester follows is hidden from the list
-        (issue #398) — its profile can't be opened, so listing it is a dead end."""
+        """A shadow-banned account the requester follows is excluded from the list
+        (issue #398): shadow-ban semantics hide the account from everyone else, so
+        it's dropped here just as user search drops it (the profile itself still
+        opens)."""
         self.user_a.following.add(self.user_b)
         self.user_a.following.add(self.user_c)
         UserBan.objects.create(user=self.user_b, ban_type=BAN_TYPE_SHADOW)

--- a/backend/user_system/tests/test_get_posts_for_user_view.py
+++ b/backend/user_system/tests/test_get_posts_for_user_view.py
@@ -146,6 +146,37 @@ class GetPostsForUserTests(PositiveOnlySocialTestCase):
         # (Assuming POST_BATCH_SIZE >= 10)
         self.assertEqual(len(responses), 10)
 
+    def test_own_posts_not_duplicated_when_following_multiple(self):
+        """Regression for #397: a viewer's own posts must not fan out by the
+        number of accounts they follow.
+
+        The per-post audience filter joins the author's outgoing follow edges;
+        on your own profile (viewer == author) that join was unrestricted, so
+        each post was returned once per account you follow. Following two
+        accounts reproduced the reported 2x duplication. .distinct() collapses
+        it.
+        """
+        me = get_user_with_username(self.username)
+        for prefix in ('followed_one', 'followed_two'):
+            followed = get_user_with_username(
+                self.make_user_with_prefix(prefix)[Fields.username])
+            me.following.add(followed)
+
+        # Gather every batch: with the fan-out the queryset held 20 rows (10
+        # posts x 2 follows), so the duplicates would otherwise just spill into
+        # batch 1 rather than vanish.
+        posts = []
+        for batch in (0, 1):
+            url = reverse('get_posts_for_user', kwargs={
+                'username': self.username, 'batch': batch})
+            response = self.client.get(url, **self.valid_header)
+            self.assertEqual(response.status_code, 200)
+            posts.extend(response.json())
+
+        ids = [post[Fields.post_identifier] for post in posts]
+        self.assertEqual(len(ids), len(set(ids)), "own posts were duplicated")
+        self.assertEqual(len(set(ids)), 10)
+
     def test_posts_include_original_image_url_fallback(self):
         """
         Each post carries an `original_image_url` (the full-resolution original)

--- a/backend/user_system/views.py
+++ b/backend/user_system/views.py
@@ -3487,12 +3487,16 @@ def get_followers(request):
     Only ever returns the signed-in user's own followers — there is no username
     parameter, so a follower/following list can't be requested for anyone else.
 
-    Filtered through searchable_users so shadow-banned accounts and accounts
-    outside the requester's age band are excluded (issue #398): those profiles
-    are unopenable — get_profile_details returns "not found" for them — so
-    listing them here just produces a "couldn't load them" dead end. This keeps
-    the follow lists consistent with the central visibility invariant that
-    cross-band accounts are mutually invisible (README "Age segregation").
+    Filtered through searchable_users (issue #398), which drops two kinds of
+    account for different reasons:
+    - Cross-age-band accounts: get_profile_details returns "User not found" for
+      a cross-band profile, so listing it here is the "couldn't load them" dead
+      end from the bug report, and surfacing it would leak a cross-band
+      account's existence — the age-segregation invariant forbids it (README
+      "Age segregation").
+    - Shadow-banned accounts: their profile still opens, but shadow-ban
+      semantics keep the account hidden from everyone else, so it is excluded
+      here just as user search excludes it.
     """
     logger.info("Endpoint get_followers invoked by IP or User")
     # request.user.followers is the reverse side of the (non-symmetrical)
@@ -3522,11 +3526,12 @@ def get_following(request):
     Only ever returns the signed-in user's own following list — there is no
     username parameter, so this can't be requested for anyone else.
 
-    Filtered through searchable_users so shadow-banned accounts and accounts
-    outside the requester's age band are excluded (issue #398): those profiles
-    can't be opened, so listing them here is a dead end and would also leak a
-    cross-band account's existence, which the age-segregation invariant forbids
-    (README "Age segregation").
+    Filtered through searchable_users (issue #398), for two distinct reasons: a
+    cross-age-band profile is unopenable — get_profile_details returns "User not
+    found" for it — so listing it is a dead end and would leak a cross-band
+    account's existence (README "Age segregation"); a shadow-banned account's
+    profile still opens, but shadow-ban semantics keep it hidden from everyone
+    else, so it is excluded here just as user search excludes it.
     """
     logger.info("Endpoint get_following invoked by IP or User")
     following = searchable_users(

--- a/backend/user_system/views.py
+++ b/backend/user_system/views.py
@@ -3486,11 +3486,20 @@ def get_followers(request):
 
     Only ever returns the signed-in user's own followers — there is no username
     parameter, so a follower/following list can't be requested for anyone else.
+
+    Filtered through searchable_users so shadow-banned accounts and accounts
+    outside the requester's age band are excluded (issue #398): those profiles
+    are unopenable — get_profile_details returns "not found" for them — so
+    listing them here just produces a "couldn't load them" dead end. This keeps
+    the follow lists consistent with the central visibility invariant that
+    cross-band accounts are mutually invisible (README "Age segregation").
     """
     logger.info("Endpoint get_followers invoked by IP or User")
     # request.user.followers is the reverse side of the (non-symmetrical)
     # `following` relation: everyone with request.user in their `following`.
-    followers = request.user.followers.order_by('username')
+    followers = searchable_users(
+        request.user.followers.all(), request.user
+    ).order_by('username')
 
     users_data = [
         {
@@ -3512,9 +3521,17 @@ def get_following(request):
 
     Only ever returns the signed-in user's own following list — there is no
     username parameter, so this can't be requested for anyone else.
+
+    Filtered through searchable_users so shadow-banned accounts and accounts
+    outside the requester's age band are excluded (issue #398): those profiles
+    can't be opened, so listing them here is a dead end and would also leak a
+    cross-band account's existence, which the age-segregation invariant forbids
+    (README "Age segregation").
     """
     logger.info("Endpoint get_following invoked by IP or User")
-    following = request.user.following.order_by('username')
+    following = searchable_users(
+        request.user.following.all(), request.user
+    ).order_by('username')
 
     users_data = [
         {

--- a/backend/user_system/visibility.py
+++ b/backend/user_system/visibility.py
@@ -97,10 +97,16 @@ def visible_posts(posts, viewer):
             & _audience_q(viewer)
             & _same_age_band_q(viewer, 'author')
         )
-    # .distinct() collapses the audience-join fan-out: without it, a viewer's
-    # own posts are returned once per account the viewer's *author* follows, so
-    # your own profile shows each post N times where N = accounts you follow
-    # (issue #397). Ordering is by -creation_time only, so distinct is safe.
+    # .distinct() collapses the audience-join fan-out from _audience_q: on the
+    # author-owns-it branch the join over the author's outgoing follow edges is
+    # unrestricted, so a viewer's own posts come back once per account they
+    # follow — N copies on your own profile where N = accounts you follow
+    # (issue #397). Plain row-level distinct is correct for every caller: the
+    # duplicated rows are identical across all selected columns (the audience
+    # edge is unique per (author, viewer)), and the callers' own orderings and
+    # annotations (feed weight, -creation_time, saved posts' -saved_time) are
+    # single-valued per post, so none of them split a post back into rows that
+    # distinct would keep.
     ).distinct()
 
 

--- a/backend/user_system/visibility.py
+++ b/backend/user_system/visibility.py
@@ -27,11 +27,15 @@ def _audience_q(viewer):
     admits = Q(audience=POST_AUDIENCE_PUBLIC)
     if viewer is not None and getattr(viewer, 'is_authenticated', False):
         for audience, categories in AUDIENCE_ALLOWED_CATEGORIES.items():
-            # Join the author's outgoing follow edges to this viewer. The
-            # UserFollow unique constraint on (user_from, user_to) means at most
-            # one such edge exists, so this join never duplicates a post row —
-            # and a plain Q join keeps the whole filter combinable with the other
-            # Q terms in visible_posts.
+            # Join the author's outgoing follow edges (following_set) and keep
+            # rows whose edge points at this viewer. A plain Q join keeps the
+            # whole filter combinable with the other Q terms in visible_posts.
+            #
+            # NOTE: this DOES fan out. `following_set` is multi-valued, and the
+            # OR with the author-owns-it branch in visible_posts leaves the join
+            # unrestricted for the author's own posts (viewer == author), so a
+            # post is emitted once per follow edge its author has. visible_posts
+            # must therefore .distinct() to collapse the duplicates (issue #397).
             admits |= Q(
                 audience=audience,
                 author__following_set__user_to=viewer,
@@ -93,7 +97,11 @@ def visible_posts(posts, viewer):
             & _audience_q(viewer)
             & _same_age_band_q(viewer, 'author')
         )
-    )
+    # .distinct() collapses the audience-join fan-out: without it, a viewer's
+    # own posts are returned once per account the viewer's *author* follows, so
+    # your own profile shows each post N times where N = accounts you follow
+    # (issue #397). Ordering is by -creation_time only, so distinct is safe.
+    ).distinct()
 
 
 def visible_comments(comments, viewer):

--- a/website/src/pages/MainApp.css
+++ b/website/src/pages/MainApp.css
@@ -275,9 +275,10 @@
 /* A default/old text post has no chosen color, so CaptionTile adds no `.post-bg`
    class and nothing overrides `.detail-image`'s solid #1a1a1a — it renders black
    in the detail view while the feed/grid (no `.detail-image`) shows the themed
-   gradient (issue #405). Restore the gradient for that case only; posts with a
-   chosen color carry `.post-bg--x`, which this :not() excludes so their color
-   still wins. */
+   gradient (issue #405). Restore the gradient for that case only. A post that
+   DID pick a color gets the base `.post-bg` class (alongside its `.post-bg--x`
+   modifier), so `:not(.post-bg)` excludes it here and its chosen color still
+   wins. */
 .caption-tile--detail.detail-image:not(.post-bg) {
   background: linear-gradient(135deg, #2b5876, #5ba4dc);
   color: #ffffff;

--- a/website/src/pages/MainApp.css
+++ b/website/src/pages/MainApp.css
@@ -261,6 +261,28 @@
   font-size: 1.15rem;
 }
 
+/* A text-only post's detail tile also carries `.detail-image` (for the shared
+   width/border-radius/cursor), whose `display: block` would otherwise override
+   the tile's flex centering — at equal specificity it wins by source order —
+   and drop the caption to the top of the box (issue #404). Re-assert centering
+   with a two-class selector so it wins regardless of order. */
+.caption-tile--detail.detail-image {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* A default/old text post has no chosen color, so CaptionTile adds no `.post-bg`
+   class and nothing overrides `.detail-image`'s solid #1a1a1a — it renders black
+   in the detail view while the feed/grid (no `.detail-image`) shows the themed
+   gradient (issue #405). Restore the gradient for that case only; posts with a
+   chosen color carry `.post-bg--x`, which this :not() excludes so their color
+   still wins. */
+.caption-tile--detail.detail-image:not(.post-bg) {
+  background: linear-gradient(135deg, #2b5876, #5ba4dc);
+  color: #ffffff;
+}
+
 /* Appeals list: thumbnail-sized stand-in. */
 .caption-tile--thumb {
   width: 48px;


### PR DESCRIPTION
Release merge of `dev` into `main`. Contains PR #403 (the only change on `dev` since the last release, #395).

## What ships
- **#397** (backend) — `.distinct()` in `visible_posts()` fixes own-profile posts duplicating once per followed account.
- **#398** (backend) — `get_followers`/`get_following` filter through `searchable_users`, excluding shadow-banned and cross-age-band accounts.
- **#404** (website CSS) — center the caption in the text-only post detail tile.
- **#405** (website CSS) — restore the themed gradient for default/old text posts in the detail view.

## Deploy notes
- **No migrations, no new dependencies.** `main` is behind `dev` only by these commits; no migration-leaf conflict, so GitHub's merge button is safe.
- Spans backend (#397/#398) and website (#404/#405) — both need redeploying.
- Per issue #399's finding, the backend deploy must restart **both** `gunicorn` and `classification-worker.service` (not just gunicorn), or the async worker keeps running stale code.

## Not included
- #399 was fixed live (worker restart), no code change.
- #402 (setup/status-script hardening) is a separate in-progress PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)