### PR TITLE
Filter follower/following counts to match the filtered lists (#398 follow-up)

### DIFF
--- a/backend/user_system/tests/test_get_profile_details_view.py
+++ b/backend/user_system/tests/test_get_profile_details_view.py
@@ -1,7 +1,8 @@
+from django.contrib.auth import get_user_model
 from django.urls import reverse
 from .test_parent_case import PositiveOnlySocialTestCase
-from ..constants import Fields
-from ..models import PositiveOnlySocialUser  # Import model for setup
+from ..constants import BAN_TYPE_SHADOW, Fields
+from ..models import PositiveOnlySocialUser, UserBan  # Import model for setup
 
 # Constants for this test case
 invalid_session_management_token = '?'
@@ -119,6 +120,31 @@ class GetProfileDetailsTests(PositiveOnlySocialTestCase):
         self.assertEqual(data[Fields.username], self.profile_username)
         self.assertEqual(data[Fields.follower_count], 1)  # The profile user now has 1 follower
         self.assertEqual(data[Fields.is_following], True)
+
+    def test_follower_count_excludes_shadow_banned_and_cross_band(self):
+        """The follower count must agree with the filtered follower list (issue
+        #398): a shadow-banned or cross-age-band follower is hidden from the list,
+        so it must not inflate the count either. Viewing own profile here, so the
+        requester's age band is the filter — matching get_followers."""
+        normal = PositiveOnlySocialUser.objects.get(
+            username=self.make_user_with_prefix('normie')[Fields.username])
+        shadow = PositiveOnlySocialUser.objects.get(
+            username=self.make_user_with_prefix('shady')[Fields.username])
+        minor = PositiveOnlySocialUser.objects.get(
+            username=self.make_user_with_prefix('minorx')[Fields.username])
+        for follower in (normal, shadow, minor):
+            follower.following.add(self.requesting_user)
+        # Hide two of the three: one shadow-banned, one in the other age band.
+        UserBan.objects.create(user=shadow, ban_type=BAN_TYPE_SHADOW)
+        get_user_model().objects.filter(pk=minor.pk).update(
+            identity_is_verified=True, is_adult=False)
+
+        url = reverse('get_profile_details', kwargs={'username': self.local_username})
+        response = self.client.get(url, **self.valid_header)
+
+        self.assertEqual(response.status_code, 200)
+        # Only the normal, same-band follower is counted — not 3.
+        self.assertEqual(response.json()[Fields.follower_count], 1)
 
     def test_is_blocked_is_true_when_blocked(self):
         """

--- a/backend/user_system/views.py
+++ b/backend/user_system/views.py
@@ -3595,12 +3595,13 @@ def get_profile_details(request, username):
     # shadow-banned profile shows no posts to others (but all to its owner).
     post_count = visible_posts(profile_user.post_set.all(), request.user).count()
 
-    # Assuming UserFollow model or a ManyToMany 'followers' field
-    # This logic depends heavily on your model structure.
-    # The original code's `followers_set` and `following_set` imply a
-    # ManyToMany relationship, perhaps 'following' on the User model.
-    follower_count = profile_user.followers.count()
-    following_count = profile_user.following.count()
+    # The follower/following counts must agree with the filtered lists
+    # (issue #398): a shadow-banned or cross-age-band account is hidden from the
+    # follower/following list, so it must not inflate the count either. Apply the
+    # same searchable_users exclusion the list endpoints use — mirroring how
+    # post_count above counts only visible_posts.
+    follower_count = searchable_users(profile_user.followers.all(), request.user).count()
+    following_count = searchable_users(profile_user.following.all(), request.user).count()
 
     # The follow edge (if any) carries the viewer's relationship category for
     # this profile user (issue #392); null when not following.


### PR DESCRIPTION
Follow-up to #398 (merged in #403). We filtered the follower/following **lists** through `searchable_users`, but `get_profile_details` still computed the **counts** from every edge — so a shadow-banned or cross-age-band account disappeared from the list yet kept inflating the follower/following number (visible when viewing your own profile: the count includes people the menu no longer shows).

**Fix:** count `follower_count`/`following_count` through the same `searchable_users(..., request.user)` filter the list endpoints use — mirroring how `post_count` already counts only `visible_posts`.

**Test:** `test_follower_count_excludes_shadow_banned_and_cross_band` — own-profile follower count is 1, not 3, when two of three followers are shadow-banned / cross-age-band.

Backend-only, no migrations. Targeted suite green locally; full suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)