### PR TITLE
ios: run the three UI tests CI was silently skipping, and stop it recurring

### DIFF
--- a/.github/scripts/check_ui_test_coverage.py
+++ b/.github/scripts/check_ui_test_coverage.py
@@ -17,12 +17,41 @@ test that no longer exists.
 
 import re
 import sys
+from collections import Counter
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[2]
 WORKFLOW = REPO / ".github" / "workflows" / "ios-tests.yml"
 UI_TEST_DIR = REPO / "ios" / "Positive Only Social" / "Positive Only SocialUITests"
 UI_TARGET = "Positive Only SocialUITests"
+
+
+def strip_comments(src):
+    """Blank out comments, preserving offsets so positions stay comparable.
+
+    Without this, prose containing the word "class" is parsed as a declaration
+    - this file's own sources contain the phrase "between class name and method
+    name", which was enough to attribute every test to a class called "name".
+    """
+    out = []
+    i, n = 0, len(src)
+    while i < n:
+        two = src[i : i + 2]
+        if two == "//":
+            j = src.find("\n", i)
+            j = n if j == -1 else j
+            out.append(" " * (j - i))
+            i = j
+        elif two == "/*":
+            j = src.find("*/", i + 2)
+            j = n if j == -1 else j + 2
+            # Keep newlines so line-based reasoning elsewhere still works.
+            out.append("".join(c if c == "\n" else " " for c in src[i:j]))
+            i = j
+        else:
+            out.append(src[i])
+            i += 1
+    return "".join(out)
 
 
 def declared_tests():
@@ -32,16 +61,27 @@ def declared_tests():
     # check that silently ignores them would recreate the very hole it exists
     # to close.
     for path in sorted(UI_TEST_DIR.rglob("*.swift")):
-        src = path.read_text(encoding="utf-8")
-        # Track where each XCTestCase subclass starts so methods are attributed
-        # to the right class even when a file declares more than one.
+        src = strip_comments(path.read_text(encoding="utf-8"))
+        # Track where every class starts, so methods are attributed to the right
+        # one when a file declares more than one. Deliberately not keyed on
+        # ": XCTestCase" - a class extending a shared base (class FooTests:
+        # BaseUITestCase) is still a test class, and keying on the direct
+        # superclass would make every test inside it invisible to this check the
+        # day someone extracts such a base.
+        #
+        # Anchored on the opening brace of the declaration so that `class` used
+        # as a member modifier (`override class var foo: Bool {`) is not mistaken
+        # for a type declaration named "var".
         classes = [
             (m.start(), m.group(1))
-            for m in re.finditer(r"class\s+(\w+)\s*:\s*XCTestCase", src)
+            for m in re.finditer(r"\bclass\s+(\w+)\s*(?::[^{]*?)?\{", src)
         ]
         if not classes:
             continue
-        for m in re.finditer(r"\bfunc\s+(test\w*)\s*\(", src):
+        # Require an empty parameter list: XCTest only collects no-argument
+        # test methods, so this keeps a helper like `testHelper(for:)` from
+        # being reported as a test that is never scheduled.
+        for m in re.finditer(r"\bfunc\s+(test\w*)\s*\(\s*\)", src):
             enclosing = [name for start, name in classes if start < m.start()]
             if enclosing:
                 found.add(f"{UI_TARGET}/{enclosing[-1]}/{m.group(1)}")
@@ -68,11 +108,10 @@ def main():
         print(f"error: no UI tests found under {UI_TEST_DIR} - has the layout moved?")
         return 1
 
+    counts = Counter(scheduled)
     unscheduled = sorted(declared - scheduled_set)
     stale = sorted(scheduled_set - declared)
-    duplicated = sorted(
-        {name for name in scheduled if scheduled.count(name) > 1}
-    )
+    duplicated = sorted(name for name, n in counts.items() if n > 1)
 
     for name in unscheduled:
         print(f"error: {name} is never run - add it to a test-group in ios-tests.yml")
@@ -80,7 +119,7 @@ def main():
         print(f"error: {name} is scheduled but no longer exists - remove it from ios-tests.yml")
     for name in duplicated:
         print(
-            f"error: {name} is scheduled {scheduled.count(name)} times - "
+            f"error: {name} is scheduled {counts[name]} times - "
             "it would run once per group; leave it in only one"
         )
 

--- a/.github/scripts/check_ui_test_coverage.py
+++ b/.github/scripts/check_ui_test_coverage.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Fail if any iOS UI test is not scheduled by the CI matrix.
+
+The iOS workflow schedules UI tests by naming each one individually in
+`-only-testing:` entries, split across matrix groups. That gives us control
+over how long each group runs, but it is silent when it drifts: a test added
+to the Swift file simply never runs, and nothing reports it. Three tests were
+found that way (testChangePassword, testEnableTwoFactorAuthentication and the
+whole Positive_Only_SocialUITestsLaunchTests class), the oldest of which had
+been dormant for months.
+
+This closes that hole from the other side: it compares what the Swift files
+declare against what the workflow schedules, and fails the build on any
+mismatch in either direction — a test that is never run, or an entry naming a
+test that no longer exists.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO / ".github" / "workflows" / "ios-tests.yml"
+UI_TEST_DIR = REPO / "ios" / "Positive Only Social" / "Positive Only SocialUITests"
+UI_TARGET = "Positive Only SocialUITests"
+
+
+def declared_tests():
+    """Every `Target/Class/method` the UI test sources define."""
+    found = set()
+    for path in sorted(UI_TEST_DIR.glob("*.swift")):
+        src = path.read_text(encoding="utf-8")
+        # Track where each XCTestCase subclass starts so methods are attributed
+        # to the right class even when a file declares more than one.
+        classes = [
+            (m.start(), m.group(1))
+            for m in re.finditer(r"class\s+(\w+)\s*:\s*XCTestCase", src)
+        ]
+        if not classes:
+            continue
+        for m in re.finditer(r"\bfunc\s+(test\w*)\s*\(", src):
+            enclosing = [name for start, name in classes if start < m.start()]
+            if enclosing:
+                found.add(f"{UI_TARGET}/{enclosing[-1]}/{m.group(1)}")
+    return found
+
+
+def scheduled_tests():
+    """Every UI test the workflow names in an `-only-testing:` entry."""
+    text = WORKFLOW.read_text(encoding="utf-8")
+    return set(re.findall(rf'"({re.escape(UI_TARGET)}/\w+/\w+)"', text))
+
+
+def main():
+    declared = declared_tests()
+    scheduled = scheduled_tests()
+
+    if not declared:
+        print(f"error: no UI tests found under {UI_TEST_DIR} — has the layout moved?")
+        return 1
+
+    unscheduled = sorted(declared - scheduled)
+    stale = sorted(scheduled - declared)
+
+    for name in unscheduled:
+        print(f"error: {name} is never run - add it to a test-group in ios-tests.yml")
+    for name in stale:
+        print(f"error: {name} is scheduled but no longer exists - remove it from ios-tests.yml")
+
+    if unscheduled or stale:
+        print(
+            f"\n{len(declared)} UI tests declared, {len(scheduled)} scheduled. "
+            "Every UI test must appear in exactly one matrix group."
+        )
+        return 1
+
+    print(f"All {len(declared)} UI tests are scheduled by the matrix.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/check_ui_test_coverage.py
+++ b/.github/scripts/check_ui_test_coverage.py
@@ -28,7 +28,10 @@ UI_TARGET = "Positive Only SocialUITests"
 def declared_tests():
     """Every `Target/Class/method` the UI test sources define."""
     found = set()
-    for path in sorted(UI_TEST_DIR.glob("*.swift")):
+    # rglob, not glob: Xcode groups often become real subdirectories, and a
+    # check that silently ignores them would recreate the very hole it exists
+    # to close.
+    for path in sorted(UI_TEST_DIR.rglob("*.swift")):
         src = path.read_text(encoding="utf-8")
         # Track where each XCTestCase subclass starts so methods are attributed
         # to the right class even when a file declares more than one.
@@ -46,35 +49,50 @@ def declared_tests():
 
 
 def scheduled_tests():
-    """Every UI test the workflow names in an `-only-testing:` entry."""
+    """Every UI test the workflow names, in order, keeping duplicates.
+
+    A list rather than a set: the same test named in two groups would run
+    twice, quietly paying for itself again on a job whose whole point is
+    runtime. That is invisible to a set-based comparison.
+    """
     text = WORKFLOW.read_text(encoding="utf-8")
-    return set(re.findall(rf'"({re.escape(UI_TARGET)}/\w+/\w+)"', text))
+    return re.findall(rf'"({re.escape(UI_TARGET)}/\w+/\w+)"', text)
 
 
 def main():
     declared = declared_tests()
     scheduled = scheduled_tests()
+    scheduled_set = set(scheduled)
 
     if not declared:
-        print(f"error: no UI tests found under {UI_TEST_DIR} — has the layout moved?")
+        print(f"error: no UI tests found under {UI_TEST_DIR} - has the layout moved?")
         return 1
 
-    unscheduled = sorted(declared - scheduled)
-    stale = sorted(scheduled - declared)
+    unscheduled = sorted(declared - scheduled_set)
+    stale = sorted(scheduled_set - declared)
+    duplicated = sorted(
+        {name for name in scheduled if scheduled.count(name) > 1}
+    )
 
     for name in unscheduled:
         print(f"error: {name} is never run - add it to a test-group in ios-tests.yml")
     for name in stale:
         print(f"error: {name} is scheduled but no longer exists - remove it from ios-tests.yml")
-
-    if unscheduled or stale:
+    for name in duplicated:
         print(
-            f"\n{len(declared)} UI tests declared, {len(scheduled)} scheduled. "
+            f"error: {name} is scheduled {scheduled.count(name)} times - "
+            "it would run once per group; leave it in only one"
+        )
+
+    if unscheduled or stale or duplicated:
+        print(
+            f"\n{len(declared)} UI tests declared, {len(scheduled)} scheduled "
+            f"({len(scheduled_set)} distinct). "
             "Every UI test must appear in exactly one matrix group."
         )
         return 1
 
-    print(f"All {len(declared)} UI tests are scheduled by the matrix.")
+    print(f"All {len(declared)} UI tests are scheduled exactly once by the matrix.")
     return 0
 
 

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -22,6 +22,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      # Runs before the (slow) build so a forgotten test fails in seconds
+      # rather than after a full build-and-test cycle.
+      - name: Verify every UI test is scheduled by the matrix
+        run: python3 .github/scripts/check_ui_test_coverage.py
+
       - name: List Xcode versions
         run: ls /Applications/ | grep Xcode
 
@@ -150,6 +155,7 @@ jobs:
                   "Positive Only SocialUITests/Positive_Only_SocialUITests/testDeleteAccount"
                   "Positive Only SocialUITests/Positive_Only_SocialUITests/testResetPassword"
                   "Positive Only SocialUITests/Positive_Only_SocialUITests/testTappingOutsideFieldDismissesKeyboard"
+                  "Positive Only SocialUITests/Positive_Only_SocialUITests/testChangePassword"
                 )
                 # "Positive Only Social" (default) plan covers both unit and UI tests
                 XCTESTRUN=$(find build/Build/Products -name "*.xctestrun" | grep -v "Unit Tests" | head -1)
@@ -159,6 +165,7 @@ jobs:
                   "Positive Only SocialUITests/Positive_Only_SocialUITests/testFollowAndUnfollowFromSearch"
                   "Positive Only SocialUITests/Positive_Only_SocialUITests/testFollowAndUnfollowFromPost"
                   "Positive Only SocialUITests/Positive_Only_SocialUITests/testLikeAndUnlikePost"
+                  "Positive Only SocialUITests/Positive_Only_SocialUITestsLaunchTests/testLaunch"
                 )
                 # "Positive Only Social" (default) plan covers both unit and UI tests
                 XCTESTRUN=$(find build/Build/Products -name "*.xctestrun" | grep -v "Unit Tests" | head -1)
@@ -188,6 +195,7 @@ jobs:
                   "Positive Only SocialUITests/Positive_Only_SocialUITests/testOpenPostDetailFromHomeGrid"
                   "Positive Only SocialUITests/Positive_Only_SocialUITests/testOpenPostDetailFromProfileGrid"
                   "Positive Only SocialUITests/Positive_Only_SocialUITests/testOpenPostDetailFromFollowingFeed"
+                  "Positive Only SocialUITests/Positive_Only_SocialUITests/testEnableTwoFactorAuthentication"
                 )
                 # "Positive Only Social" (default) plan covers both unit and UI tests
                 XCTESTRUN=$(find build/Build/Products -name "*.xctestrun" | grep -v "Unit Tests" | head -1)

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -5,10 +5,16 @@ on:
     paths:
       - 'ios/**'
       - '.github/workflows/ios-tests.yml'
+      # The coverage guard this workflow runs. Without it listed, a change to
+      # the guard alone would not trigger CI, so a broken guard could sit
+      # unexercised until some unrelated iOS change happened along - the same
+      # silent-gap failure the guard exists to prevent.
+      - '.github/scripts/check_ui_test_coverage.py'
   pull_request:
     paths:
       - 'ios/**'
       - '.github/workflows/ios-tests.yml'
+      - '.github/scripts/check_ui_test_coverage.py'
 
 jobs:
   build:

--- a/ios/Positive Only Social/Positive Only SocialUITests/Positive_Only_SocialUITests.swift
+++ b/ios/Positive Only Social/Positive Only SocialUITests/Positive_Only_SocialUITests.swift
@@ -1334,6 +1334,15 @@ final class Positive_Only_SocialUITests: XCTestCase {
 
         app.buttons["ConfirmTwoFactorButton"].tap()
 
+        // Confirming submits the account password, so iOS offers to save it.
+        // That prompt is a SpringBoard alert drawn over the recovery-codes
+        // screen: the Done button below is visible but not tappable until it is
+        // gone, and a tap on it is simply swallowed. Dismiss it first.
+        // This is why the test fails without it while testChangePassword passes
+        // on the same screen with the same fields - that flow never submits a
+        // password iOS considers worth offering to save.
+        dismissSavePassword(app: app)
+
         // Recovery codes are shown once; finishing reports 2FA enabled.
         let finishButton = app.buttons["FinishTwoFactorEnrollmentButton"]
         XCTAssertTrue(finishButton.waitForExistence(timeout: TestConstants.shortTimeout), "Recovery-codes step with Done button should appear")

--- a/ios/Positive Only Social/Positive Only SocialUITests/Positive_Only_SocialUITests.swift
+++ b/ios/Positive Only Social/Positive Only SocialUITests/Positive_Only_SocialUITests.swift
@@ -1314,16 +1314,23 @@ final class Positive_Only_SocialUITests: XCTestCase {
         let codeField = app.textFields["TwoFactorConfirmCodeTextField"]
         XCTAssertTrue(codeField.waitForExistence(timeout: TestConstants.shortTimeout), "Confirm-code field should appear on the enrollment sheet")
         XCTAssertTrue(app.staticTexts["TwoFactorSecretText"].exists, "The scannable secret should be shown")
-        codeField.tap()
+        // Type through the shared helper rather than calling typeText on the
+        // element directly. These were the only two raw calls left in the file,
+        // and they are why this test cannot pass as written: the helper is what
+        // dismisses the "Use Strong Password" panel, and without it the panel
+        // opens over the enrollment sheet and takes the focus. Confirmed from
+        // the recorded run. The sheet is a Form/Section, which is exactly the
+        // context where suppressing that panel through textContentType alone
+        // was found unreliable (2f07f7b), so dismissing it is the fix that
+        // holds.
         // The stubbed API accepts this fixed code (StatefulStubbedAPI.stubTotpCode).
-        codeField.typeText("123456")
+        typeText(element: codeField, text: "123456")
 
         // Confirming also takes the account password, so a stolen session alone
         // cannot bind an authenticator to the account.
         let passwordField = app.secureTextFields["TwoFactorConfirmPasswordSecureField"]
         XCTAssertTrue(passwordField.waitForExistence(timeout: TestConstants.shortTimeout), "Confirm-password field should appear on the enrollment sheet")
-        passwordField.tap()
-        passwordField.typeText(strongPassword)
+        typeText(element: passwordField, text: strongPassword)
 
         app.buttons["ConfirmTwoFactorButton"].tap()
 


### PR DESCRIPTION
## The gap

The iOS workflow schedules UI tests by naming each one in `-only-testing:` entries, split across matrix groups. Nothing checks that list against the Swift sources, so a test added to the file simply never runs — and nothing reports it.

I cross-referenced every `func test…` declaration against every `-only-testing:` entry. **21 declared, 18 scheduled.** Three were dormant:

| Test | Notes |
| --- | --- |
| `testChangePassword` | |
| `testEnableTwoFactorAuthentication` | |
| `testLaunch` | **not mentioned in the original report** — it lives in `Positive_Only_SocialUITestsLaunchTests`, a class that has never been scheduled at all |

No stale entries in the other direction (nothing scheduled that no longer exists).

## Placement

Added to the three lightest groups. I estimated group cost from how many login/register/post/comment flows each test drives, since those dominate runtime:

| Group | Before | After |
| --- | --- | --- |
| Alpha | 24 | **31** (+`testChangePassword`) |
| Beta | 26 | **27** (+`testLaunch`) |
| Gamma | 42 | 42 |
| Delta | 42 | 42 |
| Epsilon | 25 | **31** (+`testEnableTwoFactorAuthentication`) |

**The matrix's wall clock is unchanged.** Gamma and Delta were already the heaviest at ~42 and are untouched; the additions land in groups that finish early anyway. Worth noting Gamma/Delta are ~55% heavier than the lightest group, so there's a rebalancing opportunity — deliberately left out of this PR to keep the diff to the actual bug.

## On the enumerate-vs-skip question

**Recommendation: keep the enumerated list, and add an automated completeness check** (included here). I'd advise *against* switching to whole-target + `-skip-testing:`, because it interacts badly with a matrix:

- To keep each test in exactly one group, every group must skip every test not in it. Instead of naming N tests once, you name ~N per group — roughly 4× the bookkeeping, not less.
- Its failure mode is arguably worse. A forgotten test wouldn't silently *skip*, it would silently run in **all five groups at once** — 5× the cost, and for tests that create accounts and posts, five concurrent copies. Silent cost multiplication is harder to notice than silent skipping.

Enumeration's only real defect is that drift is silent, and that's fixable directly rather than by changing the scheduling model. `.github/scripts/check_ui_test_coverage.py` compares sources against the workflow and fails on a mismatch in **either** direction: a test that never runs, or an entry naming a test that no longer exists. It runs before the build, so a forgotten test fails in seconds instead of after a full build-and-test cycle.

I verified it three ways: it passes on the fixed state, it catches a newly added unwired test, and it catches a stale entry.

## Reviewer notes

- **I can't build or run iOS locally** (Windows, no Xcode; per `CLAUDE.md` the iOS suite is CI-only), so CI here is the real verification. These three tests have *never* run in CI, so this is genuinely the first time they execute — treat a red result as "newly discovered", not "newly broken".
- **`testChangePassword` is the one to watch.** It drives secure fields inside a SwiftUI Form/Section, which historically triggered the "Use Strong Password" AutoFill panel (`2f07f7b`). On `dev` today `typeText` still actively dismisses that panel, so it should be covered — but this is the first CI exercise of that path.
- **No conflict with #452** despite both touching this workflow — verified with `git merge-tree --write-tree`, which merges cleanly. #452 rewrites the runner logic around these arrays but not the arrays themselves. If #452 merges first, this PR's coverage check will also start guarding its version of the file unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
