### PR TITLE
Fix light-mode black grid boxes on the profile grid (#415)

### DIFF
--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/ProfileScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/ProfileScreen.kt
@@ -494,13 +494,16 @@ fun ProfileBody(
                         )
                     }
                 } else {
-                    // Black backing shows through the 1dp gaps as thin borders between
-                    // posts; the 1dp contentPadding extends that border around the outer edge.
+                    // The grid backing shows through the 1dp gaps and contentPadding,
+                    // and behind any empty slots in a partial last row. Use the theme
+                    // background — the Scaffold's default container color — so those
+                    // empties truly match the screen behind the grid in both light and
+                    // dark mode instead of painting black boxes next to posts (#415).
                     LazyVerticalGrid(
                         columns = GridCells.Fixed(3),
                         modifier = Modifier
                             .fillMaxSize()
-                            .background(Color.Black),
+                            .background(MaterialTheme.colorScheme.background),
                         contentPadding = PaddingValues(1.dp),
                         horizontalArrangement = Arrangement.spacedBy(1.dp),
                         verticalArrangement = Arrangement.spacedBy(1.dp)

--- a/ios/Positive Only Social/Positive Only Social/VibesViews/ProfileView.swift
+++ b/ios/Positive Only Social/Positive Only Social/VibesViews/ProfileView.swift
@@ -83,8 +83,9 @@ struct ProfileBodyView: View {
     /// "MyPostImage" so your own grid stays distinguishable from someone else's.
     var postAccessibilityIdentifier: String = "ProfilePostImage"
 
-    // Grid layout: 3 columns with a 1pt gap that shows the black grid
-    // background as a thin border between posts.
+    // Grid layout: 3 columns with a 1pt gap. The gap (and any empty slots in a
+    // partial last row) show the grid's background, which is the theme background
+    // so it blends in both light and dark mode rather than painting black (#415).
     private let columns: [GridItem] = Array(repeating: GridItem(.flexible(), spacing: 1), count: 3)
 
     var body: some View {
@@ -421,8 +422,9 @@ struct ProfileBodyView: View {
 
                         PostActionBar(post: post, postActions: postActions)
                     }
-                    // Keeps the action bar off the grid's black backing, which
-                    // is only meant to show through as the 1pt tile borders.
+                    // Each cell (tile + action bar) sits on the theme background,
+                    // matching the grid backing so the whole grid reads as one
+                    // surface with hairline gaps between tiles.
                     .background(Color(.systemBackground))
                     .onAppear {
                         // Trigger for infinite scrolling
@@ -432,8 +434,10 @@ struct ProfileBodyView: View {
                     }
                 }
             }
-            // Black backing shows through the 1pt gaps as thin borders between posts.
-            .background(Color.black)
+            // The theme background shows through the 1pt gaps and any empty slots
+            // in a partial last row, so it blends with the screen in both light and
+            // dark mode instead of painting black boxes next to posts (#415).
+            .background(Color(.systemBackground))
         }
     }
 }

--- a/website/src/pages/MainApp.css
+++ b/website/src/pages/MainApp.css
@@ -119,9 +119,11 @@
 .post-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  /* The black backing shows through the 1px gaps as thin borders between posts. */
+  /* The page background shows through the 1px gaps as thin borders between posts,
+     and behind any empty slots in a partial last row — so those empties blend with
+     the screen instead of painting black boxes next to posts (#415). */
   gap: 1px;
-  background: #000;
+  background: transparent;
 }
 
 .post-grid__cell {


### PR DESCRIPTION
## Summary

Fixes [#415](https://github.com/andrewkatson/pos/issues/415). Despite the branch name, this is **not** a dark-mode issue — it's a *light-mode* rendering bug on the profile post grid.

The profile grid used a hardcoded black backing (`Color.black` / `Color.Black` / `#000`) that was only *meant* to show through as the 1px gaps between tiles. But that backing also fills the empty column slots of a **partial last row**, so a row with fewer than 3 posts rendered black boxes next to the real tile ("filling out the row with boxes instead of nothing"). It blended into the dark UI but stood out against a light screen.

This surfaces on **mobile only**: the web app is dark-only (hardcoded), while iOS/Android follow the system light/dark theme.

## Changes

Point the grid backing at the theme/screen background instead of black:

| Platform | File | Change |
|---|---|---|
| iOS | `ProfileView.swift` | `.background(Color.black)` → `.background(Color(.systemBackground))` |
| Android | `ProfileScreen.kt` | `.background(Color.Black)` → `.background(MaterialTheme.colorScheme.background)` |
| Web | `MainApp.css` | `.post-grid` `background: #000` → `transparent` |

Empty slots in a partial last row now match the screen in both light and dark mode. The tiles themselves were already theme-adaptive (`systemBackground` / `colorScheme.surface` / `#1a1a1a`); only the grid *backing* was wrong. It now uses the theme/screen background — `Color(.systemBackground)` on iOS, `colorScheme.background` (the Scaffold container color) on Android, and `transparent` on web (inheriting the `#000` app shell).

## Notes / trade-offs

- The 1px inter-tile separators become invisible on mobile (the grid now reads as one uniform surface). This was the chosen trade-off over keeping black separators.
- **Web is a visual no-op**: `.post-grid`'s ancestor (`.app-shell`) is `#000`, so `transparent` renders identically today — the change just makes it theme-correct if a web light theme is ever added.
- The home/feed grids don't use this black backing, so they're unaffected. Fix is scoped to the profile grid.

## Testing

UI-only change across three clients; no tests assert on these grid colors. Website/iOS/Android suites verify via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)