### PR TITLE
Upgrade website to react-router v8.3.0 (Dependabot GHSA-qwww-vcr4-c8h2)

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -10,9 +10,9 @@
       "dependencies": {
         "blurhash": "^2.0.5",
         "qrcode.react": "^4.2.0",
-        "react": "^19.1.0",
-        "react-dom": "^19.1.0",
-        "react-router-dom": "^7.18.1"
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
+        "react-router": "^8.3.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
@@ -1740,18 +1740,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3116,24 +3109,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
-      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
-      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.6"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-is": {
@@ -3145,41 +3138,24 @@
       "peer": true
     },
     "node_modules/react-router": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
       "license": "MIT",
       "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
+        "cookie-es": "^3.1.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
       },
       "peerDependenciesMeta": {
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
-      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.18.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "node_modules/redent": {
@@ -3272,12 +3248,6 @@
       "bin": {
         "semver": "bin/semver.js"
       }
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/website/package.json
+++ b/website/package.json
@@ -14,9 +14,9 @@
   "dependencies": {
     "blurhash": "^2.0.5",
     "qrcode.react": "^4.2.0",
-    "react": "^19.1.0",
-    "react-dom": "^19.1.0",
-    "react-router-dom": "^7.18.1"
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "react-router": "^8.3.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/website/src/App.test.tsx
+++ b/website/src/App.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter } from 'react-router'
 import App from './App'
 
 test('renders the landing page at the root route', () => {

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -1,4 +1,4 @@
-import { Routes, Route } from 'react-router-dom'
+import { Routes, Route } from 'react-router'
 import LandingPage from './pages/LandingPage'
 import LoginPage from './pages/LoginPage'
 import RegisterPage from './pages/RegisterPage'

--- a/website/src/components/CaptionText.test.tsx
+++ b/website/src/components/CaptionText.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { MemoryRouter, Routes, Route } from 'react-router'
 import { test, expect } from 'vitest'
 import { CaptionText } from './CaptionText'
 

--- a/website/src/components/CaptionText.tsx
+++ b/website/src/components/CaptionText.tsx
@@ -1,5 +1,5 @@
 import { Fragment } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router'
 import { splitCaptionByTags, tagPathFor } from '../utils/tags'
 
 /**

--- a/website/src/components/FeedTab.test.tsx
+++ b/website/src/components/FeedTab.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { MemoryRouter, Routes, Route } from 'react-router'
 import { vi, beforeEach, afterEach, test, expect } from 'vitest'
 import FeedTab from './FeedTab'
 

--- a/website/src/components/FeedTab.tsx
+++ b/website/src/components/FeedTab.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router'
 import { apiClient } from '../api/client'
 import { getCurrentUsername } from '../api/session'
 import type { FeedPost, FollowCategory } from '../api/types'

--- a/website/src/components/PostGrid.tsx
+++ b/website/src/components/PostGrid.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router'
 import type { FeedPost } from '../api/types'
 import PostThumbnail from './PostThumbnail'
 import PostActionBar from './PostActionBar'

--- a/website/src/components/ProfileTab.test.tsx
+++ b/website/src/components/ProfileTab.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { MemoryRouter, Routes, Route } from 'react-router'
 import { vi, beforeEach, afterEach, test, expect } from 'vitest'
 import ProfileTab from './ProfileTab'
 

--- a/website/src/components/ProfileTab.tsx
+++ b/website/src/components/ProfileTab.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router'
 import { apiClient } from '../api/client'
 import { getCurrentUsername } from '../api/session'
 import type { UserSearchResult } from '../api/types'

--- a/website/src/components/ProfileView.tsx
+++ b/website/src/components/ProfileView.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState, type ChangeEvent } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router'
 import { apiClient, ApiError } from '../api/client'
 import { uploadImage } from '../api/s3Uploader'
 import { isWithinLimit, MAX_BIO_LENGTH } from '../auth/requirements'

--- a/website/src/components/SettingsTab.test.tsx
+++ b/website/src/components/SettingsTab.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { MemoryRouter, Routes, Route } from 'react-router'
 import { vi, beforeEach, afterEach, test, expect } from 'vitest'
 import SettingsTab from './SettingsTab'
 

--- a/website/src/components/SettingsTab.tsx
+++ b/website/src/components/SettingsTab.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router'
 import { apiClient } from '../api/client'
 import { clearSession } from '../api/session'
 import type { CurrentUser } from '../api/types'

--- a/website/src/main.tsx
+++ b/website/src/main.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import { BrowserRouter } from 'react-router-dom'
+import { BrowserRouter } from 'react-router'
 import App from './App'
 import { apiClient } from './api/client'
 import {

--- a/website/src/pages/AppealsPage.test.tsx
+++ b/website/src/pages/AppealsPage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { MemoryRouter, Routes, Route } from 'react-router'
 import { vi, beforeEach, test, expect } from 'vitest'
 import AppealsPage from './AppealsPage'
 import type { HiddenComment, HiddenPost, MyAppeal } from '../api/types'

--- a/website/src/pages/AppealsPage.tsx
+++ b/website/src/pages/AppealsPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { Navigate, useNavigate } from 'react-router-dom'
+import { Navigate, useNavigate } from 'react-router'
 import { apiClient } from '../api/client'
 import type { ApiError } from '../api/client'
 import type { AppealTargetType, HiddenComment, HiddenPost, MyAppeal } from '../api/types'

--- a/website/src/pages/BlockedUsersPage.test.tsx
+++ b/website/src/pages/BlockedUsersPage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { MemoryRouter, Routes, Route } from 'react-router'
 import { vi, beforeEach, test, expect } from 'vitest'
 import BlockedUsersPage from './BlockedUsersPage'
 import type { UserSearchResult } from '../api/types'

--- a/website/src/pages/BlockedUsersPage.tsx
+++ b/website/src/pages/BlockedUsersPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { Navigate, useNavigate } from 'react-router-dom'
+import { Navigate, useNavigate } from 'react-router'
 import { apiClient } from '../api/client'
 import type { ApiError } from '../api/client'
 import type { UserSearchResult } from '../api/types'

--- a/website/src/pages/CheckEmailPage.test.tsx
+++ b/website/src/pages/CheckEmailPage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { MemoryRouter, Routes, Route } from 'react-router'
 import { vi, beforeEach } from 'vitest'
 import CheckEmailPage from './CheckEmailPage'
 

--- a/website/src/pages/CheckEmailPage.tsx
+++ b/website/src/pages/CheckEmailPage.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from 'react'
-import { useLocation, useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router'
 import Logo from '../components/Logo'
 import { apiClient } from '../api/client'
 import type { ApiError } from '../api/client'

--- a/website/src/pages/FollowListPage.test.tsx
+++ b/website/src/pages/FollowListPage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { MemoryRouter, Routes, Route } from 'react-router'
 import { vi, beforeEach, test, expect } from 'vitest'
 import FollowListPage from './FollowListPage'
 import type { UserSearchResult } from '../api/types'

--- a/website/src/pages/FollowListPage.tsx
+++ b/website/src/pages/FollowListPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { Navigate, useNavigate } from 'react-router-dom'
+import { Navigate, useNavigate } from 'react-router'
 import { apiClient } from '../api/client'
 import type { ApiError } from '../api/client'
 import type { UserSearchResult } from '../api/types'

--- a/website/src/pages/HomePage.test.tsx
+++ b/website/src/pages/HomePage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { MemoryRouter, Routes, Route } from 'react-router'
 import { vi, beforeEach, afterEach, test, expect } from 'vitest'
 import HomePage from './HomePage'
 

--- a/website/src/pages/HomePage.tsx
+++ b/website/src/pages/HomePage.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { useNavigate, useSearchParams } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router'
 import ProfileTab from '../components/ProfileTab'
 import FeedTab from '../components/FeedTab'
 import NewPostTab from '../components/NewPostTab'

--- a/website/src/pages/LandingPage.test.tsx
+++ b/website/src/pages/LandingPage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { MemoryRouter, Routes, Route } from 'react-router'
 import LandingPage from './LandingPage'
 
 function renderWithRouter(initialPath = '/') {

--- a/website/src/pages/LandingPage.tsx
+++ b/website/src/pages/LandingPage.tsx
@@ -1,4 +1,4 @@
-import { Link, useNavigate } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router'
 import Logo from '../components/Logo'
 import './LandingPage.css'
 

--- a/website/src/pages/LoginPage.test.tsx
+++ b/website/src/pages/LoginPage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { MemoryRouter, Routes, Route } from 'react-router'
 import { vi, beforeEach, afterEach } from 'vitest'
 import LoginPage from './LoginPage'
 

--- a/website/src/pages/LoginPage.tsx
+++ b/website/src/pages/LoginPage.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from 'react'
-import { useNavigate, useSearchParams } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router'
 import Logo from '../components/Logo'
 import {
   ACCOUNT_BANNED,

--- a/website/src/pages/PostDetailPage.test.tsx
+++ b/website/src/pages/PostDetailPage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { MemoryRouter, Routes, Route } from 'react-router'
 import { vi, beforeEach, afterEach, test, expect } from 'vitest'
 import PostDetailPage from './PostDetailPage'
 import type { Comment, PostDetails } from '../api/types'

--- a/website/src/pages/PostDetailPage.tsx
+++ b/website/src/pages/PostDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { Navigate, useNavigate, useParams } from 'react-router-dom'
+import { Navigate, useNavigate, useParams } from 'react-router'
 import { apiClient } from '../api/client'
 import { getCurrentUsername } from '../api/session'
 import type { Comment, CommentFormatSpan, PostDetails, TextSize } from '../api/types'

--- a/website/src/pages/PrivacyPolicyPage.test.tsx
+++ b/website/src/pages/PrivacyPolicyPage.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { MemoryRouter, Routes, Route } from 'react-router'
 import PrivacyPolicyPage from './PrivacyPolicyPage'
 import { PRIVACY_POLICY_TEXT } from '../privacyPolicy'
 

--- a/website/src/pages/PrivacyPolicyPage.tsx
+++ b/website/src/pages/PrivacyPolicyPage.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom'
+import { Link } from 'react-router'
 import Logo from '../components/Logo'
 import { PRIVACY_POLICY_TEXT } from '../privacyPolicy'
 import './PrivacyPolicyPage.css'

--- a/website/src/pages/ProfilePage.test.tsx
+++ b/website/src/pages/ProfilePage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { MemoryRouter, Routes, Route } from 'react-router'
 import { vi, beforeEach, test, expect } from 'vitest'
 import ProfilePage from './ProfilePage'
 import type { ProfileDetails } from '../api/types'

--- a/website/src/pages/ProfilePage.tsx
+++ b/website/src/pages/ProfilePage.tsx
@@ -1,4 +1,4 @@
-import { Navigate, useNavigate, useParams } from 'react-router-dom'
+import { Navigate, useNavigate, useParams } from 'react-router'
 import { apiClient } from '../api/client'
 import { getCurrentUsername } from '../api/session'
 import ProfileView from '../components/ProfileView'

--- a/website/src/pages/RegisterPage.test.tsx
+++ b/website/src/pages/RegisterPage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen,fireEvent} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { MemoryRouter, Routes, Route } from 'react-router'
 import { vi, beforeEach, afterEach } from 'vitest'
 import RegisterPage from './RegisterPage'
 

--- a/website/src/pages/RegisterPage.tsx
+++ b/website/src/pages/RegisterPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useRef, useState, useEffect } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router'
 import Logo from '../components/Logo'
 import { apiClient } from '../api/client'
 import type { ApiError } from '../api/client'

--- a/website/src/pages/RequestResetPage.test.tsx
+++ b/website/src/pages/RequestResetPage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { MemoryRouter, Routes, Route } from 'react-router'
 import { vi, beforeEach } from 'vitest'
 import RequestResetPage from './RequestResetPage'
 

--- a/website/src/pages/RequestResetPage.tsx
+++ b/website/src/pages/RequestResetPage.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router'
 import Logo from '../components/Logo'
 import { apiClient } from '../api/client'
 import type { ApiError } from '../api/client'

--- a/website/src/pages/ResetPasswordPage.test.tsx
+++ b/website/src/pages/ResetPasswordPage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { MemoryRouter, Routes, Route } from 'react-router'
 import { vi, beforeEach, afterEach } from 'vitest'
 import ResetPasswordPage from './ResetPasswordPage'
 

--- a/website/src/pages/ResetPasswordPage.tsx
+++ b/website/src/pages/ResetPasswordPage.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from 'react'
-import { Navigate, useNavigate, useLocation } from 'react-router-dom'
+import { Navigate, useNavigate, useLocation } from 'react-router'
 import Logo from '../components/Logo'
 import { apiClient } from '../api/client'
 import type { ApiError } from '../api/client'

--- a/website/src/pages/SavedPostsPage.test.tsx
+++ b/website/src/pages/SavedPostsPage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { MemoryRouter, Routes, Route } from 'react-router'
 import { vi, beforeEach, afterEach, test, expect } from 'vitest'
 import SavedPostsPage from './SavedPostsPage'
 import type { FeedPost } from '../api/types'

--- a/website/src/pages/SavedPostsPage.tsx
+++ b/website/src/pages/SavedPostsPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { Navigate, useNavigate } from 'react-router-dom'
+import { Navigate, useNavigate } from 'react-router'
 import { apiClient } from '../api/client'
 import type { ApiError } from '../api/client'
 import { getCurrentUsername } from '../api/session'

--- a/website/src/pages/TagPage.test.tsx
+++ b/website/src/pages/TagPage.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { MemoryRouter, Routes, Route } from 'react-router'
 import { vi, beforeEach, afterEach, test, expect } from 'vitest'
 import TagPage from './TagPage'
 

--- a/website/src/pages/TagPage.tsx
+++ b/website/src/pages/TagPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { Navigate, useNavigate, useParams } from 'react-router-dom'
+import { Navigate, useNavigate, useParams } from 'react-router'
 import { apiClient } from '../api/client'
 import { getCurrentUsername } from '../api/session'
 import type { FeedPost } from '../api/types'

--- a/website/src/pages/VerifyEmailPage.test.tsx
+++ b/website/src/pages/VerifyEmailPage.test.tsx
@@ -1,6 +1,6 @@
 import { act, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter, Routes, Route, useNavigate } from 'react-router-dom'
+import { MemoryRouter, Routes, Route, useNavigate } from 'react-router'
 import { vi, beforeEach } from 'vitest'
 import VerifyEmailPage from './VerifyEmailPage'
 

--- a/website/src/pages/VerifyEmailPage.tsx
+++ b/website/src/pages/VerifyEmailPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, type FormEvent } from 'react'
-import { useNavigate, useSearchParams } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router'
 import Logo from '../components/Logo'
 import { apiClient } from '../api/client'
 import type { ApiError } from '../api/client'

--- a/website/src/pages/VerifyResetPage.test.tsx
+++ b/website/src/pages/VerifyResetPage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { MemoryRouter, Routes, Route } from 'react-router'
 import { vi, beforeEach } from 'vitest'
 import VerifyResetPage from './VerifyResetPage'
 

--- a/website/src/pages/VerifyResetPage.tsx
+++ b/website/src/pages/VerifyResetPage.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from 'react'
-import { Navigate, useNavigate, useLocation } from 'react-router-dom'
+import { Navigate, useNavigate, useLocation } from 'react-router'
 import Logo from '../components/Logo'
 import { apiClient } from '../api/client'
 import type { ApiError } from '../api/client'


### PR DESCRIPTION
## What & why

Clears Dependabot alert **#11** ([GHSA-qwww-vcr4-c8h2](https://github.com/andrewkatson/pos/security/dependabot/11), high) — `react-router` 7.18.1 is in the vulnerable range `>= 7.12.0, < 8.3.0`. The only patched version is **8.3.0**, a major release.

**Exploitability:** the advisory is specific to **RSC (React Server Components) mode**. This site is a client-only Vite SPA (`<BrowserRouter>` + declarative `<Routes>`/`<Route>`, deployed as static files to S3+CloudFront), with no RSC/server-action code path — so it was never actually exploitable. This upgrade clears the alert and keeps us current rather than fixing a live exploit.

## Changes

react-router v8 removes the `react-router-dom` re-export package and raises the floor to React ≥ 19.2.7:

- `package.json`: drop `react-router-dom`, add `react-router@^8.3.0`; bump `react`/`react-dom` to `^19.2.7`.
- Rewrite all **47** `from 'react-router-dom'` imports to `from 'react-router'`. Every symbol we use — `BrowserRouter`, `Link`, `useSearchParams`, `Routes`, `Route`, `MemoryRouter`, `Navigate`, `useNavigate`, `useParams`, `useLocation` — is still exported from the main `react-router` entry in library mode (`tsc` confirms; the `react-router/dom` split only matters for framework/RSC mode).
- `package-lock.json` regenerated (`react-router@8.3.0`, `react@19.2.8`).

The diff is purely the import-string swap plus the dependency/lock changes — no logic changes.

## Testing

Verified locally with Node 22 / npm — all four CI checks green:
- `npm run lint` — clean
- `npx tsc -b --noEmit` — clean
- `npm test` — **375/375 passing**
- `npm run build` — succeeds
- `npm audit` — **0 vulnerabilities**

🤖 Generated with [Claude Code](https://claude.com/claude-code)