### PR TITLE
ios: give the entitlements file's repo path in PUSH_SETUP.md

### DIFF
--- a/ios/PUSH_SETUP.md
+++ b/ios/PUSH_SETUP.md
@@ -19,11 +19,15 @@ the user still learns async outcomes via in-app reconciliation (#282).
 
 ## To enable it (Xcode + Apple Developer)
 
-1. Already done: the target has the **Push Notifications** capability, and
-   `Positive Only Social/Positive Only Social.entitlements` (`aps-environment`)
-   is committed and wired up via `CODE_SIGN_ENTITLEMENTS` on both
-   configurations. What still has to happen per-machine is provisioning — the
-   signing team needs an APNs-enabled profile for the bundle id.
+1. Already done: the target has the **Push Notifications** capability, and the
+   entitlements file carrying `aps-environment` is committed at
+   `ios/Positive Only Social/Positive Only Social/Positive Only Social.entitlements`.
+   It is wired up on both configurations as
+   `CODE_SIGN_ENTITLEMENTS = "Positive Only Social/Positive Only Social.entitlements"`
+   — that build setting is resolved relative to the `.xcodeproj`, which is why it
+   has one fewer path component than the repo path above. What still has to happen
+   per-machine is provisioning — the signing team needs an APNs-enabled profile for
+   the bundle id.
 2. In the Apple Developer portal, create an **APNs Auth Key** (`.p8`) and note
    its Key ID and your Team ID. Give these to the backend (`APNS_AUTH_KEY*`,
    `APNS_KEY_ID`, `APNS_TEAM_ID`, `APNS_TOPIC` = the app bundle id


### PR DESCRIPTION
From Copilot's review of #465.

`ios/PUSH_SETUP.md` quoted `Positive Only Social/Positive Only Social.entitlements` when describing the committed entitlements. That string is the `CODE_SIGN_ENTITLEMENTS` build-setting value verbatim (pbxproj lines 552/583) and is correct as such — but the setting resolves relative to the `.xcodeproj`, so it is one path component short of where the file actually lives:

```
ios/Positive Only Social/Positive Only Social/Positive Only Social.entitlements
```

Someone following the doc to locate the file lands in the wrong directory. This gives the full repo path, keeps the build-setting value, and explains why they differ — so the mismatch reads as intentional rather than a typo.

Doc-only change; no code, no build settings touched.

## Note on the second half of the review comment

Copilot also flagged line 45 as having the same problem. It does not — that line is `CI overrides the entitlements away with CODE_SIGN_ENTITLEMENTS="" in ios-tests.yml` and contains no path. Left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)