### PR TITLE
Add public account & data deletion page (#439)

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,26 @@ policy as registration and must differ from the current one. On success every
 should evict other devices), while the caller's current session is preserved so
 they stay logged in on the device they just used.
 
+## Account & data deletion
+
+Every client can **delete the account** from the Settings tab (a confirmation
+dialog, then `POST /user/delete/`), which cascades to the user's posts (and
+their S3 images), comments, likes, saved posts, follows, blocks, appeals,
+sessions, and remembered devices.
+
+Google Play additionally requires a **stable, publicly reachable web URL** where
+a user can request account and data deletion without going through the app, so
+the website serves a standalone page at `https://smiling.social/delete-account`
+(issue #439). It is reachable without an existing session — linked from the
+landing-page footer and the public privacy-policy page — and walks the visitor
+through three steps: sign in (username/email + password, plus the two-factor
+step for enrolled accounts, so no one else can delete an account that isn't
+theirs), an explicit acknowledgement of what will be removed, and the permanent
+delete. It reuses the same `POST /user/delete/` endpoint, so the deleted data is
+exactly the cascade above; on success the local session is cleared and a
+confirmation is shown. A session already restored on page load skips straight to
+the confirmation step.
+
 ## Email verification
 
 Registering does not prove you own the email address you signed up with, so

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -16,6 +16,7 @@ import BlockedUsersPage from './pages/BlockedUsersPage'
 import SavedPostsPage from './pages/SavedPostsPage'
 import FollowListPage from './pages/FollowListPage'
 import PrivacyPolicyPage from './pages/PrivacyPolicyPage'
+import DeleteAccountPage from './pages/DeleteAccountPage'
 
 function App() {
   return (
@@ -38,6 +39,7 @@ function App() {
       <Route path="/followers" element={<FollowListPage mode="followers" />} />
       <Route path="/following" element={<FollowListPage mode="following" />} />
       <Route path="/privacy-policy" element={<PrivacyPolicyPage />} />
+      <Route path="/delete-account" element={<DeleteAccountPage />} />
     </Routes>
   )
 }

--- a/website/src/pages/DeleteAccountPage.css
+++ b/website/src/pages/DeleteAccountPage.css
@@ -1,0 +1,66 @@
+/* ============================================================
+   Account & data deletion page (issue #439). Reuses the shared
+   auth-page/auth-card/auth-* styles from LoginPage.css; the rules
+   below cover only the deletion-specific bits.
+   ============================================================ */
+
+.delete-account__list {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.delete-account__ack {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  font-size: 0.9rem;
+  line-height: 1.4;
+  color: rgba(255, 255, 255, 0.8);
+  cursor: pointer;
+}
+
+.delete-account__ack input {
+  margin-top: 0.15rem;
+  width: 1.1rem;
+  height: 1.1rem;
+  flex-shrink: 0;
+  accent-color: #dc3232;
+  cursor: pointer;
+}
+
+/* Destructive primary action — red rather than the blue auth-button so the
+   permanent delete never looks like a routine confirm. */
+.delete-account__danger-button {
+  width: 100%;
+  padding: 0.8rem;
+  border-radius: 12px;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  border: none;
+  background: #dc3232;
+  color: #ffffff;
+  transition: opacity 0.15s ease;
+}
+
+.delete-account__danger-button:not(:disabled):hover {
+  opacity: 0.85;
+}
+
+.delete-account__danger-button:disabled {
+  background: #444;
+  cursor: not-allowed;
+}
+
+/* The "Return home" link reuses auth-button but is an <a>, so re-assert the
+   centered text a button gets for free. */
+.delete-account__home-link {
+  text-align: center;
+  text-decoration: none;
+}

--- a/website/src/pages/DeleteAccountPage.test.tsx
+++ b/website/src/pages/DeleteAccountPage.test.tsx
@@ -1,0 +1,180 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Routes, Route } from 'react-router'
+import { vi, beforeEach, test, expect } from 'vitest'
+import DeleteAccountPage from './DeleteAccountPage'
+
+vi.mock('../api/client', async importOriginal => {
+  const actual = await importOriginal<typeof import('../api/client')>()
+  return {
+    ...actual,
+    apiClient: {
+      login: vi.fn(),
+      loginWithTwoFactor: vi.fn(),
+      deleteAccount: vi.fn(),
+      setToken: vi.fn(),
+    },
+  }
+})
+
+vi.mock('../api/session', () => ({
+  getStoredSessionToken: vi.fn(),
+  clearSession: vi.fn(),
+}))
+
+import { apiClient } from '../api/client'
+import { clearSession, getStoredSessionToken } from '../api/session'
+
+const mockLogin = vi.mocked(apiClient.login)
+const mockLoginWithTwoFactor = vi.mocked(apiClient.loginWithTwoFactor)
+const mockDeleteAccount = vi.mocked(apiClient.deleteAccount)
+const mockClearSession = vi.mocked(clearSession)
+const mockGetStoredSessionToken = vi.mocked(getStoredSessionToken)
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/delete-account']}>
+      <Routes>
+        <Route path="/delete-account" element={<DeleteAccountPage />} />
+        <Route path="/" element={<div>Landing page</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  mockLogin.mockReset()
+  mockLoginWithTwoFactor.mockReset()
+  mockDeleteAccount.mockReset().mockResolvedValue({ message: 'ok' })
+  mockClearSession.mockReset()
+  mockGetStoredSessionToken.mockReset().mockReturnValue(null)
+})
+
+/** Signs in with a password-only account and lands on the confirmation step. */
+async function signIn() {
+  mockLogin.mockResolvedValueOnce({
+    session_management_token: 't',
+    user_id: 'u',
+  })
+  await userEvent.type(screen.getByLabelText('Username or Email'), 'ada')
+  await userEvent.type(screen.getByLabelText('Password'), 'pass')
+  await userEvent.click(screen.getByRole('button', { name: 'Continue' }))
+}
+
+test('a visitor without a session must sign in first', () => {
+  renderPage()
+  expect(screen.getByLabelText('Username or Email')).toBeInTheDocument()
+  expect(screen.getByLabelText('Password')).toBeInTheDocument()
+  // The delete action is not reachable until identity is verified.
+  expect(
+    screen.queryByRole('button', { name: 'Delete my account and data' }),
+  ).not.toBeInTheDocument()
+})
+
+test('signing in reveals the confirmation step, and deletion needs acknowledgement', async () => {
+  renderPage()
+  await signIn()
+
+  expect(mockLogin).toHaveBeenCalledWith({
+    username_or_email: 'ada',
+    password: 'pass',
+    remember_me: false,
+  })
+
+  const deleteButton = await screen.findByRole('button', {
+    name: 'Delete my account and data',
+  })
+  // The button is gated on the acknowledgement checkbox.
+  expect(deleteButton).toBeDisabled()
+
+  await userEvent.click(
+    screen.getByRole('checkbox', {
+      name: /permanently deletes my account and data/i,
+    }),
+  )
+  expect(deleteButton).toBeEnabled()
+
+  await userEvent.click(deleteButton)
+  expect(mockDeleteAccount).toHaveBeenCalled()
+  expect(mockClearSession).toHaveBeenCalled()
+  expect(
+    await screen.findByText(/permanently deleted/i),
+  ).toBeInTheDocument()
+})
+
+test('a restored session skips sign-in and goes straight to confirmation', async () => {
+  mockGetStoredSessionToken.mockReturnValue('existing-token')
+  renderPage()
+
+  expect(screen.queryByLabelText('Password')).not.toBeInTheDocument()
+  expect(
+    await screen.findByRole('button', { name: 'Delete my account and data' }),
+  ).toBeInTheDocument()
+})
+
+test('a two-factor account completes the challenge before confirming', async () => {
+  renderPage()
+  mockLogin.mockResolvedValueOnce({
+    two_factor_required: true,
+    challenge_token: 'c'.repeat(64),
+  })
+  await userEvent.type(screen.getByLabelText('Username or Email'), 'ada')
+  await userEvent.type(screen.getByLabelText('Password'), 'pass')
+  await userEvent.click(screen.getByRole('button', { name: 'Continue' }))
+
+  mockLoginWithTwoFactor.mockResolvedValueOnce({
+    session_management_token: 't',
+    user_id: 'u',
+  })
+  await userEvent.type(screen.getByLabelText('Authenticator Code'), '123456')
+  await userEvent.click(screen.getByRole('button', { name: 'Verify' }))
+
+  expect(mockLoginWithTwoFactor).toHaveBeenCalledWith({
+    challenge_token: 'c'.repeat(64),
+    totp_code: '123456',
+  })
+  expect(
+    await screen.findByRole('button', { name: 'Delete my account and data' }),
+  ).toBeInTheDocument()
+})
+
+test('a failed sign-in surfaces the error and stays on the form', async () => {
+  renderPage()
+  mockLogin.mockRejectedValueOnce({ message: 'Login failed. Please check your credentials.' })
+  await userEvent.type(screen.getByLabelText('Username or Email'), 'ada')
+  await userEvent.type(screen.getByLabelText('Password'), 'wrong')
+  await userEvent.click(screen.getByRole('button', { name: 'Continue' }))
+
+  expect(await screen.findByRole('alert')).toHaveTextContent(
+    'Login failed. Please check your credentials.',
+  )
+  expect(screen.getByLabelText('Password')).toBeInTheDocument()
+})
+
+test('a failed deletion surfaces the error and keeps the session', async () => {
+  renderPage()
+  await signIn()
+  await userEvent.click(
+    screen.getByRole('checkbox', {
+      name: /permanently deletes my account and data/i,
+    }),
+  )
+  mockDeleteAccount.mockRejectedValueOnce({ message: 'Something went wrong. Please try again.' })
+  await userEvent.click(screen.getByRole('button', { name: 'Delete my account and data' }))
+
+  expect(await screen.findByRole('alert')).toHaveTextContent(
+    'Something went wrong. Please try again.',
+  )
+  // The local session is not cleared when the delete fails, so the user can retry.
+  expect(mockClearSession).not.toHaveBeenCalled()
+  expect(
+    screen.getByRole('button', { name: 'Delete my account and data' }),
+  ).toBeInTheDocument()
+})
+
+test('Cancel returns to the landing page', async () => {
+  mockGetStoredSessionToken.mockReturnValue('existing-token')
+  renderPage()
+  await userEvent.click(await screen.findByRole('button', { name: 'Cancel' }))
+  expect(screen.getByText('Landing page')).toBeInTheDocument()
+})

--- a/website/src/pages/DeleteAccountPage.test.tsx
+++ b/website/src/pages/DeleteAccountPage.test.tsx
@@ -172,6 +172,28 @@ test('a failed deletion surfaces the error and keeps the session', async () => {
   ).toBeInTheDocument()
 })
 
+test('an expired session (401) sends the user back to sign in', async () => {
+  // Started on the confirmation step from a restored token that turns out to be
+  // revoked; the delete 401s, so we must drop the session and re-auth.
+  mockGetStoredSessionToken.mockReturnValue('stale-token')
+  renderPage()
+  await userEvent.click(
+    await screen.findByRole('checkbox', {
+      name: /permanently deletes my account and data/i,
+    }),
+  )
+  mockDeleteAccount.mockRejectedValueOnce({ status: 401, message: 'Not authenticated' })
+  await userEvent.click(screen.getByRole('button', { name: 'Delete my account and data' }))
+
+  expect(mockClearSession).toHaveBeenCalled()
+  expect(await screen.findByRole('alert')).toHaveTextContent(/session has expired/i)
+  // Back on the sign-in form, not stuck on a confirmation step with no way in.
+  expect(screen.getByLabelText('Username or Email')).toBeInTheDocument()
+  expect(
+    screen.queryByRole('button', { name: 'Delete my account and data' }),
+  ).not.toBeInTheDocument()
+})
+
 test('Cancel returns to the landing page', async () => {
   mockGetStoredSessionToken.mockReturnValue('existing-token')
   renderPage()

--- a/website/src/pages/DeleteAccountPage.tsx
+++ b/website/src/pages/DeleteAccountPage.tsx
@@ -1,0 +1,354 @@
+import { useState, type FormEvent } from 'react'
+import { Link, useNavigate } from 'react-router'
+import Logo from '../components/Logo'
+import {
+  ACCOUNT_BANNED,
+  ACCOUNT_SUSPENDED_MESSAGE,
+  EMAIL_NOT_VERIFIED,
+  EMAIL_NOT_VERIFIED_MESSAGE,
+  INVALID_TWO_FACTOR_CHALLENGE,
+  apiClient,
+} from '../api/client'
+import type { ApiError } from '../api/client'
+import { isTwoFactorRequired } from '../api/types'
+import { clearSession, getStoredSessionToken } from '../api/session'
+import './LoginPage.css'
+import './DeleteAccountPage.css'
+
+/**
+ * Public, unauthenticated-reachable account & data deletion page, served at
+ * /delete-account (issue #439). Google Play requires a stable web URL where a
+ * user can request that their account and associated data be deleted, so this
+ * page stands alone rather than living behind the in-app Settings tab.
+ *
+ * Flow:
+ *   1. `auth`    — if no session is present, the user signs in here (username /
+ *                  email + password, plus a two-factor step for enrolled
+ *                  accounts). A session restored on page load (main.tsx) skips
+ *                  straight to the confirmation step.
+ *   2. `confirm` — the account and everything tied to it is listed, and an
+ *                  explicit acknowledgement gates the permanent delete.
+ *   3. `done`    — the account is gone and the local session is cleared.
+ *
+ * The actual deletion reuses `POST /user/delete/` (apiClient.deleteAccount),
+ * the same endpoint the Settings tab and native clients use, which cascades to
+ * the user's posts, comments, likes, saved posts, follows, blocks, and images.
+ */
+type Step = 'auth' | 'confirm' | 'done'
+
+function DeleteAccountPage() {
+  const navigate = useNavigate()
+
+  // Start on the confirmation step when a session was restored on load
+  // (main.tsx puts the persisted token back on the client); otherwise sign in.
+  const [step, setStep] = useState<Step>(() =>
+    getStoredSessionToken() ? 'confirm' : 'auth',
+  )
+
+  const [usernameOrEmail, setUsernameOrEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+
+  // Two-factor step, mirroring LoginPage: login can answer with a challenge
+  // instead of a session, which is exchanged (with a code) for the real session.
+  const [challengeToken, setChallengeToken] = useState<string | null>(null)
+  const [twoFactorCode, setTwoFactorCode] = useState('')
+  const [useRecoveryCode, setUseRecoveryCode] = useState(false)
+
+  // Final acknowledgement guard so the permanent action can't be a stray click.
+  const [acknowledged, setAcknowledged] = useState(false)
+
+  const isFormValid = usernameOrEmail.trim().length > 0 && password.length > 0
+  const isCodeValid = useRecoveryCode
+    ? /^[0-9a-fA-F]{10}$/.test(twoFactorCode.trim())
+    : /^\d{6}$/.test(twoFactorCode.trim())
+
+  async function handleLogin(e: FormEvent) {
+    e.preventDefault()
+    if (!isFormValid || isLoading) return
+    setIsLoading(true)
+    try {
+      // No remember-me: deletion is a one-off action, so we never persist a
+      // long-lived credential here — the in-memory session token is enough.
+      const response = await apiClient.login({
+        username_or_email: usernameOrEmail.trim(),
+        password,
+        remember_me: false,
+      })
+      if (isTwoFactorRequired(response)) {
+        setChallengeToken(response.challenge_token)
+        setErrorMessage(null)
+        return
+      }
+      setErrorMessage(null)
+      setStep('confirm')
+    } catch (err) {
+      const apiErr = err as ApiError
+      if (apiErr.message === ACCOUNT_BANNED) {
+        setErrorMessage(ACCOUNT_SUSPENDED_MESSAGE)
+      } else if (apiErr.message === EMAIL_NOT_VERIFIED) {
+        setErrorMessage(EMAIL_NOT_VERIFIED_MESSAGE)
+      } else {
+        setErrorMessage(apiErr.message ?? 'Login failed. Please check your credentials.')
+      }
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  async function handleTwoFactorSubmit(e: FormEvent) {
+    e.preventDefault()
+    if (!challengeToken || !isCodeValid || isLoading) return
+    setErrorMessage(null)
+    setIsLoading(true)
+    try {
+      const code = twoFactorCode.trim()
+      await apiClient.loginWithTwoFactor(
+        useRecoveryCode
+          ? { challenge_token: challengeToken, recovery_code: code.toLowerCase() }
+          : { challenge_token: challengeToken, totp_code: code },
+      )
+      setStep('confirm')
+    } catch (err) {
+      const apiErr = err as ApiError
+      if (apiErr.message === INVALID_TWO_FACTOR_CHALLENGE) {
+        backToLogin()
+        setErrorMessage('Your login expired. Please sign in again.')
+      } else {
+        setErrorMessage(apiErr.message ?? 'Verification failed. Please try again.')
+      }
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  function backToLogin() {
+    setChallengeToken(null)
+    setTwoFactorCode('')
+    setUseRecoveryCode(false)
+    setErrorMessage(null)
+  }
+
+  async function handleDelete() {
+    if (!acknowledged || isLoading) return
+    setErrorMessage(null)
+    setIsLoading(true)
+    try {
+      await apiClient.deleteAccount()
+      clearSession()
+      setStep('done')
+    } catch (err) {
+      const apiErr = err as ApiError
+      setErrorMessage(apiErr.message ?? 'Failed to delete your account. Please try again.')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <div className="auth-page">
+      <div className="auth-card">
+        {step !== 'done' && (
+          <button
+            type="button"
+            className="auth-back"
+            disabled={isLoading}
+            onClick={() => (challengeToken ? backToLogin() : navigate('/'))}
+            aria-label={challengeToken ? 'Back to sign in' : 'Back to home'}
+          >
+            ← Back
+          </button>
+        )}
+
+        <div className="auth-logo">
+          <Logo size={80} />
+        </div>
+
+        <h1 className="auth-title">Delete Account &amp; Data</h1>
+
+        {errorMessage && (
+          <div className="auth-error" role="alert">
+            <p>{errorMessage}</p>
+            <button
+              type="button"
+              className="auth-error__dismiss"
+              aria-label="Dismiss error"
+              onClick={() => setErrorMessage(null)}
+            >
+              ✕
+            </button>
+          </div>
+        )}
+
+        {step === 'auth' &&
+          (challengeToken ? (
+            <form className="auth-form" onSubmit={handleTwoFactorSubmit} noValidate>
+              <p className="auth-instructions">
+                {useRecoveryCode
+                  ? 'Enter one of your recovery codes. Each code works only once.'
+                  : 'Enter the 6-digit code from your authenticator app.'}
+              </p>
+
+              <div className="auth-field">
+                <label className="auth-label" htmlFor="twoFactorCode">
+                  {useRecoveryCode ? 'Recovery Code' : 'Authenticator Code'}
+                </label>
+                <input
+                  id="twoFactorCode"
+                  className="auth-input"
+                  type="text"
+                  inputMode={useRecoveryCode ? 'text' : 'numeric'}
+                  autoComplete="one-time-code"
+                  autoCapitalize="none"
+                  maxLength={useRecoveryCode ? 10 : 6}
+                  value={twoFactorCode}
+                  onChange={e => setTwoFactorCode(e.target.value)}
+                  disabled={isLoading}
+                />
+              </div>
+
+              {isLoading ? (
+                <div className="auth-spinner" aria-label="Verifying…">
+                  <span className="spinner" />
+                </div>
+              ) : (
+                <button type="submit" className="auth-button" disabled={!isCodeValid}>
+                  Verify
+                </button>
+              )}
+
+              <button
+                type="button"
+                className="auth-link auth-link--right"
+                disabled={isLoading}
+                onClick={() => {
+                  setUseRecoveryCode(v => !v)
+                  setTwoFactorCode('')
+                }}
+              >
+                {useRecoveryCode
+                  ? 'Use an authenticator code instead'
+                  : 'Use a recovery code instead'}
+              </button>
+            </form>
+          ) : (
+            <>
+              <p className="auth-instructions">
+                Sign in to the account you want to delete. We verify your identity
+                first so no one else can delete your account.
+              </p>
+              <form className="auth-form" onSubmit={handleLogin} noValidate>
+                <div className="auth-field">
+                  <label className="auth-label" htmlFor="usernameOrEmail">
+                    Username or Email
+                  </label>
+                  <input
+                    id="usernameOrEmail"
+                    className="auth-input"
+                    type="text"
+                    inputMode="email"
+                    autoComplete="username"
+                    autoCapitalize="none"
+                    value={usernameOrEmail}
+                    onChange={e => setUsernameOrEmail(e.target.value)}
+                    disabled={isLoading}
+                  />
+                </div>
+
+                <div className="auth-field">
+                  <label className="auth-label" htmlFor="password">
+                    Password
+                  </label>
+                  <input
+                    id="password"
+                    className="auth-input"
+                    type="password"
+                    autoComplete="current-password"
+                    value={password}
+                    onChange={e => setPassword(e.target.value)}
+                    disabled={isLoading}
+                  />
+                </div>
+
+                {isLoading ? (
+                  <div className="auth-spinner" aria-label="Signing in…">
+                    <span className="spinner" />
+                  </div>
+                ) : (
+                  <button type="submit" className="auth-button" disabled={!isFormValid}>
+                    Continue
+                  </button>
+                )}
+              </form>
+            </>
+          ))}
+
+        {step === 'confirm' && (
+          <>
+            <p className="auth-instructions">
+              Deleting your account is <strong>permanent and cannot be undone</strong>.
+              Everything below is removed right away:
+            </p>
+            <ul className="delete-account__list">
+              <li>Your profile, username, email, and bio</li>
+              <li>All of your posts and their images</li>
+              <li>Your comments and replies</li>
+              <li>Your likes and saved posts</li>
+              <li>Who you follow and who follows you, and your blocks</li>
+              <li>Your login sessions and remembered devices</li>
+            </ul>
+
+            <label className="delete-account__ack">
+              <input
+                type="checkbox"
+                checked={acknowledged}
+                onChange={e => setAcknowledged(e.target.checked)}
+                disabled={isLoading}
+              />
+              <span>I understand this permanently deletes my account and data.</span>
+            </label>
+
+            {isLoading ? (
+              <div className="auth-spinner" aria-label="Deleting your account…">
+                <span className="spinner" />
+              </div>
+            ) : (
+              <button
+                type="button"
+                className="delete-account__danger-button"
+                disabled={!acknowledged}
+                onClick={handleDelete}
+              >
+                Delete my account and data
+              </button>
+            )}
+
+            <button
+              type="button"
+              className="auth-link"
+              disabled={isLoading}
+              onClick={() => navigate('/')}
+            >
+              Cancel
+            </button>
+          </>
+        )}
+
+        {step === 'done' && (
+          <>
+            <p className="auth-instructions">
+              Your account and all associated data have been permanently deleted.
+              We're sorry to see you go.
+            </p>
+            <Link to="/" className="auth-button delete-account__home-link">
+              Return home
+            </Link>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default DeleteAccountPage

--- a/website/src/pages/DeleteAccountPage.tsx
+++ b/website/src/pages/DeleteAccountPage.tsx
@@ -32,7 +32,8 @@ import './DeleteAccountPage.css'
  *
  * The actual deletion reuses `POST /user/delete/` (apiClient.deleteAccount),
  * the same endpoint the Settings tab and native clients use, which cascades to
- * the user's posts, comments, likes, saved posts, follows, blocks, and images.
+ * the user's posts, comments, likes, saved posts, appeals, follows, blocks, and
+ * images.
  */
 type Step = 'auth' | 'confirm' | 'done'
 
@@ -109,6 +110,10 @@ function DeleteAccountPage() {
           ? { challenge_token: challengeToken, recovery_code: code.toLowerCase() }
           : { challenge_token: challengeToken, totp_code: code },
       )
+      // Drop the challenge state now that it's exchanged for a session, so the
+      // confirmation step's Back button doesn't behave as if we're still in the
+      // 2FA step.
+      backToLogin()
       setStep('confirm')
     } catch (err) {
       const apiErr = err as ApiError
@@ -295,6 +300,7 @@ function DeleteAccountPage() {
               <li>All of your posts and their images</li>
               <li>Your comments and replies</li>
               <li>Your likes and saved posts</li>
+              <li>Your appeals</li>
               <li>Who you follow and who follows you, and your blocks</li>
               <li>Your login sessions and remembered devices</li>
             </ul>

--- a/website/src/pages/DeleteAccountPage.tsx
+++ b/website/src/pages/DeleteAccountPage.tsx
@@ -145,7 +145,17 @@ function DeleteAccountPage() {
       setStep('done')
     } catch (err) {
       const apiErr = err as ApiError
-      setErrorMessage(apiErr.message ?? 'Failed to delete your account. Please try again.')
+      // A 401 means the session we started on (restored on page load) is
+      // revoked or expired, so there's nothing to retry from the confirmation
+      // step — drop the stale session and send the user back to sign in.
+      if (apiErr.status === 401) {
+        clearSession()
+        setAcknowledged(false)
+        setStep('auth')
+        setErrorMessage('Your session has expired. Please sign in again to delete your account.')
+      } else {
+        setErrorMessage(apiErr.message ?? 'Failed to delete your account. Please try again.')
+      }
     } finally {
       setIsLoading(false)
     }

--- a/website/src/pages/LandingPage.css
+++ b/website/src/pages/LandingPage.css
@@ -76,6 +76,7 @@
 .landing__footer {
   display: flex;
   justify-content: center;
+  gap: 1.5rem;
   padding: 1.5rem;
 }
 

--- a/website/src/pages/LandingPage.test.tsx
+++ b/website/src/pages/LandingPage.test.tsx
@@ -11,6 +11,7 @@ function renderWithRouter(initialPath = '/') {
         <Route path="/login" element={<div>Login page</div>} />
         <Route path="/register" element={<div>Register page</div>} />
         <Route path="/privacy-policy" element={<div>Privacy policy page</div>} />
+        <Route path="/delete-account" element={<div>Delete account page</div>} />
       </Routes>
     </MemoryRouter>,
   )
@@ -41,4 +42,10 @@ test('Privacy Policy link navigates to /privacy-policy', async () => {
   renderWithRouter()
   await userEvent.click(screen.getByRole('link', { name: 'Privacy Policy' }))
   expect(screen.getByText('Privacy policy page')).toBeInTheDocument()
+})
+
+test('Delete Account link navigates to /delete-account', async () => {
+  renderWithRouter()
+  await userEvent.click(screen.getByRole('link', { name: 'Delete Account' }))
+  expect(screen.getByText('Delete account page')).toBeInTheDocument()
 })

--- a/website/src/pages/LandingPage.tsx
+++ b/website/src/pages/LandingPage.tsx
@@ -36,6 +36,9 @@ function LandingPage() {
         <Link to="/privacy-policy" className="landing__footer-link">
           Privacy Policy
         </Link>
+        <Link to="/delete-account" className="landing__footer-link">
+          Delete Account
+        </Link>
       </footer>
     </div>
   )

--- a/website/src/pages/PrivacyPolicyPage.css
+++ b/website/src/pages/PrivacyPolicyPage.css
@@ -36,3 +36,12 @@
   line-height: 1.6;
   color: rgba(255, 255, 255, 0.85);
 }
+
+.privacy-page__deletion {
+  margin-top: 1.5rem;
+}
+
+.privacy-page__deletion-link {
+  color: #5ba4dc;
+  text-decoration: underline;
+}

--- a/website/src/pages/PrivacyPolicyPage.test.tsx
+++ b/website/src/pages/PrivacyPolicyPage.test.tsx
@@ -9,6 +9,7 @@ function renderWithRouter(initialPath = '/privacy-policy') {
       <Routes>
         <Route path="/" element={<div>Landing page</div>} />
         <Route path="/privacy-policy" element={<PrivacyPolicyPage />} />
+        <Route path="/delete-account" element={<div>Delete account page</div>} />
       </Routes>
     </MemoryRouter>,
   )
@@ -26,4 +27,11 @@ test('logo links back to the landing page', () => {
 
   const homeLink = screen.getByRole('link', { name: 'Good Vibes Only smiley logo' })
   expect(homeLink).toHaveAttribute('href', '/')
+})
+
+test('links to the account & data deletion page', () => {
+  renderWithRouter()
+
+  const deletionLink = screen.getByRole('link', { name: 'account & data deletion page' })
+  expect(deletionLink).toHaveAttribute('href', '/delete-account')
 })

--- a/website/src/pages/PrivacyPolicyPage.tsx
+++ b/website/src/pages/PrivacyPolicyPage.tsx
@@ -20,6 +20,13 @@ function PrivacyPolicyPage() {
       <main className="privacy-page__main">
         <h1 className="privacy-page__title">Privacy Policy</h1>
         <p className="privacy-page__body">{PRIVACY_POLICY_TEXT}</p>
+        <p className="privacy-page__body privacy-page__deletion">
+          To permanently delete your account and all associated data, visit the{' '}
+          <Link to="/delete-account" className="privacy-page__deletion-link">
+            account &amp; data deletion page
+          </Link>
+          .
+        </p>
       </main>
     </div>
   )

--- a/website/src/pages/PrivacyPolicyPage.tsx
+++ b/website/src/pages/PrivacyPolicyPage.tsx
@@ -24,8 +24,7 @@ function PrivacyPolicyPage() {
           To permanently delete your account and all associated data, visit the{' '}
           <Link to="/delete-account" className="privacy-page__deletion-link">
             account &amp; data deletion page
-          </Link>
-          .
+          </Link>.
         </p>
       </main>
     </div>


### PR DESCRIPTION
## What

Adds a standalone, publicly reachable website page at **`/delete-account`** so users can request account and data deletion without going through the app — a Google Play requirement. Closes #439.

The backend endpoint (`POST /user/delete/`) and the `apiClient.deleteAccount()` wrapper already existed (they power the in-app Settings "Delete Account" flow); this builds the web page on top of them.

## The page ([DeleteAccountPage.tsx](https://github.com/andrewkatson/pos/blob/claude/account-data-deletion-page-ffadeb/website/src/pages/DeleteAccountPage.tsx))

Reachable without an existing session, it walks the visitor through three steps:

1. **Sign in** — username/email + password, plus the full two-factor challenge step for enrolled accounts, so no one else can delete an account that isn't theirs. No remember-me is persisted (deletion is a one-off).
2. **Confirm** — lists exactly what's removed (profile, posts + images, comments, likes, saved posts, follows/blocks, sessions/devices), gated behind an explicit "I understand this is permanent" checkbox.
3. **Done** — session cleared, confirmation shown.

A session already restored on page load skips straight to the confirmation step. Deletion reuses `POST /user/delete/`, so the removed data is exactly the existing cascade.

## Discoverability & docs

- Route registered in `App.tsx`.
- Linked from the **landing-page footer** (next to Privacy Policy) and the **public privacy-policy page** — the URLs app-store reviewers typically land on.
- New "Account & data deletion" section in the README (the product spec).

## Tests

- New `DeleteAccountPage.test.tsx`: sign-in-required, happy path, 2FA path, restored-session shortcut, login/delete error handling, and Cancel.
- Updated landing + privacy-policy tests for the new links.
- CI checks run locally and pass: `npm run lint`, `npx tsc -b --noEmit`, `npm test` (385 passing), `npm run build`.

## Reviewer notes

- Website-only change. If you want the Android/iOS in-app Settings deletion reviewed for parity, happy to follow up.
- The backend `delete_user` view still has no dedicated test — it's a destructive, store-required path, so a focused test would be worth adding in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)