### PR TITLE
Pin androidx.fragment forward so release lint passes

### DIFF
--- a/android/PositiveOnlySocial/app/build.gradle.kts
+++ b/android/PositiveOnlySocial/app/build.gradle.kts
@@ -80,6 +80,9 @@ dependencies {
     implementation(libs.androidx.navigation.compose)
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.messaging)
+    // Forces firebase-messaging's transitive androidx.fragment 1.1.0 up past the
+    // 1.3.0 that ActivityResult APIs require (see libs.versions.toml).
+    implementation(libs.androidx.fragment)
     implementation(libs.io.coil.compose)
     implementation(libs.zxing.core)
     implementation(libs.androidx.material.icons.extended)

--- a/android/PositiveOnlySocial/gradle/libs.versions.toml
+++ b/android/PositiveOnlySocial/gradle/libs.versions.toml
@@ -21,10 +21,16 @@ mockitoKotlin = "6.1.0"
 byteBuddy = "1.18.1"
 zxingCore = "3.5.3"
 firebaseBom = "33.7.0"
+# firebase-messaging pulls androidx.fragment 1.1.0 transitively (via
+# play-services-basement), which trips the InvalidFragmentVersionForActivityResult
+# lint check on registerForActivityResult in MainActivity. Pin it forward; nothing
+# else in the app depends on fragment directly.
+fragment = "1.8.6"
 
 [libraries]
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
 firebase-messaging = { module = "com.google.firebase:firebase-messaging" }
+androidx-fragment = { group = "androidx.fragment", name = "fragment", version.ref = "fragment" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-security-crypto = { module = "androidx.security:security-crypto", version.ref = "securityCrypto" }
 converter-gson = { module = "com.squareup.retrofit2:converter-gson", version.ref = "converterGson" }


### PR DESCRIPTION
`./gradlew assembleRelease` currently fails at `lintVitalRelease`:

```
MainActivity.kt:32: Error: Upgrade Fragment version to at least 1.3.0.
[InvalidFragmentVersionForActivityResult from androidx.activity]
```

## Cause

`firebase-messaging` (added with the push clients in #448) pulls `androidx.fragment` transitively, and nothing else in the app depends on fragment — so the old version won unopposed:

```
firebase-messaging:24.1.0 -> play-services-basement:18.3.0 -> androidx.fragment:1.1.0
play-services-base:18.0.1 -> androidx.fragment:1.0.0 -> 1.1.0
```

Declaring `androidx.fragment:fragment:1.8.6` explicitly resolves every path to 1.8.6.

## Why not a lint baseline

`MainActivity` extends `ComponentActivity`, not `FragmentActivity`, so the bug lint describes (FragmentActivity failing to call `super.onRequestPermissionsResult()`) cannot actually affect this code — a baseline would be defensible. But shipping a 2019 fragment purely because nothing forced it higher is worth fixing on its own, and the real fix is one line.

## Why CI missed it

[android-tests.yml](.github/workflows/android-tests.yml) runs `test`, `assembleDebug`, and `assembleAndroidTest`. `lintVital` only runs on **release** builds, so this class of failure is invisible to CI by construction. Worth considering adding `assembleRelease` (or `lintVitalRelease`) to the workflow separately — not done here to keep this change minimal.

## Testing

`:app:lintVitalRelease` and `:app:test` both pass locally (AGP 9.1.1 / Gradle 9.3.1, the versions on `dev`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)