### PR TITLE
Fix npm audit advisories: bump brace-expansion + react-router (7.x, no major upgrade)

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -11,7 +11,7 @@
         "qrcode.react": "^4.2.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "react-router-dom": "^7.6.0"
+        "react-router-dom": "^7.18.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
@@ -1650,16 +1650,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -3139,9 +3139,9 @@
       "peer": true
     },
     "node_modules/react-router": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
-      "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -3161,12 +3161,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.16.0.tgz",
-      "integrity": "sha512-kMUAbimWB5FVbF4Bce4bJsiKJWLIUHq/mEG8+CFDnCSgltptBiG5nguducmsJeGKytlCvQud9Qhzpn49iduTlA==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.16.0"
+        "react-router": "7.18.1"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/website/package.json
+++ b/website/package.json
@@ -15,7 +15,7 @@
     "qrcode.react": "^4.2.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router-dom": "^7.6.0"
+    "react-router-dom": "^7.18.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",


### PR DESCRIPTION
## Summary

Resolves the high-severity `npm audit` findings in `website/` with a minimal, minor-version bump — **no react-router v8 major upgrade required**.

| Package | Before | After | Advisory | Applies here? |
|---|---|---|---|---|
| `brace-expansion` | 5.0.7 | **5.0.8** | GHSA-mh99-v99m-4gvg (high, DoS via unbounded expansion) | Transitive build-tooling dep (glob/minimatch chain), not shipped to the browser — low real risk, bumped anyway |
| `react-router` / `react-router-dom` | 7.16.0 | **7.18.1** | multiple (see below) | See breakdown |

Both `package.json` (`react-router-dom` range → `^7.18.1`) and `package-lock.json` are committed so CI's `npm ci` stays consistent.

## react-router advisory breakdown

This is a **Vite client-only SPA** using `<BrowserRouter>` (declarative mode) in [`src/main.tsx`](website/src/main.tsx) — **no SSR, no RSC, no framework mode**. That determines which advisories apply:

- ✅ **Fixed & applicable** — Open redirect via backslash in `<Link>`/`useNavigate` (GHSA-wrjc-x8rr-h8h6, "multi-mode"). Patched in **7.18.0**. This is the one that genuinely matters: the app uses `useNavigate`/`<Link>` throughout, so this is the real reason for the bump.
- ✅ **Fixed (not applicable anyway)** — the SSR/RSC/framework-mode advisories (RSCErrorHandler XSS, SSR hydration constructor injection, `__manifest` DoS, etc.) are all patched in 7.18.0 too. None apply to a client-only SPA, but they're cleared for free.
- ⚠️ **Not applicable, intentionally deferred** — GHSA-qwww-vcr4-c8h2 (RSC Mode CSRF Bypass) is the **only** react-router advisory patched exclusively in **v8.3.0**. It is **RSC framework-mode only** and does not affect this SPA. `npm audit` may therefore still list react-router as vulnerable against a non-applicable finding; clearing it would require the **v7 → v8 major upgrade**, which is deliberately deferred rather than force-installed, per the "don't blindly `--force`" guidance.

## No major upgrade

`npm audit fix` (without `--force`) stays within 7.x, and 7.18.1 is the latest 7.x. Since every *applicable* advisory is fixed at 7.18.0, the minor bump is the correct call; a v7→v8 migration for a single non-applicable RSC advisory is not warranted.

## Verification

- `package-lock.json` metadata (version/resolved/integrity/deps/engines) taken directly from the npm registry for each target version; no new transitive deps are introduced (react-router keeps `cookie`/`set-cookie-parser`; brace-expansion keeps `balanced-match`), so no other lockfile entries change.
- JSON validity of both files confirmed.
- ⚠️ **Note:** node/npm is not installed on the dev machine, so the full local website gate (`npm run lint`, `npx tsc -b --noEmit`, `npm test`, `npm run build`) could not be run here — this follows the repo's established workflow of verifying website suites via GitHub Actions CI. These are patch/minor bumps within react-router 7.x with a stable public API (`BrowserRouter`, `Routes`, `Route`, `useNavigate`, `Link`, `Navigate`, `useParams`, `useSearchParams`, `useLocation`, `MemoryRouter` are all unchanged across 7.16→7.18), so routing behavior is unaffected. Please confirm the CI gate is green before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)