### PR TITLE
Swallow the background showNotification rejection in the push service worker

### DIFF
--- a/website/public/firebase-messaging-sw.js
+++ b/website/public/firebase-messaging-sw.js
@@ -32,10 +32,16 @@ if (config && config.apiKey) {
   messaging.onBackgroundMessage((payload) => {
     const notification = payload.notification || {}
     const data = payload.data || {}
-    self.registration.showNotification(notification.title || 'Good Vibes Only', {
-      body: notification.body || '',
-      data: { deep_link: data.deep_link },
-    })
+    // showNotification returns a Promise that can reject (permission revoked
+    // after registration, a transient worker error). Swallow it explicitly, as
+    // the foreground handler in src/push/webPush.ts does: leaving it unhandled
+    // just prints noise, and background push is best-effort either way.
+    self.registration
+      .showNotification(notification.title || 'Good Vibes Only', {
+        body: notification.body || '',
+        data: { deep_link: data.deep_link },
+      })
+      .catch(() => {})
   })
 }
 


### PR DESCRIPTION
From Copilot's review of #456 (the dev→main release PR).

The service worker's `onBackgroundMessage` handler called `self.registration.showNotification(...)` without a `.catch()`, so a rejection — permission revoked after registration, or a transient worker error — became an unhandled rejection in the worker log.

The identical call in the foreground handler ([webPush.ts:95](website/src/push/webPush.ts)) already guards this, with a comment noting that a bare `void` still surfaces an unhandled rejection. This brings the two paths into line. Background push is best-effort either way, so the failure itself isn't worth acting on — only the log noise.

Opened against `dev` rather than pushing to `dev` directly; #456 picks it up on merge.

## Testing

Full website CI suite, all green: `npm run lint`, `npx tsc -b --noEmit`, `npm test` (426 passed / 37 files), `npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)