### PR TITLE
Clear create-post file input so the same photo can be re-picked

### DIFF
--- a/website/src/components/NewPostTab.test.tsx
+++ b/website/src/components/NewPostTab.test.tsx
@@ -268,6 +268,18 @@ test('the photo picker shows a + placeholder until a photo is chosen, then the i
   expect(screen.getByAltText('Selected post preview')).toBeInTheDocument()
 })
 
+test('the file input is cleared after a pick so the same file can be re-selected', async () => {
+  render(<NewPostTab onPosted={() => {}} />)
+
+  const input = screen.getByLabelText('Choose a photo') as HTMLInputElement
+  await userEvent.upload(input, makeFile())
+
+  // The preview appeared, but the input value is reset — otherwise the browser
+  // skips onChange when the user re-picks the identical file via "Change photo".
+  expect(screen.getByAltText('Selected post preview')).toBeInTheDocument()
+  expect(input.value).toBe('')
+})
+
 test('style settings live behind an Advanced options disclosure (#419)', async () => {
   render(<NewPostTab onPosted={() => {}} />)
 

--- a/website/src/components/NewPostTab.tsx
+++ b/website/src/components/NewPostTab.tsx
@@ -194,7 +194,14 @@ function NewPostTab({ onPosted }: NewPostTabProps) {
           type="file"
           accept="image/*"
           aria-label="Choose a photo"
-          onChange={e => handleFileChange(e.target.files?.[0] ?? null)}
+          onChange={e => {
+            handleFileChange(e.target.files?.[0] ?? null)
+            // Clear the input so picking the *same* file again still fires
+            // onChange (browsers skip it when the value is unchanged), letting
+            // "Change photo" re-select the current image. Safe because the
+            // chosen File is held in state, not read back off the input.
+            e.target.value = ''
+          }}
           disabled={isLoading}
         />
       </div>


### PR DESCRIPTION
Addresses a Copilot review comment on release PR #434 (NewPostTab.tsx:177).

**Problem:** the photo picker fires a hidden `<input type=file>` via `.click()`, but the input value was never cleared. Browsers skip the `change` event when the user re-selects the *same* file, so tapping **Change photo** and re-choosing the current image did nothing.

**Fix:** reset `e.target.value` after handling the change. Safe because the chosen `File` lives in React state, not read back off the input.

Added a regression test asserting the input clears after a pick. Ran `npm run lint`, `npx tsc -b --noEmit`, `npm test` (376 pass), and `npm run build` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)