### PR TITLE
Release: follow-count fix, npm-audit deps, async-services deploy hardening (#408, #409, #406)

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,11 +209,22 @@ own posts only.
 
 Without `REDIS_URL` (local dev, tests, CI) there is no queue, so the job runs
 eagerly in-process; production must set `REDIS_URL` and run the worker. The
-`sweep_classifications` management command (cron, like
-`cleanup_orphan_images`) re-enqueues posts stuck pending past a threshold,
-alerts (log error) once a post has exhausted its retry budget, and purges old
-final-rejection tombstones (default 7 days, `--tombstone-days`; preview with
-`--dry-run`).
+`sweep_classifications` management command (scheduled, like
+`cleanup_orphan_images`) re-enqueues posts **and pending profile photos** stuck
+pending past a threshold (default 15 min, `--stuck-minutes`), alerts (log error)
+once an item has exhausted its retry budget, and purges old final-rejection
+tombstones (default 7 days, `--tombstone-days`; preview with `--dry-run`).
+
+On the app host these async pieces are provisioned by `backend/tools/setup-django.sh`
+as systemd units (see [Deploying and restarting services](#deploying-and-restarting-services)):
+
+- **`classification-worker.service`** — the long-lived RQ worker
+  (`manage.py classification_worker`). Installed always but only enabled when
+  `REDIS_URL` is set in `.env` (queue mode); in eager mode it is not needed.
+- **`sweep-classifications.timer`** — runs `manage.py sweep_classifications`
+  every 15 minutes (matching the stuck threshold).
+- **`cleanup-orphan-images.timer`** — the daily S3 orphan sweep (see
+  [Post image cleanup](#post-image-cleanup)).
 
 Comments are still classified inline in the request (text-only, much smaller
 worst case); moving them to the same async flow is a tracked follow-up.
@@ -657,3 +668,48 @@ resolution trail.
 
 Admins review appeals and either approve them — reversing the moderation action
 (un-hiding the content) — or deny them.
+
+## Deploying and restarting services
+
+The Django API runs on an EC2 host provisioned by `backend/tools/setup-django.sh`
+(gunicorn behind nginx; the website is a separate S3 + CloudFront SPA published
+with `website/deploy-web.sh`). Beyond gunicorn, the backend relies on several
+**async background services**, all installed as systemd units by that script:
+
+| Unit | Kind | What it does | Enabled when |
+| --- | --- | --- | --- |
+| `gunicorn.service` | long-lived | Serves the API (WSGI). | always |
+| `classification-worker.service` | long-lived | RQ worker draining the async post/profile-photo moderation queue (`manage.py classification_worker`). | `REDIS_URL` set (queue mode) |
+| `sweep-classifications.timer` | timer (15 min) | `manage.py sweep_classifications` — re-enqueues stuck-pending items and purges tombstones. | always |
+| `cleanup-orphan-images.timer` | timer (daily) | `manage.py cleanup_orphan_images` — reclaims orphaned S3 images. | always |
+
+**Restart every long-lived process on every deploy.** Both gunicorn *and* the
+classification worker cache the imported source in memory, so a `git pull` alone
+does not pick up new code. In issue #399 a profile photo was stuck "in review"
+forever because the prod worker had been running since **before** the
+profile-photo feature was committed and was never restarted after deploy — its
+cached `user_system.tasks` lacked `classify_profile_photo`, so every job failed
+on import and silently stranded classifications. The generated `~/update-app.sh`
+therefore restarts gunicorn **and** the worker and reloads the timers after
+migrating and collecting static files; use it (or replicate its steps) for every
+by-hand deploy. (The timers run oneshot services that re-exec the new code on
+their next fire, so they self-heal, but the units are reloaded in case their
+definitions changed.)
+
+**Queue vs eager mode.** `REDIS_URL` (set via `--redis-url`, written to
+`backend/.env`) flips the app from eager in-process classification to queue mode.
+Only in queue mode is a worker needed, so `setup-django.sh` installs
+`classification-worker.service` unconditionally but only **enables** it when
+`REDIS_URL` is present. To switch an existing eager host to queue mode: add
+`REDIS_URL` to `.env`, restart gunicorn, then
+`sudo systemctl enable --now classification-worker`.
+
+**`.env` and systemd.** `manage.py` loads `.env` via `python-dotenv`, but
+`wsgi.py` does not — so every systemd unit points at the `.env` with
+`EnvironmentFile=` (parent-of-`backend` on the prod host), or the service would
+start without `REDIS_URL`/DB/AWS credentials.
+
+`backend/tools/status_check.sh` reports the health of all of the above — gunicorn,
+nginx, the classification worker (active/enabled, or "stranding!" if enabled but
+dead), the two timers (last/next run), and best-effort `classification` queue
+depth — so a silently dead worker is visible at a glance.

--- a/README.md
+++ b/README.md
@@ -706,8 +706,9 @@ Only in queue mode is a worker needed, so `setup-django.sh` installs
 
 **`.env` and systemd.** `manage.py` loads `.env` via `python-dotenv`, but
 `wsgi.py` does not — so every systemd unit points at the `.env` with
-`EnvironmentFile=` (parent-of-`backend` on the prod host), or the service would
-start without `REDIS_URL`/DB/AWS credentials.
+`EnvironmentFile=$BACKEND_DIR/.env` (i.e. `backend/.env`, the same file
+`setup-django.sh` generates), or the service would start without
+`REDIS_URL`/DB/AWS credentials.
 
 `backend/tools/status_check.sh` reports the health of all of the above — gunicorn,
 nginx, the classification worker (active/enabled, or "stranding!" if enabled but

--- a/backend/tools/setup-django.sh
+++ b/backend/tools/setup-django.sh
@@ -76,6 +76,7 @@ DATABASE_PASSWORD=""
 DATABASE_HOST=""
 DATABASE_PORT="5432"
 ADMIN_IP_ALLOWLIST=""                 # optional: exact public IP(s) allowed to reach /admin
+REDIS_URL=""                          # optional: enables queue mode + the classification worker
 
 ###############################################################################
 # Helper Functions
@@ -126,6 +127,9 @@ Optional:
   --domain DOMAIN               API host (default: api.smiling.social)
   --frontend-domain DOMAIN      Website host, for CORS/CSRF origins (default: smiling.social)
   --admin-ip-allowlist IPS      Comma-separated exact IPs allowed to reach /admin
+  --redis-url URL               Redis URL (e.g. redis://localhost:6379/0). Setting this
+                                enables queue mode: async classification runs in the
+                                classification-worker service instead of eagerly in-process.
   --admin-email EMAIL           Admin email for Let's Encrypt (standalone TLS only)
   --help                        Show this help message
 EOF
@@ -154,6 +158,7 @@ parse_arguments() {
             --domain)                DOMAIN="$2"; shift 2 ;;
             --frontend-domain)       FRONTEND_DOMAIN="$2"; shift 2 ;;
             --admin-ip-allowlist)    ADMIN_IP_ALLOWLIST="$2"; shift 2 ;;
+            --redis-url)             REDIS_URL="$2"; shift 2 ;;
             --admin-email)           ADMIN_EMAIL="$2"; shift 2 ;;
             --help)                  print_usage ;;
             *) print_error "Unknown option: $1"; print_usage ;;
@@ -327,6 +332,19 @@ DATABASE_HOST=$(env_quote "$DATABASE_HOST")
 DATABASE_PORT=$(env_quote "$DATABASE_PORT")
 EOF
 
+    # REDIS_URL is optional and only written when provided: its presence flips
+    # the app from eager in-process classification to queue mode (settings.py:
+    # CLASSIFICATION_EAGER = not bool(REDIS_URL)), which is what the
+    # classification-worker service consumes. Left unset, the worker service is
+    # installed but stays disabled (see setup_classification_worker_service).
+    if [ -n "$REDIS_URL" ]; then
+        cat >> "$BACKEND_DIR/.env" << EOF
+
+# Redis (enables queue mode + the classification worker; also used for caching/rate-limiting)
+REDIS_URL=$(env_quote "$REDIS_URL")
+EOF
+    fi
+
     chmod 600 "$BACKEND_DIR/.env"
     print_status ".env file created successfully"
 
@@ -404,6 +422,110 @@ EOF
         print_status "Gunicorn service started successfully"
     else
         print_error "Gunicorn failed to start. Check logs with: sudo journalctl -u gunicorn -n 50"
+    fi
+}
+
+setup_classification_worker_service() {
+    # Long-lived RQ worker that drains the async classification queue (issue
+    # #282: posts, issue #7: profile photos). It is the counterpart to gunicorn
+    # and MUST be restarted on every deploy — a worker started before a feature
+    # was committed keeps a stale user_system.tasks in memory and every job it
+    # picks up fails on import, silently stranding classifications (issue #399).
+    #
+    # It only makes sense in QUEUE MODE: the command hard-requires REDIS_URL and
+    # exits non-zero without it, so Restart=always would just crash-loop. We
+    # therefore always install the unit (so a later `enable --now` is one step)
+    # but only enable/start it when REDIS_URL is present in .env. In eager mode
+    # (no REDIS_URL) classification runs in-process and no worker is needed.
+    print_status "Setting up classification worker systemd service..."
+
+    sudo tee /etc/systemd/system/classification-worker.service > /dev/null << EOF
+[Unit]
+Description=RQ classification worker for $DOMAIN (async post/profile-photo moderation)
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+User=$APP_USER
+Group=www-data
+WorkingDirectory=$BACKEND_DIR
+Environment="PATH=$BACKEND_DIR/venv/bin"
+# wsgi.py does not load .env; systemd must, or the worker starts without
+# REDIS_URL/DB/AWS creds and cannot reach the queue.
+EnvironmentFile=$BACKEND_DIR/.env
+ExecStart=$BACKEND_DIR/venv/bin/python manage.py classification_worker
+# Long-lived: restart if it ever exits (crash, OOM, transient Redis blip).
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+    sudo systemctl daemon-reload
+
+    # Gate enablement on REDIS_URL actually being set in .env (queue mode).
+    if grep -Eq '^REDIS_URL=..*' "$BACKEND_DIR/.env"; then
+        sudo systemctl enable --now classification-worker
+        if sudo systemctl is-active --quiet classification-worker; then
+            print_status "Classification worker started successfully (queue mode)"
+        else
+            print_error "Classification worker failed to start. Check: sudo journalctl -u classification-worker -n 50"
+        fi
+    else
+        print_warning "REDIS_URL is not set in $BACKEND_DIR/.env — the app runs in eager mode,"
+        print_warning "so the classification-worker service was installed but left DISABLED."
+        print_warning "To switch to queue mode: add REDIS_URL to .env, restart gunicorn, then run"
+        print_warning "  sudo systemctl enable --now classification-worker"
+    fi
+}
+
+setup_sweep_timer() {
+    # Backstop for the async classification pipeline (issue #282/#7): re-enqueues
+    # posts and profile photos stuck pending past ~15 min (worker crash, deploy,
+    # Redis flush) and purges old final-rejection tombstones. The stuck threshold
+    # is 15 min, so the timer runs every 15 min to match. Like cleanup-orphan-
+    # images it needs the database + AWS/Redis env, so it runs on the app host.
+    # It is safe in eager mode too (no stuck items accumulate; it still purges
+    # tombstones), so it is enabled unconditionally.
+    print_status "Setting up classification sweep systemd timer..."
+
+    sudo tee /etc/systemd/system/sweep-classifications.service > /dev/null << EOF
+[Unit]
+Description=Re-enqueue stuck classifications and purge tombstones for $DOMAIN
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+User=$APP_USER
+Group=www-data
+WorkingDirectory=$BACKEND_DIR
+Environment="PATH=$BACKEND_DIR/venv/bin"
+EnvironmentFile=$BACKEND_DIR/.env
+ExecStart=$BACKEND_DIR/venv/bin/python manage.py sweep_classifications
+EOF
+
+    sudo tee /etc/systemd/system/sweep-classifications.timer > /dev/null << EOF
+[Unit]
+Description=Run classification sweep every 15 minutes
+
+[Timer]
+# Matches sweep_classifications' 15-minute stuck threshold.
+OnCalendar=*:0/15
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+EOF
+
+    sudo systemctl daemon-reload
+    sudo systemctl enable --now sweep-classifications.timer
+
+    if sudo systemctl is-enabled --quiet sweep-classifications.timer; then
+        print_status "Classification sweep timer enabled (every 15 min)"
+    else
+        print_error "Sweep timer failed to enable. Check: sudo journalctl -u sweep-classifications -n 50"
     fi
 }
 
@@ -577,8 +699,21 @@ python manage.py migrate --noinput
 python manage.py collectstatic --noinput
 deactivate
 
-# Restart services
+# Restart ALL long-lived processes so none keeps running the pre-pull code.
+# gunicorn AND the classification worker are both long-lived and cache the
+# imported source in memory: a worker not restarted after a deploy keeps a
+# stale user_system.tasks and every new-feature job fails on import, silently
+# stranding classifications (issue #399). The sweep/cleanup timers run oneshot
+# services that re-exec the new code on their next fire, but reload the units in
+# case their definitions changed.
 sudo systemctl restart gunicorn
+# The worker only exists in queue mode; restart it only if it is enabled, so an
+# eager-mode host (no REDIS_URL) doesn't error on a disabled unit.
+if systemctl is-enabled --quiet classification-worker 2>/dev/null; then
+    sudo systemctl restart classification-worker
+fi
+sudo systemctl daemon-reload
+sudo systemctl restart sweep-classifications.timer cleanup-orphan-images.timer
 sudo systemctl reload nginx
 
 echo "API updated successfully!"
@@ -601,10 +736,17 @@ print_summary() {
     echo ""
     echo "Useful Commands:"
     echo "  - Check server status: ~/status_check.sh"
-    echo "  - Update application: ~/update-app.sh"
+    echo "  - Update application: ~/update-app.sh  (restarts gunicorn AND the worker)"
     echo "  - View Gunicorn logs: sudo journalctl -u gunicorn -f"
+    echo "  - View classification worker logs: sudo journalctl -u classification-worker -f"
     echo "  - View Nginx logs: sudo tail -f /var/log/nginx/error.log"
     echo ""
+    if ! grep -Eq '^REDIS_URL=..*' "$BACKEND_DIR/.env"; then
+        echo -e "${YELLOW}NOTE:${NC} REDIS_URL is unset — running in eager mode (classification on the"
+        echo "      request path). For production set REDIS_URL in $BACKEND_DIR/.env and run"
+        echo "      'sudo systemctl enable --now classification-worker' to switch to queue mode."
+        echo ""
+    fi
     echo "Next Steps:"
     echo "  1. Confirm the ALB target group points at this instance on :80 and is healthy."
     echo "  2. Create Django superuser:"
@@ -648,6 +790,8 @@ main() {
     test_database_connection
     run_django_setup
     setup_gunicorn_service
+    setup_classification_worker_service
+    setup_sweep_timer
     setup_cleanup_timer
     setup_nginx
     setup_log_rotation

--- a/backend/tools/setup-django.sh
+++ b/backend/tools/setup-django.sh
@@ -383,6 +383,13 @@ run_django_setup() {
     # Run migrations
     python manage.py migrate --noinput || print_warning "Migration failed - check database connection"
 
+    # Create the rate-limit cache table. Without REDIS_URL the app falls back to
+    # Django's DatabaseCache (settings.py), which needs this table or every
+    # rate-limited request errors at runtime. It is idempotent (skips if the
+    # table exists) and a no-op when REDIS_URL is set (RedisCache defines no
+    # DatabaseCache backend), so it is safe to run unconditionally.
+    python manage.py createcachetable || print_warning "createcachetable failed - check database connection"
+
     # Collect static files
     python manage.py collectstatic --noinput
 
@@ -699,6 +706,9 @@ pip install -r requirements.txt
 
 # manage.py loads .env via python-dotenv (no shell 'source' of secrets).
 python manage.py migrate --noinput
+# Idempotent; needed for eager-mode (no REDIS_URL) DatabaseCache rate limiting,
+# a no-op under Redis. Cheap insurance in case the cache backend changes.
+python manage.py createcachetable
 python manage.py collectstatic --noinput
 deactivate
 
@@ -748,7 +758,9 @@ print_summary() {
     echo ""
     if ! grep -Eq '^REDIS_URL="?[^"]' "$BACKEND_DIR/.env"; then
         echo -e "${YELLOW}NOTE:${NC} REDIS_URL is unset — running in eager mode (classification on the"
-        echo "      request path). For production set REDIS_URL in $BACKEND_DIR/.env and run"
+        echo "      request path, and rate limiting via the DatabaseCache 'rate_limit_cache'"
+        echo "      table, which this setup already created). For production set REDIS_URL in"
+        echo "      $BACKEND_DIR/.env and run"
         echo "      'sudo systemctl enable --now classification-worker' to switch to queue mode."
         echo ""
     fi

--- a/backend/tools/setup-django.sh
+++ b/backend/tools/setup-django.sh
@@ -464,8 +464,11 @@ EOF
 
     sudo systemctl daemon-reload
 
-    # Gate enablement on REDIS_URL actually being set in .env (queue mode).
-    if grep -Eq '^REDIS_URL=..*' "$BACKEND_DIR/.env"; then
+    # Gate enablement on REDIS_URL actually being set to a NON-EMPTY value in
+    # .env (queue mode). The optional-quote + non-quote-char match rejects both
+    # a missing line and an empty `REDIS_URL=""`, either of which would make the
+    # worker crash-loop (the command hard-requires a non-empty REDIS_URL).
+    if grep -Eq '^REDIS_URL="?[^"]' "$BACKEND_DIR/.env"; then
         sudo systemctl enable --now classification-worker
         if sudo systemctl is-active --quiet classification-worker; then
             print_status "Classification worker started successfully (queue mode)"
@@ -706,13 +709,15 @@ deactivate
 # stranding classifications (issue #399). The sweep/cleanup timers run oneshot
 # services that re-exec the new code on their next fire, but reload the units in
 # case their definitions changed.
+#
+# daemon-reload FIRST, so the restarts below pick up any changed unit files.
+sudo systemctl daemon-reload
 sudo systemctl restart gunicorn
 # The worker only exists in queue mode; restart it only if it is enabled, so an
 # eager-mode host (no REDIS_URL) doesn't error on a disabled unit.
 if systemctl is-enabled --quiet classification-worker 2>/dev/null; then
     sudo systemctl restart classification-worker
 fi
-sudo systemctl daemon-reload
 sudo systemctl restart sweep-classifications.timer cleanup-orphan-images.timer
 sudo systemctl reload nginx
 
@@ -741,7 +746,7 @@ print_summary() {
     echo "  - View classification worker logs: sudo journalctl -u classification-worker -f"
     echo "  - View Nginx logs: sudo tail -f /var/log/nginx/error.log"
     echo ""
-    if ! grep -Eq '^REDIS_URL=..*' "$BACKEND_DIR/.env"; then
+    if ! grep -Eq '^REDIS_URL="?[^"]' "$BACKEND_DIR/.env"; then
         echo -e "${YELLOW}NOTE:${NC} REDIS_URL is unset — running in eager mode (classification on the"
         echo "      request path). For production set REDIS_URL in $BACKEND_DIR/.env and run"
         echo "      'sudo systemctl enable --now classification-worker' to switch to queue mode."

--- a/backend/tools/status_check.sh
+++ b/backend/tools/status_check.sh
@@ -8,6 +8,9 @@
 DOMAIN="${DOMAIN:-api.smiling.social}"
 FRONTEND_DOMAIN="${FRONTEND_DOMAIN:-smiling.social}"
 SOCKET="${SOCKET:-/var/www/smiling-social/gunicorn.sock}"
+# Django project root (manage.py + venv + .env). Matches setup-django.sh's
+# nested layout; used to read REDIS_URL and inspect the classification queue.
+BACKEND_DIR="${BACKEND_DIR:-/var/www/smiling-social/pos/backend}"
 
 echo "=== Checking Gunicorn ==="
 sudo systemctl status gunicorn --no-pager
@@ -24,6 +27,69 @@ echo -e "\n=== Checking Nginx Ports ==="
 
 echo -e "\n=== Recent Gunicorn Logs ==="
 sudo journalctl -u gunicorn -n 10 --no-pager
+
+echo -e "\n=== Checking Classification Worker (async moderation) ==="
+# The long-lived RQ worker that drains the async post/profile-photo queue. A dead
+# or never-restarted worker strands classifications in pending forever (issue
+# #399), so surface its state explicitly. It only exists in queue mode; on an
+# eager-mode host (no REDIS_URL) the unit is installed but intentionally disabled.
+if [ -f /etc/systemd/system/classification-worker.service ]; then
+  if systemctl is-enabled --quiet classification-worker 2>/dev/null; then
+    if sudo systemctl is-active --quiet classification-worker; then
+      echo "classification-worker: ACTIVE + enabled"
+    else
+      echo "classification-worker: ENABLED but NOT running — classifications are stranding!"
+    fi
+    sudo systemctl status classification-worker --no-pager --lines=5
+  else
+    echo "classification-worker: installed but DISABLED (eager mode / no REDIS_URL)."
+  fi
+else
+  echo "classification-worker.service NOT installed — re-run setup-django.sh."
+fi
+
+echo -e "\n=== Checking Async Timers (sweep + orphan cleanup) ==="
+# list-timers shows LAST/NEXT run so a timer that has silently stopped firing is
+# visible. --all includes timers whose unit is inactive between runs.
+sudo systemctl list-timers --all --no-pager \
+  'sweep-classifications.timer' 'cleanup-orphan-images.timer' \
+  || echo "Could not list timers."
+for t in sweep-classifications.timer cleanup-orphan-images.timer; do
+  if [ -f "/etc/systemd/system/$t" ]; then
+    state=$(systemctl is-enabled "$t" 2>/dev/null || echo "unknown")
+    echo "$t: $state"
+  else
+    echo "$t: NOT installed — re-run setup-django.sh."
+  fi
+done
+
+echo -e "\n=== Classification queue depth (best-effort) ==="
+# Reuse python-dotenv (a backend dependency, exactly how manage.py loads .env) to
+# read REDIS_URL and report how many jobs are waiting/failed. Skipped cleanly in
+# eager mode or if the venv/.env isn't where we expect.
+if [ -x "$BACKEND_DIR/venv/bin/python" ] && [ -f "$BACKEND_DIR/.env" ]; then
+  "$BACKEND_DIR/venv/bin/python" - "$BACKEND_DIR/.env" <<'PY' || echo "Could not read queue depth."
+import sys, os
+from dotenv import load_dotenv
+load_dotenv(sys.argv[1])
+url = os.environ.get("REDIS_URL")
+if not url:
+    print("REDIS_URL not set (eager mode) — no queue to inspect.")
+    sys.exit(0)
+try:
+    from redis import Redis
+    from rq import Queue
+    # Name matches settings.CLASSIFICATION_QUEUE_NAME.
+    q = Queue("classification", connection=Redis.from_url(url))
+    print(f"'classification' queue: {q.count} queued, "
+          f"{q.failed_job_registry.count} failed, "
+          f"{q.deferred_job_registry.count} deferred")
+except Exception as e:
+    print(f"Could not reach Redis to read queue depth: {e}")
+PY
+else
+  echo "Backend venv/.env not found under $BACKEND_DIR — skipping queue depth."
+fi
 
 echo -e "\n=== Testing API locally (gunicorn socket) ==="
 curl --unix-socket "$SOCKET" \

--- a/backend/user_system/tests/test_get_profile_details_view.py
+++ b/backend/user_system/tests/test_get_profile_details_view.py
@@ -1,7 +1,8 @@
+from django.contrib.auth import get_user_model
 from django.urls import reverse
 from .test_parent_case import PositiveOnlySocialTestCase
-from ..constants import Fields
-from ..models import PositiveOnlySocialUser  # Import model for setup
+from ..constants import BAN_TYPE_SHADOW, Fields
+from ..models import PositiveOnlySocialUser, UserBan  # Import model for setup
 
 # Constants for this test case
 invalid_session_management_token = '?'
@@ -119,6 +120,31 @@ class GetProfileDetailsTests(PositiveOnlySocialTestCase):
         self.assertEqual(data[Fields.username], self.profile_username)
         self.assertEqual(data[Fields.follower_count], 1)  # The profile user now has 1 follower
         self.assertEqual(data[Fields.is_following], True)
+
+    def test_follower_count_excludes_shadow_banned_and_cross_band(self):
+        """The follower count must agree with the filtered follower list (issue
+        #398): a shadow-banned or cross-age-band follower is hidden from the list,
+        so it must not inflate the count either. Viewing own profile here, so the
+        requester's age band is the filter — matching get_followers."""
+        normal = PositiveOnlySocialUser.objects.get(
+            username=self.make_user_with_prefix('normie')[Fields.username])
+        shadow = PositiveOnlySocialUser.objects.get(
+            username=self.make_user_with_prefix('shady')[Fields.username])
+        minor = PositiveOnlySocialUser.objects.get(
+            username=self.make_user_with_prefix('minorx')[Fields.username])
+        for follower in (normal, shadow, minor):
+            follower.following.add(self.requesting_user)
+        # Hide two of the three: one shadow-banned, one in the other age band.
+        UserBan.objects.create(user=shadow, ban_type=BAN_TYPE_SHADOW)
+        get_user_model().objects.filter(pk=minor.pk).update(
+            identity_is_verified=True, is_adult=False)
+
+        url = reverse('get_profile_details', kwargs={'username': self.local_username})
+        response = self.client.get(url, **self.valid_header)
+
+        self.assertEqual(response.status_code, 200)
+        # Only the normal, same-band follower is counted — not 3.
+        self.assertEqual(response.json()[Fields.follower_count], 1)
 
     def test_is_blocked_is_true_when_blocked(self):
         """

--- a/backend/user_system/views.py
+++ b/backend/user_system/views.py
@@ -3595,12 +3595,13 @@ def get_profile_details(request, username):
     # shadow-banned profile shows no posts to others (but all to its owner).
     post_count = visible_posts(profile_user.post_set.all(), request.user).count()
 
-    # Assuming UserFollow model or a ManyToMany 'followers' field
-    # This logic depends heavily on your model structure.
-    # The original code's `followers_set` and `following_set` imply a
-    # ManyToMany relationship, perhaps 'following' on the User model.
-    follower_count = profile_user.followers.count()
-    following_count = profile_user.following.count()
+    # The follower/following counts must agree with the filtered lists
+    # (issue #398): a shadow-banned or cross-age-band account is hidden from the
+    # follower/following list, so it must not inflate the count either. Apply the
+    # same searchable_users exclusion the list endpoints use — mirroring how
+    # post_count above counts only visible_posts.
+    follower_count = searchable_users(profile_user.followers.all(), request.user).count()
+    following_count = searchable_users(profile_user.following.all(), request.user).count()
 
     # The follow edge (if any) carries the viewer's relationship category for
     # this profile user (issue #392); null when not following.

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -11,7 +11,7 @@
         "qrcode.react": "^4.2.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "react-router-dom": "^7.6.0"
+        "react-router-dom": "^7.18.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
@@ -1650,16 +1650,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -3139,9 +3139,9 @@
       "peer": true
     },
     "node_modules/react-router": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
-      "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -3161,12 +3161,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.16.0.tgz",
-      "integrity": "sha512-kMUAbimWB5FVbF4Bce4bJsiKJWLIUHq/mEG8+CFDnCSgltptBiG5nguducmsJeGKytlCvQud9Qhzpn49iduTlA==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.16.0"
+        "react-router": "7.18.1"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/website/package.json
+++ b/website/package.json
@@ -15,7 +15,7 @@
     "qrcode.react": "^4.2.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router-dom": "^7.6.0"
+    "react-router-dom": "^7.18.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",


### PR DESCRIPTION
Second release since #407. Brings the three PRs merged to `dev` afterward.

## What ships
- **#408** (backend) — `get_profile_details` now filters `follower_count`/`following_count` through `searchable_users`, so shadow-banned / cross-age-band accounts no longer inflate the counts. Follow-up to #398 (they were dropped from the lists but still counted).
- **#409** (website deps) — resolves the `npm audit` advisories: bumps `brace-expansion` (build-tooling DoS) and `react-router`/`react-router-dom` **within 7.x** (minor bump — no v7→v8 migration). Addresses the open-redirect advisory; the RSC/SSR advisories don't apply to this client-only SPA.
- **#406 / #402** (deploy tooling + docs) — `setup-django.sh`/`status_check.sh` now provision, health-check, and restart-on-deploy the async classification services (RQ worker + sweep/cleanup timers), and create the `rate_limit_cache` table for eager-mode. Codifies the #399 lesson so a stale worker can't recur. Scripts/docs only — no app runtime change.

## Deploy notes
- **No migrations, no dual-leaf.** GitHub merge button is safe.
- **Backend redeploy** (for #408): `git pull` → `pip install` → `migrate` (no-op) → `collectstatic` → **`sudo systemctl restart gunicorn classification-worker.service`** (both).
- **Website redeploy** (for #409): `./pos/website/deploy-web.sh` — rebuilds with react-router 7.x; sanity-check routing after.
- **#406** changes the setup/deploy *scripts*, not the running host — no separate action, but follow the updated deploy docs going forward. `createcachetable` only matters in eager mode; prod runs queue mode (Redis), so it's a no-op there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)