### PR TITLE
Merge dev into main: service worker showNotification fix

### DIFF
--- a/website/public/firebase-messaging-sw.js
+++ b/website/public/firebase-messaging-sw.js
@@ -32,10 +32,16 @@ if (config && config.apiKey) {
   messaging.onBackgroundMessage((payload) => {
     const notification = payload.notification || {}
     const data = payload.data || {}
-    self.registration.showNotification(notification.title || 'Good Vibes Only', {
-      body: notification.body || '',
-      data: { deep_link: data.deep_link },
-    })
+    // showNotification returns a Promise that can reject (permission revoked
+    // after registration, a transient worker error). Swallow it explicitly, as
+    // the foreground handler in src/push/webPush.ts does: leaving it unhandled
+    // just prints noise, and background push is best-effort either way.
+    self.registration
+      .showNotification(notification.title || 'Good Vibes Only', {
+        body: notification.body || '',
+        data: { deep_link: data.deep_link },
+      })
+      .catch(() => {})
   })
 }
 


### PR DESCRIPTION
Follow-up to #456. The Copilot review fix (#457) landed on `dev` after #456 had already merged, so this brings `main` up to date with it.

Sole change: the push service worker's `onBackgroundMessage` handler now swallows a `showNotification` rejection, matching the already-guarded identical call in the foreground handler in `src/push/webPush.ts`. One file, +10 / -4.

No backend, migration, or client changes — `main` and `dev` differ only in this file. Verified conflict-free.

## Deploy impact

Website-only, but it affects a **build-time** artifact: `firebase-messaging-sw.js` ships from `website/public/`, so this needs a web deploy to reach users. If you already deployed the site from #456, redeploy after this merges.

## Testing

Full website CI suite was run green on #457: `npm run lint`, `npx tsc -b --noEmit`, `npm test` (426 passed / 37 files), `npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)