### PR TITLE
Default Gemma classifier tier to the paid OpenRouter slug (drop :free)

### DIFF
--- a/backend/user_system/classifiers/classifier_utils.py
+++ b/backend/user_system/classifiers/classifier_utils.py
@@ -14,8 +14,8 @@ from .classifier_constants import (
 
 logger = logging.getLogger(__name__)
 
-# Logical cascade tiers, consulted in this order: a free model first and Claude
-# only as a last resort (issue #393). Every call is routed through OpenRouter
+# Logical cascade tiers, consulted in this order: the cheapest model first and
+# Claude only as a last resort (issue #393). Every call is routed through OpenRouter
 # (one OPENROUTER_API_KEY), so the concrete model behind each tier can be
 # swapped via env without a code change. All four defaults are vision-capable,
 # so the same tiers serve both the text and image cascades.
@@ -186,7 +186,7 @@ def classify_with_thresholds(available_apis, call_fn):
     - If the cascade needs another AI and none is available, the content is
       rejected; it is appealable only if the last score was in the middle zone.
 
-    APIs are consulted in the given priority order (free models first, Claude
+    APIs are consulted in the given priority order (cheapest models first, Claude
     last — issue #393), so clear content is usually settled by the cheap tier
     and only ambiguous content escalates to the pricier ones. An API that
     errors or returns an unparseable score is skipped as if unavailable. With

--- a/backend/user_system/classifiers/classifier_utils.py
+++ b/backend/user_system/classifiers/classifier_utils.py
@@ -24,7 +24,7 @@ API_GEMINI = 'gemini'
 API_OPENAI = 'openai'
 API_CLAUDE = 'claude'
 
-# Priority order: cheapest/free first, most expensive last.
+# Priority order: cheapest first, most expensive last.
 #
 # NOTE: classify_with_thresholds consults at most THREE tiers (it decides by the
 # 3rd usable score), so on the normal path where the first three tiers all
@@ -38,8 +38,15 @@ CASCADE_ORDER = (API_GEMMA, API_GEMINI, API_OPENAI, API_CLAUDE)
 # Default OpenRouter model ID per tier. Override any one of them with the env
 # var OPENROUTER_MODEL_<TIER> (e.g. OPENROUTER_MODEL_GEMMA) to switch models
 # without touching code.
+#
+# The Gemma tier uses the paid `google/gemma-3-12b-it` slug, not the
+# `:free` variant: OpenRouter retired the free Gemma 3 12B (it now 404s with
+# "unavailable for free"), which made the whole first tier fail on every call
+# and fall through to the pricier Gemini tier. The paid slug is still very
+# cheap, so it keeps the cheapest-first ordering intact. Don't reintroduce a
+# `:free` slug here — those tiers get rate-limited and deprecated.
 _DEFAULT_MODELS = {
-    API_GEMMA:  'google/gemma-3-12b-it:free',
+    API_GEMMA:  'google/gemma-3-12b-it',
     API_GEMINI: 'google/gemini-2.5-flash',
     API_OPENAI: 'openai/gpt-4o-mini',
     API_CLAUDE: 'anthropic/claude-haiku-4-5',
@@ -56,7 +63,7 @@ def model_for(api_name):
 
 
 def get_available_apis():
-    """Cascade tiers to consult, in priority order (free first, Claude last).
+    """Cascade tiers to consult, in priority order (cheapest first, Claude last).
 
     Everything routes through OpenRouter, so the whole cascade is available
     when OPENROUTER_API_KEY is set, and nothing is otherwise.

--- a/backend/user_system/tests/test_classifiers.py
+++ b/backend/user_system/tests/test_classifiers.py
@@ -113,14 +113,14 @@ class TestClassifiers(PositiveOnlySocialTestCase):
 
     @patch.dict(os.environ, _OPENROUTER_KEY, clear=True)
     def test_get_available_apis_is_full_priority_order_with_key(self):
-        # Free model first, Claude last (issue #393).
+        # Cheapest model first, Claude last (issue #393).
         self.assertEqual(get_available_apis(), list(CASCADE_ORDER))
         self.assertEqual(get_available_apis()[0], API_GEMMA)
         self.assertEqual(get_available_apis()[-1], API_CLAUDE)
 
     @patch.dict(os.environ, {}, clear=True)
     def test_model_for_uses_defaults(self):
-        self.assertEqual(model_for(API_GEMMA), 'google/gemma-3-12b-it:free')
+        self.assertEqual(model_for(API_GEMMA), 'google/gemma-3-12b-it')
         self.assertEqual(model_for(API_CLAUDE), 'anthropic/claude-haiku-4-5')
 
     @patch.dict(os.environ, {"OPENROUTER_MODEL_GEMMA": "vendor/some-other-model"}, clear=True)


### PR DESCRIPTION
## Problem (seen in production logs during the release rollout)

OpenRouter retired the **free** variant of Gemma 3 12B. Every classification now logs an ERROR + traceback:

```
openai.NotFoundError: Error code: 404 - {'error': {'message':
  'This model is unavailable for free. The paid version is available now -
   use this slug instead: google/gemma-3-12b-it', 'code': 404}}
```

Gemma is the **first tier** of the cascade (`gemma → gemini → openai → claude`), so on every text/image classification the worker:
- burns a failed ~0.6–1.3s call to gemma,
- logs a noisy ERROR + traceback, then
- falls through to the pricier **Gemini** tier — meaning the cheapest tier is effectively dead and each post pays for the next tier up.

Classification still succeeds (the cascade fails through correctly), but the design intent — cheapest-first — is broken.

## Fix

- Change the Gemma default in `_DEFAULT_MODELS` from `google/gemma-3-12b-it:free` → `google/gemma-3-12b-it` (the exact slug OpenRouter's error recommends; still very cheap).
- Add a comment explaining why we don't use a `:free` slug (they get rate-limited/deprecated) so it isn't reintroduced.
- Reword the now-inaccurate "free first" comments to "cheapest first".
- Update `test_model_for_uses_defaults` to expect the new slug.

Fresh deploys now work out of the box; the `OPENROUTER_MODEL_GEMMA` env override becomes a convenience rather than a required workaround.

## Testing

`python manage.py test user_system.tests.test_classifiers` — **56 passed**.

> Operators already running an affected host can apply the same fix immediately without waiting for this to ship: set `OPENROUTER_MODEL_GEMMA="google/gemma-3-12b-it"` in `.env` and restart `classification-worker`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)