### PR TITLE
Sharing (Scope B) part 2: iOS Universal Links + Android App Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,10 +255,39 @@ mapping 403/404 to `/index.html` with a 200, so a cold load of a client-side
 `/post/<id>` route resolves at all; and the published function association
 itself.
 
-### Still to come
+### Opening the app instead of the browser (issue #382)
 
-On mobile a shared link opens the browser rather than the app. iOS Universal
-Links and Android App Links are a tracked follow-up (issue #382).
+On a phone with the app installed, a shared link opens the **app**, not the
+browser: iOS via Universal Links (`applinks:smiling.social` in the app's
+entitlements) and Android via App Links (an `autoVerify` intent-filter for
+`https://smiling.social/post/*`). Both are claimed by a file the OS fetches from
+the website at install time, published by `website/deploy-web.sh`:
+
+- `/.well-known/apple-app-site-association` — checked into
+  `website/public/.well-known/` and scoped to `/post/*`;
+- `/.well-known/assetlinks.json` — generated at deploy time, because it needs
+  the release signing certificate's SHA-256 fingerprint, which lives in Play
+  Console rather than the repo. Export `ANDROID_SHA256_CERT_FINGERPRINTS` to
+  publish it; without it the deploy leaves the file alone and Android App Links
+  simply do not verify (links keep opening the browser, which still works
+  because the web page is public).
+
+Only `/post/*` is claimed. Every other route — login, profiles, the privacy
+policy — belongs to the website, and claiming them would hijack links the app
+has no screen for.
+
+Each client parses the URL itself rather than letting the navigation framework
+resolve it (`ShareURL.parse` on iOS, `ShareLinks.parseSharedPostLink` on
+Android), because the post detail is an **authenticated** screen. The parsed
+post id goes onto the same small router a tapped push notification uses, which
+holds the request until a session exists — so a link opened while signed out
+waits for login instead of dropping the user on a screen with no session behind
+it. Both parsers are strict about scheme, host and path shape: a `VIEW` intent
+or an `.onOpenURL` callback can carry any URL, and one that merely looks similar
+must not navigate anywhere. A `#comment-<id>` fragment is parsed and the post
+still opens; scrolling to the specific comment is web-only today.
+
+If the app is not installed, the link opens the public web page as before.
 
 ## Text formatting (issue #318)
 

--- a/README.md
+++ b/README.md
@@ -203,12 +203,62 @@ Android fires an `ACTION_SEND` chooser, and the website uses the Web Share API
 when the browser offers it (typically mobile), otherwise copying the link to the
 clipboard and confirming with a "Link copied" prompt.
 
-This is deliberately the client-only first step. A shared link today opens the
-website and, because the single-post view is still behind auth, prompts a
-signed-out recipient to log in; on mobile it opens the browser rather than the
-app. Making a single post (and comment) publicly viewable with link-preview
-metadata, and adding iOS Universal Links / Android App Links so a shared link
-opens the app, are tracked follow-ups.
+### What a recipient sees (issue #381)
+
+A shared link opens the website's post page **whether or not the recipient has
+an account**. Signed out, the page is read-only: the image, caption, like count
+and the whole comment tree are all there, but liking, commenting, replying,
+reporting and the relationship filter are replaced by a prompt to log in or
+join. Share itself still works, so a link can be passed along.
+
+What is public is deliberately narrower than what a signed-in viewer sees. A
+signed-out visitor is resolved against a fixed anonymous viewer, so a post is
+served only when it is:
+
+- not hidden — approved, not pending classification, not hidden by reports, and
+  not a final-rejection tombstone;
+- `public` audience — a following/friends/family post is never public, because
+  an anonymous visitor is on nobody's follow list;
+- by an author who is **not shadow banned** (an outright ban stops the account
+  from acting but is not a content takedown, so their approved posts stay up);
+- by an author who is **not a verified minor** — an anonymous visitor's age is
+  unknown, which puts them in the adult band, and the two bands are mutually
+  invisible (see [Age and identity](#age-and-identity)). A minor's post is
+  therefore never served to the open internet.
+
+Comments are filtered by the same rule, so a public post can serve an empty
+comment list when every comment on it is hidden or narrowly scoped.
+
+Anything that fails these checks is reported as **404, identical to a post that
+never existed** — the endpoints cannot be used to probe moderation state. The
+answer does not depend on who asks: a signed-in browser, a signed-out one, and a
+crawler all get the same bytes.
+
+A comment link's `#comment-<id>` fragment is resolved by the post page itself:
+the whole thread is served (a reply only makes sense inside the conversation it
+belongs to) and the page scrolls to that comment and marks it out.
+
+### Link previews
+
+The website is a client-only SPA, so a crawler that fetches
+`https://smiling.social/post/<id>` gets an empty root div and nothing to unfurl.
+CloudFront's viewer-request function (`website/cloudfront/link-preview.js`)
+redirects known link-preview crawlers — and only those — to a backend endpoint
+that returns a meta-only HTML document with the post's Open Graph and Twitter
+Card tags. Real browsers are untouched and get the SPA. The preview endpoint
+applies exactly the public-visibility rule above, so a post it may not show
+unfurls as the generic site card rather than leaking anything.
+
+Two pieces of CloudFront configuration make this work and are not managed by
+`website/deploy-web.sh` (which warns about the first): custom error responses
+mapping 403/404 to `/index.html` with a 200, so a cold load of a client-side
+`/post/<id>` route resolves at all; and the published function association
+itself.
+
+### Still to come
+
+On mobile a shared link opens the browser rather than the app. iOS Universal
+Links and Android App Links are a tracked follow-up (issue #382).
 
 ## Text formatting (issue #318)
 

--- a/android/PositiveOnlySocial/app/src/main/AndroidManifest.xml
+++ b/android/PositiveOnlySocial/app/src/main/AndroidManifest.xml
@@ -30,6 +30,30 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+
+            <!-- App Links for shared post links (issue #382). autoVerify makes
+                 Android check https://smiling.social/.well-known/assetlinks.json
+                 for this package + signing certificate at install time; only
+                 then does the link open the app instead of the browser. Both
+                 hosts serve the same site, so a link shared with the www.
+                 prefix opens the app too.
+
+                 Scoped to /post/ rather than the whole site on purpose: every
+                 other route (login, profiles, the privacy policy) belongs to
+                 the website, and claiming them would hijack links the app has
+                 no screen for. MainActivity parses the URL and routes it
+                 through the same navigator a tapped push notification uses, so
+                 a link opened while signed out waits for login instead of
+                 dropping the user on an authenticated screen. -->
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="https" android:host="smiling.social" android:pathPrefix="/post/" />
+                <data android:scheme="https" android:host="www.smiling.social" android:pathPrefix="/post/" />
+            </intent-filter>
         </activity>
 
         <!-- Receives FCM push (issues #342/#343). onNewToken re-registers the

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/MainActivity.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/MainActivity.kt
@@ -22,6 +22,7 @@ import com.example.positiveonlysocial.fcm.PushNavigator
 import com.example.positiveonlysocial.ui.navigation.NavGraph
 import com.example.positiveonlysocial.ui.preview.PreviewHelpers
 import com.example.positiveonlysocial.ui.theme.PositiveOnlySocialTheme
+import com.example.positiveonlysocial.util.ShareLinks
 
 class MainActivity : ComponentActivity() {
 
@@ -34,8 +35,10 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         maybeRequestNotificationPermission()
-        // The activity may have been launched by tapping a notification.
+        // The activity may have been launched by tapping a notification, or by
+        // opening a shared post link (issue #382).
         handleNotificationIntent(intent)
+        handleSharedLinkIntent(intent)
         setContent {
             PositiveOnlySocialTheme {
                 // A surface container using the 'background' color from the theme
@@ -58,6 +61,7 @@ class MainActivity : ComponentActivity() {
         // A tap while the app was already running delivers the intent here.
         setIntent(intent)
         handleNotificationIntent(intent)
+        handleSharedLinkIntent(intent)
     }
 
     private fun maybeRequestNotificationPermission() {
@@ -90,6 +94,23 @@ class MainActivity : ComponentActivity() {
             intent.removeExtra(PosFirebaseMessagingService.KEY_POST_IDENTIFIER)
             intent.removeExtra(PosFirebaseMessagingService.KEY_TYPE)
         }
+    }
+
+    /** Route to the post a shared App Link points at (issue #382).
+     *
+     * Deliberately goes through [PushNavigator] rather than letting NavHost
+     * handle the deep link itself: PostDetail is an authenticated screen, and
+     * NavHost would build a back stack straight to it even when the user is
+     * signed out. The navigator parks the request until the graph reports a
+     * session, which is the same path a tapped push notification takes. */
+    private fun handleSharedLinkIntent(intent: Intent?) {
+        if (intent == null || intent.action != Intent.ACTION_VIEW) return
+        val link = ShareLinks.parseSharedPostLink(intent.dataString) ?: return
+        PushNavigator.openPost(link.postIdentifier)
+        // Consume the data so an Activity recreation (rotation / process death)
+        // doesn't re-read the same link and navigate again, matching how the
+        // notification extras above are cleared.
+        intent.data = null
     }
 }
 

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/navigation/NavGraph.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/navigation/NavGraph.kt
@@ -48,11 +48,17 @@ fun NavGraph(
         }
     }
 
-    // A tapped "post rejected" notification asks us to open that post (issues
-    // #342/#343). Only route into the authenticated PostDetail once logged in:
-    // a stale tap while logged out is left pending (not cleared) and consumed
-    // after login — keying the effect on isLoggedIn re-runs it when auth flips —
-    // instead of pushing an authenticated screen from the Welcome flow.
+    // Something asked us to open a post: a tapped "post rejected" notification
+    // (issues #342/#343), or a shared https://smiling.social/post/<id> App Link
+    // parsed in MainActivity (issue #382). Only route into the authenticated
+    // PostDetail once logged in: a stale request while logged out is left
+    // pending (not cleared) and consumed after login — keying the effect on
+    // isLoggedIn re-runs it when auth flips — instead of pushing an
+    // authenticated screen from the Welcome flow.
+    //
+    // This is also why PostDetail carries no navDeepLink: NavHost would resolve
+    // the incoming VIEW intent itself and build a back stack straight to an
+    // authenticated screen, with no session behind it.
     val pendingPostId by PushNavigator.pendingPostId.collectAsState()
     val pushIsLoggedIn by authManager.isLoggedIn.collectAsState()
     LaunchedEffect(pendingPostId, pushIsLoggedIn) {

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/util/ShareLinks.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/util/ShareLinks.kt
@@ -28,8 +28,11 @@ data class SharedPostLink(
  *
  * The website renders these links for signed-out recipients too (issue #381),
  * so a link is useful whether or not the app is installed — which is what makes
- * claiming `https://smiling.social/post/*` with `autoVerify` safe: a device
- * without the app just opens the web page.
+ * claiming the `https://smiling.social/post/` path prefix with `autoVerify`
+ * safe: a device without the app just opens the web page.
+ *
+ * (Spelling that prefix with a trailing wildcard would end this comment early:
+ * Kotlin block comments nest, so the `/` + `*` would open one.)
  *
  * Everything except [shareText] is pure (no Android framework, [URI] rather
  * than `android.net.Uri`) so it unit-tests on the JVM without a runtime.

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/util/ShareLinks.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/util/ShareLinks.kt
@@ -78,8 +78,9 @@ object ShareLinks {
         val uri = try {
             URI(url)
         } catch (e: Exception) {
-            // A malformed URL is simply not one of ours.
-            Log.w("ShareLinks", "Ignoring unparseable link", e)
+            // A malformed URL is simply not one of ours. Returning null is the
+            // whole signal — no logging, so this stays free of the Android
+            // framework and its unit tests don't lean on the JVM stubs.
             return null
         }
 

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/util/ShareLinks.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/util/ShareLinks.kt
@@ -5,15 +5,34 @@ import android.content.Context
 import android.content.Intent
 import android.util.Log
 import android.widget.Toast
+import java.net.URI
 
 /**
- * Builds the website links shared from a post's or comment's options menu, and
- * launches the Android system share sheet with one (issue #34, Scope A).
+ * A shared link that resolved to a post, and optionally to one comment on it
+ * (issue #382).
+ */
+data class SharedPostLink(
+    val postIdentifier: String,
+    /**
+     * The comment a `#comment-<id>` fragment named, or null for a plain post
+     * link. Carried so a shared comment link routes to its post rather than
+     * being rejected outright; the app opens the post detail either way.
+     */
+    val commentIdentifier: String?
+)
+
+/**
+ * Both ends of a shared post link: the website URLs built from a post's or
+ * comment's options menu (issue #34), and the parse of the same URL when
+ * Android hands it back as an App Link (issue #382).
  *
- * These links point at the website (they currently require login to view —
- * public viewing / App Links deep-linking straight into the app is the tracked
- * Scope B follow-up). The URL builders are kept pure so they can be unit-tested
- * without an Android runtime; only [shareText] touches the framework.
+ * The website renders these links for signed-out recipients too (issue #381),
+ * so a link is useful whether or not the app is installed — which is what makes
+ * claiming `https://smiling.social/post/*` with `autoVerify` safe: a device
+ * without the app just opens the web page.
+ *
+ * Everything except [shareText] is pure (no Android framework, [URI] rather
+ * than `android.net.Uri`) so it unit-tests on the JVM without a runtime.
  */
 object ShareLinks {
     /** The website origin every shared link is rooted at. */
@@ -29,6 +48,60 @@ object ShareLinks {
      */
     fun commentUrl(postIdentifier: String, commentIdentifier: String): String =
         "${postUrl(postIdentifier)}#comment-$commentIdentifier"
+
+    /**
+     * The website hosts this app claims as App Links. Both are declared in the
+     * manifest's `autoVerify` intent-filter and both serve the same site, so a
+     * link shared with the `www.` prefix opens the app too.
+     */
+    val LINK_HOSTS = setOf("smiling.social", "www.smiling.social")
+
+    private const val COMMENT_FRAGMENT_PREFIX = "comment-"
+
+    /**
+     * The inverse of the builders above: what an App Link Android launched us
+     * with refers to, or null when [url] is not one of ours (issue #382).
+     *
+     * Deliberately strict. A VIEW intent can be sent by any app, not only by
+     * the verified-link path, so scheme, host and path shape are all checked
+     * before the identifier is used to navigate — a URL that merely looks
+     * similar must not send the user somewhere unexpected. A trailing slash is
+     * tolerated because chat apps and link shorteners add one freely, and an
+     * unrecognized fragment is ignored rather than failing the whole link: the
+     * post is still the right destination.
+     */
+    fun parseSharedPostLink(url: String?): SharedPostLink? {
+        if (url.isNullOrBlank()) return null
+        val uri = try {
+            URI(url)
+        } catch (e: Exception) {
+            // A malformed URL is simply not one of ours.
+            Log.w("ShareLinks", "Ignoring unparseable link", e)
+            return null
+        }
+
+        if (!"https".equals(uri.scheme, ignoreCase = true)) return null
+        val host = uri.host?.lowercase() ?: return null
+        if (host !in LINK_HOSTS) return null
+
+        // ["", "post", "<id>"] for /post/<id>, plus a trailing "" for a
+        // trailing slash. Anything longer is a route we don't claim.
+        val segments = (uri.path ?: "").split("/").toMutableList()
+        if (segments.isNotEmpty() && segments.last().isEmpty()) segments.removeAt(segments.size - 1)
+        if (segments.size != 3 || segments[0].isNotEmpty() || segments[1] != "post") return null
+
+        val postIdentifier = segments[2]
+        if (postIdentifier.isEmpty()) return null
+
+        // URI decodes the fragment, matching what commentUrl encoded.
+        val fragment = uri.fragment
+        val commentIdentifier = fragment
+            ?.takeIf { it.startsWith(COMMENT_FRAGMENT_PREFIX) }
+            ?.removePrefix(COMMENT_FRAGMENT_PREFIX)
+            ?.takeIf { it.isNotEmpty() }
+
+        return SharedPostLink(postIdentifier, commentIdentifier)
+    }
 
     /**
      * Launch the system share sheet (chooser) with [text] as plain-text content,

--- a/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/util/ShareLinksTest.kt
+++ b/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/util/ShareLinksTest.kt
@@ -1,6 +1,7 @@
 package com.example.positiveonlysocial.util
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -37,5 +38,90 @@ class ShareLinksTest {
         val commentUrl = ShareLinks.commentUrl("p1", "c1")
         assertTrue(commentUrl.startsWith(postUrl))
         assertEquals("$postUrl#comment-c1", commentUrl)
+    }
+
+    // ---- App Link parsing (issue #382) ----
+
+    @Test
+    fun parseReadsBackTheLinksTheBuildersProduce() {
+        // Round trip: whatever we hand the share sheet, Android can hand back.
+        assertEquals(
+            SharedPostLink("abc123", null),
+            ShareLinks.parseSharedPostLink(ShareLinks.postUrl("abc123"))
+        )
+        assertEquals(
+            SharedPostLink("abc123", "c789"),
+            ShareLinks.parseSharedPostLink(ShareLinks.commentUrl("abc123", "c789"))
+        )
+    }
+
+    @Test
+    fun parseAcceptsTheWwwHost() {
+        // Both hosts are claimed by the manifest's autoVerify intent-filter.
+        assertEquals(
+            SharedPostLink("abc123", null),
+            ShareLinks.parseSharedPostLink("https://www.smiling.social/post/abc123")
+        )
+    }
+
+    @Test
+    fun parseIsCaseInsensitiveAboutSchemeAndHost() {
+        assertEquals(
+            SharedPostLink("abc123", null),
+            ShareLinks.parseSharedPostLink("HTTPS://SMILING.social/post/abc123")
+        )
+    }
+
+    @Test
+    fun parseToleratesATrailingSlash() {
+        // Chat apps and shorteners add one freely.
+        assertEquals(
+            SharedPostLink("abc123", null),
+            ShareLinks.parseSharedPostLink("https://smiling.social/post/abc123/")
+        )
+    }
+
+    @Test
+    fun parseKeepsThePostWhenTheFragmentIsNotAComment() {
+        // An unrecognized fragment shouldn't cost the user the post.
+        assertEquals(
+            SharedPostLink("abc123", null),
+            ShareLinks.parseSharedPostLink("https://smiling.social/post/abc123#top")
+        )
+        assertEquals(
+            SharedPostLink("abc123", null),
+            ShareLinks.parseSharedPostLink("https://smiling.social/post/abc123#comment-")
+        )
+    }
+
+    @Test
+    fun parseIgnoresAQueryString() {
+        // Links pasted from a browser or a campaign tracker carry one.
+        assertEquals(
+            SharedPostLink("abc123", "c789"),
+            ShareLinks.parseSharedPostLink("https://smiling.social/post/abc123?utm=x#comment-c789")
+        )
+    }
+
+    @Test
+    fun parseRejectsUrlsThatAreNotOurs() {
+        // A VIEW intent can be sent by any app, not only by the verified-link
+        // path, so a URL that merely looks similar must not navigate anywhere.
+        val rejected = listOf(
+            "https://smiling.social.evil.example/post/abc123",  // suffix, not our host
+            "https://evil.example/post/abc123",                 // wrong host entirely
+            "http://smiling.social/post/abc123",                // not https
+            "https://smiling.social/posts/abc123",              // different route
+            "https://smiling.social/post/",                     // no identifier
+            "https://smiling.social/post/abc123/extra",         // deeper path
+            "https://smiling.social/profile/ada",               // another route
+            "https://smiling.social/",                          // the site root
+            "not a url at all",
+            "",
+            null
+        )
+        for (url in rejected) {
+            assertNull("expected $url to be rejected", ShareLinks.parseSharedPostLink(url))
+        }
     }
 }

--- a/backend/user_system/link_preview.py
+++ b/backend/user_system/link_preview.py
@@ -1,0 +1,128 @@
+"""Open Graph / Twitter Card HTML for a shared post link (issue #381).
+
+The website is a client-only Vite SPA served from S3/CloudFront, so a crawler
+that fetches `https://smiling.social/post/<id>` gets an empty `<div id="root">`
+and nothing to unfurl. This module renders the small, self-contained HTML
+document the crawler is sent instead: nothing but `<meta>` tags plus a human
+fallback that bounces a real browser on to the SPA route.
+
+It deliberately does no template loading and no JS: the document is built from
+escaped strings so it can be unit tested without a request, and so a crawler
+that ignores scripts still sees every tag it needs.
+"""
+
+from django.utils.html import escape
+
+# How much of a caption goes into og:description. Facebook/Slack/Twitter all
+# truncate somewhere near 200-300 characters anyway; cutting server-side keeps
+# the document small and avoids a mid-word cut in the middle of a preview card.
+MAX_DESCRIPTION_LENGTH = 200
+
+# Shown when a post has no caption at all (a photo-only post), so the preview
+# card never renders with an empty description line.
+DEFAULT_DESCRIPTION = "A post on Good Vibes Only, the positivity-only social network."
+
+SITE_NAME = "Good Vibes Only"
+
+
+def truncate_description(caption):
+    """A caption trimmed to preview length, ending at a word boundary.
+
+    Returns DEFAULT_DESCRIPTION for an empty/whitespace-only caption so the
+    card always has a description. Long captions are cut at the last space
+    before the limit (falling back to a hard cut when a single 'word' is longer
+    than the limit) and get a single-character ellipsis.
+    """
+    text = ' '.join((caption or '').split())
+    if not text:
+        return DEFAULT_DESCRIPTION
+    if len(text) <= MAX_DESCRIPTION_LENGTH:
+        return text
+    cut = text[:MAX_DESCRIPTION_LENGTH]
+    boundary = cut.rfind(' ')
+    if boundary > 0:
+        cut = cut[:boundary]
+    return f"{cut.rstrip()}…"
+
+
+def _meta(tags):
+    """Render `(attribute, name, content)` triples as escaped <meta> tags,
+    skipping any whose content is empty."""
+    return '\n'.join(
+        f'    <meta {attribute}="{escape(name)}" content="{escape(content)}" />'
+        for attribute, name, content in tags
+        if content
+    )
+
+
+def render_post_preview(*, title, description, canonical_url, image_url=None):
+    """The full HTML document served to a crawler for a shared post link.
+
+    `image_url` is optional: a text-only post (#307) has no image, and its card
+    degrades from a `summary_large_image` to a plain `summary`. Every value is
+    HTML-escaped, so a caption containing markup cannot break out of the meta
+    tags or inject script into the document.
+    """
+    card_type = 'summary_large_image' if image_url else 'summary'
+    tags = [
+        ('name', 'description', description),
+        ('property', 'og:type', 'article'),
+        ('property', 'og:site_name', SITE_NAME),
+        ('property', 'og:title', title),
+        ('property', 'og:description', description),
+        ('property', 'og:url', canonical_url),
+        ('property', 'og:image', image_url or ''),
+        ('name', 'twitter:card', card_type),
+        ('name', 'twitter:title', title),
+        ('name', 'twitter:description', description),
+        ('name', 'twitter:image', image_url or ''),
+    ]
+    # The refresh sends a human who somehow landed on this URL (a crawler
+    # redirect they followed by hand, a copied preview link) on to the real
+    # page. Crawlers ignore it and read the meta tags above; the visible link is
+    # the no-JS fallback for anything that ignores both.
+    return f"""<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{escape(title)}</title>
+    <link rel="canonical" href="{escape(canonical_url)}" />
+{_meta(tags)}
+    <meta http-equiv="refresh" content="0; url={escape(canonical_url)}" />
+  </head>
+  <body>
+    <p><a href="{escape(canonical_url)}">{escape(title)}</a></p>
+  </body>
+</html>
+"""
+
+
+def render_missing_preview(*, site_url):
+    """The document served when a shared link points at a post that is gone,
+    hidden, or not public. It is deliberately indistinguishable from the
+    never-existed case — a crawler must not be able to probe moderation state —
+    and carries no post-specific tags."""
+    tags = [
+        ('name', 'description', DEFAULT_DESCRIPTION),
+        ('property', 'og:type', 'website'),
+        ('property', 'og:site_name', SITE_NAME),
+        ('property', 'og:title', SITE_NAME),
+        ('property', 'og:description', DEFAULT_DESCRIPTION),
+        ('property', 'og:url', site_url),
+        ('name', 'twitter:card', 'summary'),
+    ]
+    return f"""<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{escape(SITE_NAME)}</title>
+{_meta(tags)}
+  </head>
+  <body>
+    <p>This post is no longer available.</p>
+    <p><a href="{escape(site_url)}">{escape(SITE_NAME)}</a></p>
+  </body>
+</html>
+"""

--- a/backend/user_system/tests/test_post_link_preview_view.py
+++ b/backend/user_system/tests/test_post_link_preview_view.py
@@ -1,0 +1,200 @@
+import re
+import uuid
+
+from django.test import override_settings
+from django.urls import reverse
+
+from .test_parent_case import PositiveOnlySocialTestCase
+from .. import link_preview
+from ..constants import BAN_TYPE_SHADOW, Fields, HIDDEN_REASON_CLASSIFIER, POST_AUDIENCE_FRIENDS
+from ..models import Post, UserBan
+from ..views import get_user_with_username
+
+
+def meta_content(html, attribute, name):
+    """The `content` of a <meta {attribute}="{name}"> tag, or None."""
+    match = re.search(
+        rf'<meta {attribute}="{re.escape(name)}" content="([^"]*)"', html)
+    return match.group(1) if match else None
+
+
+class TruncateDescriptionTests(PositiveOnlySocialTestCase):
+    """Caption -> og:description, the one place a preview shows user text."""
+
+    def test_empty_caption_falls_back_to_the_site_blurb(self):
+        for caption in (None, '', '   ', '\n\t'):
+            with self.subTest(caption=caption):
+                self.assertEqual(link_preview.truncate_description(caption),
+                                 link_preview.DEFAULT_DESCRIPTION)
+
+    def test_short_caption_is_passed_through_with_whitespace_collapsed(self):
+        self.assertEqual(link_preview.truncate_description('  what a\n\n lovely  day  '),
+                         'what a lovely day')
+
+    def test_long_caption_is_cut_at_a_word_boundary(self):
+        caption = 'sunshine ' * 60
+        result = link_preview.truncate_description(caption)
+
+        self.assertLessEqual(len(result), link_preview.MAX_DESCRIPTION_LENGTH + 1)
+        self.assertTrue(result.endswith('…'))
+        # The cut lands between words, so no half-word is shown.
+        self.assertTrue(result[:-1].endswith('sunshine'))
+
+    def test_single_long_word_is_hard_cut(self):
+        """A caption with no spaces has no boundary to cut at; it must still be
+        truncated rather than passed through whole."""
+        result = link_preview.truncate_description('a' * 500)
+
+        self.assertEqual(result, 'a' * link_preview.MAX_DESCRIPTION_LENGTH + '…')
+
+
+@override_settings(FRONTEND_BASE_URL='https://smiling.social')
+class PostLinkPreviewViewTests(PositiveOnlySocialTestCase):
+    """
+    The Open Graph document a link-preview crawler is served for a shared post
+    (issue #381). It follows exactly the same public-visibility rule as the JSON
+    endpoints, and a post it may not show degrades to the generic site card
+    rather than an error page.
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        self.author = self.make_user_with_prefix(prefix='author')
+        self.author_user = get_user_with_username(self.author['username'])
+
+        post_data = self._make_post(self.author[Fields.session_management_token])
+        self.post_identifier = post_data[Fields.post_identifier]
+        self.post = Post.objects.get(post_identifier=self.post_identifier)
+
+        self.url = reverse('get_post_link_preview',
+                           kwargs={'post_identifier': str(self.post_identifier)})
+
+    def _html(self, expected_status=200):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, expected_status)
+        self.assertTrue(response['Content-Type'].startswith('text/html'))
+        return response.content.decode('utf-8')
+
+    # =========================================================================
+    # A PUBLIC POST
+    # =========================================================================
+
+    def test_preview_describes_the_post(self):
+        Post.objects.filter(pk=self.post.pk).update(caption='a very good day')
+        html = self._html()
+
+        canonical = f'https://smiling.social/post/{self.post_identifier}'
+        self.assertEqual(meta_content(html, 'property', 'og:url'), canonical)
+        self.assertIn(f'<link rel="canonical" href="{canonical}" />', html)
+        self.assertEqual(meta_content(html, 'property', 'og:description'), 'a very good day')
+        self.assertEqual(meta_content(html, 'property', 'og:title'),
+                         f"{self.author['username']} on {link_preview.SITE_NAME}")
+        self.assertEqual(meta_content(html, 'property', 'og:site_name'), link_preview.SITE_NAME)
+        self.assertEqual(meta_content(html, 'property', 'og:type'), 'article')
+
+    def test_preview_carries_twitter_card_tags(self):
+        html = self._html()
+
+        self.assertEqual(meta_content(html, 'name', 'twitter:card'), 'summary_large_image')
+        self.assertEqual(meta_content(html, 'name', 'twitter:title'),
+                         meta_content(html, 'property', 'og:title'))
+        self.assertEqual(meta_content(html, 'name', 'twitter:description'),
+                         meta_content(html, 'property', 'og:description'))
+        self.assertEqual(meta_content(html, 'name', 'twitter:image'),
+                         meta_content(html, 'property', 'og:image'))
+
+    def test_preview_image_is_the_posts_compressed_image(self):
+        html = self._html()
+
+        image = meta_content(html, 'property', 'og:image')
+        self.assertTrue(image)
+        # The image URL comes off the post, not a placeholder.
+        self.assertIn(self.post.image_url.rsplit('/', 1)[-1], image)
+
+    def test_text_only_post_degrades_to_a_summary_card(self):
+        """A text-only post (#307) has no image, so there is no large-image card
+        to render and no empty og:image tag to emit."""
+        Post.objects.filter(pk=self.post.pk).update(image_url=None)
+
+        html = self._html()
+
+        self.assertEqual(meta_content(html, 'name', 'twitter:card'), 'summary')
+        self.assertIsNone(meta_content(html, 'property', 'og:image'))
+
+    def test_caption_markup_is_escaped(self):
+        """A caption is user text; it must not be able to close the meta tag or
+        inject script into the preview document."""
+        Post.objects.filter(pk=self.post.pk).update(
+            caption='" /><script>alert(1)</script><meta x="')
+
+        html = self._html()
+
+        self.assertNotIn('<script>', html)
+        self.assertIn('&lt;script&gt;', html)
+        # The description survived as text rather than breaking out of the tag.
+        self.assertIn('alert(1)', meta_content(html, 'property', 'og:description'))
+
+    def test_human_landing_on_the_preview_is_bounced_to_the_site(self):
+        html = self._html()
+
+        canonical = f'https://smiling.social/post/{self.post_identifier}'
+        self.assertIn(f'<meta http-equiv="refresh" content="0; url={canonical}" />', html)
+        self.assertIn(f'<a href="{canonical}">', html)
+
+    def test_preview_is_only_briefly_cacheable(self):
+        """og:image is a CloudFront-signed URL that expires, so the document
+        must not be cached for long."""
+        response = self.client.get(self.url)
+
+        self.assertEqual(response['Cache-Control'], 'public, max-age=300')
+
+    # =========================================================================
+    # A POST THE CRAWLER MAY NOT SEE
+    # =========================================================================
+
+    def _assert_generic_card(self):
+        html = self._html(expected_status=404)
+
+        self.assertEqual(meta_content(html, 'property', 'og:title'), link_preview.SITE_NAME)
+        self.assertEqual(meta_content(html, 'property', 'og:type'), 'website')
+        self.assertIsNone(meta_content(html, 'property', 'og:image'))
+        # Nothing about the post leaks — not even its id.
+        self.assertNotIn(str(self.post_identifier), html)
+
+    def test_hidden_post_gets_the_generic_card(self):
+        Post.objects.filter(pk=self.post.pk).update(
+            hidden=True, hidden_reason=HIDDEN_REASON_CLASSIFIER)
+
+        self._assert_generic_card()
+
+    def test_restricted_audience_post_gets_the_generic_card(self):
+        Post.objects.filter(pk=self.post.pk).update(audience=POST_AUDIENCE_FRIENDS)
+
+        self._assert_generic_card()
+
+    def test_shadow_banned_authors_post_gets_the_generic_card(self):
+        UserBan.objects.create(user=self.author_user, ban_type=BAN_TYPE_SHADOW)
+
+        self._assert_generic_card()
+
+    def test_missing_post_gets_the_generic_card(self):
+        url = reverse('get_post_link_preview', kwargs={'post_identifier': str(uuid.uuid4())})
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 404)
+        self.assertIn('no longer available', response.content.decode('utf-8'))
+
+    def test_hidden_and_missing_posts_are_indistinguishable(self):
+        """A crawler must not be able to tell a moderated post from one that
+        never existed."""
+        missing = self.client.get(
+            reverse('get_post_link_preview', kwargs={'post_identifier': str(uuid.uuid4())}))
+
+        Post.objects.filter(pk=self.post.pk).update(
+            hidden=True, hidden_reason=HIDDEN_REASON_CLASSIFIER)
+        hidden = self.client.get(self.url)
+
+        self.assertEqual(missing.status_code, hidden.status_code)
+        self.assertEqual(missing.content, hidden.content)

--- a/backend/user_system/tests/test_public_share_views.py
+++ b/backend/user_system/tests/test_public_share_views.py
@@ -1,0 +1,301 @@
+import uuid
+from datetime import timedelta
+
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from django.utils import timezone
+
+from .test_parent_case import PositiveOnlySocialTestCase
+from ..constants import (
+    BAN_TYPE_OUTRIGHT,
+    BAN_TYPE_SHADOW,
+    Fields,
+    HIDDEN_REASON_CLASSIFIER,
+    HIDDEN_REASON_CLASSIFIER_FINAL,
+    HIDDEN_REASON_PENDING_CLASSIFICATION,
+    POST_AUDIENCE_FAMILY,
+    POST_AUDIENCE_FRIENDS,
+    POST_AUDIENCE_FOLLOWING,
+)
+from ..models import Comment, CommentThread, Post, UserBan
+from ..utils import get_compressed_image_url
+from ..views import get_user_with_username
+
+
+class PublicShareViewTests(PositiveOnlySocialTestCase):
+    """
+    The signed-out half of sharing (issue #381): a recipient with no account can
+    read a shared post and its comments, but only when the content is genuinely
+    public. Everything the moderation rules hide is reported as a 404 that is
+    indistinguishable from a post that never existed, so these endpoints cannot
+    be used to probe moderation state.
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        self.author = self.make_user_with_prefix(prefix='author')
+        self.commenter = self.make_user_with_prefix(prefix='commenter')
+        self.author_user = get_user_with_username(self.author['username'])
+
+        post_data = self._make_post(self.author[Fields.session_management_token])
+        self.post_identifier = post_data[Fields.post_identifier]
+        self.post = Post.objects.get(post_identifier=self.post_identifier)
+
+        comment_data = self._comment_on_post(
+            self.commenter[Fields.session_management_token], self.post_identifier)
+        self.thread_identifier = comment_data[Fields.comment_thread_identifier]
+        self.comment_identifier = comment_data[Fields.comment_identifier]
+        self.comment = Comment.objects.get(comment_identifier=self.comment_identifier)
+
+        self.details_url = self._details_url(self.post_identifier)
+        self.comments_url = self._comments_url(self.post_identifier)
+        self.thread_url = self._thread_url(self.thread_identifier)
+
+    # -------------------------------------------------------------------------
+    # Helpers
+    # -------------------------------------------------------------------------
+
+    def _details_url(self, post_identifier):
+        return reverse('get_public_post_details', kwargs={'post_identifier': str(post_identifier)})
+
+    def _comments_url(self, post_identifier, batch=0):
+        return reverse('get_public_comments_for_post',
+                       kwargs={'post_identifier': str(post_identifier), 'batch': batch})
+
+    def _thread_url(self, thread_identifier, batch=0):
+        return reverse('get_public_comments_for_thread',
+                       kwargs={'comment_thread_identifier': str(thread_identifier), 'batch': batch})
+
+    def _assert_all_hidden(self, message):
+        """Every public endpoint for this post (and its thread) 404s."""
+        for url in (self.details_url, self.comments_url, self.thread_url):
+            self.assertEqual(self.client.get(url).status_code, 404, msg=f"{message}: {url}")
+
+    def _assert_all_visible(self, message):
+        for url in (self.details_url, self.comments_url, self.thread_url):
+            self.assertEqual(self.client.get(url).status_code, 200, msg=f"{message}: {url}")
+
+    # =========================================================================
+    # THE HAPPY PATH
+    # =========================================================================
+
+    def test_public_post_is_served_without_a_token(self):
+        response = self.client.get(self.details_url)
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data[Fields.post_identifier], str(self.post_identifier))
+        self.assertEqual(data[Fields.caption], self.post.caption)
+        self.assertEqual(data[Fields.author_username], self.author['username'])
+        # Without CloudFront configured the image URLs degrade exactly as they do
+        # for a signed-in viewer: compressed-bucket swap plus the raw original.
+        self.assertEqual(data[Fields.image_url], get_compressed_image_url(self.post.image_url))
+        self.assertEqual(data[Fields.original_image_url], self.post.image_url)
+        self.assertEqual(data[Fields.post_likes], 0)
+
+    def test_public_post_omits_per_viewer_and_author_only_state(self):
+        """There is no viewer, so there are no like/save/report flags to report,
+        and the author-only classification fields must not leak either."""
+        data = self.client.get(self.details_url).json()
+
+        for field in (Fields.is_liked, Fields.is_saved, Fields.is_reported, Fields.report_reason,
+                      Fields.status, Fields.hidden, Fields.hidden_reason, Fields.appealable):
+            self.assertNotIn(field, data)
+
+    def test_public_comments_expose_the_whole_thread(self):
+        """A shared `#comment-<id>` link needs the conversation around it, so the
+        public view serves the thread list and each thread's comments."""
+        threads = self.client.get(self.comments_url).json()
+        self.assertEqual([t[Fields.comment_thread_identifier] for t in threads],
+                         [str(self.thread_identifier)])
+
+        comments = self.client.get(self.thread_url).json()
+        self.assertEqual(len(comments), 1)
+        self.assertEqual(comments[0][Fields.comment_identifier], str(self.comment_identifier))
+        self.assertEqual(comments[0][Fields.body], self.comment.body)
+        self.assertEqual(comments[0][Fields.author_username], self.commenter['username'])
+        self.assertEqual(comments[0][Fields.comment_likes], 0)
+
+    def test_public_comments_omit_per_viewer_state(self):
+        comment = self.client.get(self.thread_url).json()[0]
+
+        for field in (Fields.is_liked, Fields.is_reported, Fields.report_reason):
+            self.assertNotIn(field, comment)
+
+    def test_public_post_likes_count_reflects_real_likes(self):
+        like_url = reverse('like_post', kwargs={'post_identifier': str(self.post_identifier)})
+        header = {'HTTP_AUTHORIZATION': f"Bearer {self.commenter[Fields.session_management_token]}"}
+        self.assertEqual(self.client.post(like_url, **header).status_code, 200)
+
+        self.assertEqual(self.client.get(self.details_url).json()[Fields.post_likes], 1)
+
+    # =========================================================================
+    # MODERATION: WHAT MUST NEVER BE PUBLIC
+    # =========================================================================
+
+    def test_missing_post_returns_not_found(self):
+        response = self.client.get(self._details_url(uuid.uuid4()))
+        self.assertEqual(response.status_code, 404)
+
+    def test_hidden_post_is_not_public(self):
+        self.post.hidden = True
+        self.post.hidden_reason = HIDDEN_REASON_CLASSIFIER
+        self.post.save()
+
+        self._assert_all_hidden("a hidden post")
+
+    def test_pending_post_is_not_public(self):
+        """A post still awaiting classification is author-only; the share link
+        must not publish it before a decision is made."""
+        self.post.hidden = True
+        self.post.hidden_reason = HIDDEN_REASON_PENDING_CLASSIFICATION
+        self.post.save()
+
+        self._assert_all_hidden("a pending post")
+
+    def test_final_rejection_tombstone_is_not_public(self):
+        self.post.hidden = True
+        self.post.hidden_reason = HIDDEN_REASON_CLASSIFIER_FINAL
+        self.post.save()
+
+        self._assert_all_hidden("a final-rejection tombstone")
+
+    def test_shadow_banned_authors_post_is_not_public(self):
+        UserBan.objects.create(user=self.author_user, ban_type=BAN_TYPE_SHADOW)
+
+        self._assert_all_hidden("a shadow-banned author's post")
+
+    def test_expired_shadow_ban_makes_the_post_public_again(self):
+        UserBan.objects.create(
+            user=self.author_user, ban_type=BAN_TYPE_SHADOW,
+            expires=timezone.now() - timedelta(days=1))
+
+        self._assert_all_visible("an expired shadow ban")
+
+    def test_outright_ban_does_not_hide_the_post(self):
+        """An outright ban stops the account from acting; it is not a content
+        takedown, so it leaves the already-approved post visible — matching what
+        signed-in viewers see."""
+        UserBan.objects.create(user=self.author_user, ban_type=BAN_TYPE_OUTRIGHT)
+
+        self._assert_all_visible("an outright-banned author's post")
+
+    def test_restricted_audience_posts_are_not_public(self):
+        for audience in (POST_AUDIENCE_FOLLOWING, POST_AUDIENCE_FRIENDS, POST_AUDIENCE_FAMILY):
+            with self.subTest(audience=audience):
+                Post.objects.filter(pk=self.post.pk).update(audience=audience)
+                self._assert_all_hidden(f"an audience={audience} post")
+
+    def test_verified_minors_post_is_not_public(self):
+        """Adults and verified minors are mutually invisible (issue #329), and an
+        anonymous visitor's age is unknown — so it sits in the adult band and a
+        minor's post is never served to the open internet."""
+        get_user_model().objects.filter(username=self.author['username']).update(
+            identity_is_verified=True, is_adult=False)
+
+        self._assert_all_hidden("a verified minor's post")
+
+    def test_verified_adults_post_stays_public(self):
+        get_user_model().objects.filter(username=self.author['username']).update(
+            identity_is_verified=True, is_adult=True)
+
+        self._assert_all_visible("a verified adult's post")
+
+    def test_hidden_comment_is_dropped_from_a_public_thread(self):
+        self.comment.hidden = True
+        self.comment.save()
+
+        # The post is still public, but the thread has nothing left to show.
+        self.assertEqual(self.client.get(self.details_url).status_code, 200)
+        self.assertEqual(self.client.get(self.comments_url).json(), [])
+        self.assertEqual(self.client.get(self.thread_url).json(), [])
+
+    def test_restricted_audience_comment_is_dropped_from_a_public_thread(self):
+        Comment.objects.filter(pk=self.comment.pk).update(audience=POST_AUDIENCE_FRIENDS)
+
+        self.assertEqual(self.client.get(self.comments_url).json(), [])
+        self.assertEqual(self.client.get(self.thread_url).json(), [])
+
+    def test_shadow_banned_commenters_comment_is_dropped(self):
+        UserBan.objects.create(
+            user=get_user_with_username(self.commenter['username']), ban_type=BAN_TYPE_SHADOW)
+
+        self.assertEqual(self.client.get(self.comments_url).json(), [])
+        self.assertEqual(self.client.get(self.thread_url).json(), [])
+
+    def test_thread_on_a_non_public_post_returns_not_found(self):
+        """A leaked thread id must not become a back door into a restricted
+        post's conversation."""
+        Post.objects.filter(pk=self.post.pk).update(audience=POST_AUDIENCE_FRIENDS)
+
+        self.assertEqual(self.client.get(self.thread_url).status_code, 404)
+
+    def test_missing_thread_returns_not_found(self):
+        self.assertEqual(self.client.get(self._thread_url(uuid.uuid4())).status_code, 404)
+
+    # =========================================================================
+    # THE ANSWER DOES NOT DEPEND ON WHO IS ASKING
+    # =========================================================================
+
+    def test_author_gets_the_same_public_answer_for_their_own_hidden_post(self):
+        """The signed-in endpoints let an author see their own hidden post. The
+        public endpoints resolve against a fixed anonymous viewer instead, so a
+        logged-in browser and a crawler get identical bytes."""
+        self.post.hidden = True
+        self.post.hidden_reason = HIDDEN_REASON_CLASSIFIER
+        self.post.save()
+
+        header = {'HTTP_AUTHORIZATION': f"Bearer {self.author[Fields.session_management_token]}"}
+        self.assertEqual(self.client.get(self.details_url, **header).status_code, 404)
+
+        # ...while the authenticated endpoint still shows it to its author.
+        private_url = reverse('get_post_details', kwargs={'post_identifier': str(self.post_identifier)})
+        self.assertEqual(self.client.get(private_url, **header).status_code, 200)
+
+    # =========================================================================
+    # INPUT VALIDATION
+    # =========================================================================
+
+    def test_below_zero_batch_does_not_route(self):
+        # The URL converter only accepts non-negative ints, so a below-zero batch
+        # never routes; the guard in the view is the belt to that suspenders.
+        self.assertEqual(self.client.get(f'/user_index/public/posts/{self.post_identifier}/comments/-1/').status_code,
+                         404)
+
+    def test_non_uuid_identifier_does_not_route(self):
+        self.assertEqual(self.client.get('/user_index/public/posts/not-a-uuid/details/').status_code, 404)
+
+    def test_post_method_not_allowed(self):
+        """These are read-only endpoints."""
+        self.assertEqual(self.client.post(self.details_url).status_code, 405)
+
+
+class PublicShareThreadOrderingTests(PositiveOnlySocialTestCase):
+    """Public threads/comments come back through the same ranking and batching
+    the signed-in endpoints use, so a shared link shows the same conversation."""
+
+    def setUp(self):
+        super().setUp()
+        self.make_many_comments_on_thread(num=3)
+        self.post = Post.objects.get(post_identifier=self.post_identifier)
+        self.thread = CommentThread.objects.get(
+            comment_thread_identifier=self.comment_thread_identifier)
+
+    def test_every_visible_comment_in_the_thread_is_served(self):
+        url = reverse('get_public_comments_for_thread', kwargs={
+            'comment_thread_identifier': str(self.comment_thread_identifier), 'batch': 0})
+
+        comments = self.client.get(url).json()
+
+        self.assertEqual(len(comments), self.thread.comment_set.count())
+
+    def test_like_counts_are_not_inflated_by_the_audience_join(self):
+        """The like count is computed off a clean queryset (mirroring
+        get_comments_for_thread), so an author's follow edges cannot multiply
+        it."""
+        url = reverse('get_public_comments_for_thread', kwargs={
+            'comment_thread_identifier': str(self.comment_thread_identifier), 'batch': 0})
+
+        for comment in self.client.get(url).json():
+            self.assertEqual(comment[Fields.comment_likes], 0)

--- a/backend/user_system/tests/test_public_share_views.py
+++ b/backend/user_system/tests/test_public_share_views.py
@@ -123,6 +123,24 @@ class PublicShareViewTests(PositiveOnlySocialTestCase):
         for field in (Fields.is_liked, Fields.is_reported, Fields.report_reason):
             self.assertNotIn(field, comment)
 
+    def test_public_comment_likes_count_reflects_real_likes(self):
+        """The batch like-count query is keyed on the comment's primary key,
+        which for Comment *is* comment_identifier (a UUID PK), so the per-comment
+        lookup resolves. Asserting a non-zero count is what proves that — a test
+        that only ever sees 0 would pass just as happily with a broken key."""
+        liker = self.make_user_with_prefix(prefix='liker')
+        like_url = reverse('like_comment', kwargs={
+            'post_identifier': str(self.post_identifier),
+            'comment_thread_identifier': str(self.thread_identifier),
+            'comment_identifier': str(self.comment_identifier),
+        })
+        header = {'HTTP_AUTHORIZATION': f"Bearer {liker[Fields.session_management_token]}"}
+        self.assertEqual(self.client.post(like_url, **header).status_code, 200)
+
+        comments = self.client.get(self.thread_url).json()
+
+        self.assertEqual(comments[0][Fields.comment_likes], 1)
+
     def test_public_post_likes_count_reflects_real_likes(self):
         like_url = reverse('like_post', kwargs={'post_identifier': str(self.post_identifier)})
         header = {'HTTP_AUTHORIZATION': f"Bearer {self.commenter[Fields.session_management_token]}"}

--- a/backend/user_system/tests/test_public_share_views.py
+++ b/backend/user_system/tests/test_public_share_views.py
@@ -217,6 +217,16 @@ class PublicShareViewTests(PositiveOnlySocialTestCase):
         self.assertEqual(self.client.get(self.comments_url).json(), [])
         self.assertEqual(self.client.get(self.thread_url).json(), [])
 
+    def test_verified_minors_comment_is_dropped_from_a_public_post(self):
+        """The age-band rule applies per author, so a minor's comment is no more
+        public than a minor's post — even on an adult's public post."""
+        get_user_model().objects.filter(username=self.commenter['username']).update(
+            identity_is_verified=True, is_adult=False)
+
+        self.assertEqual(self.client.get(self.details_url).status_code, 200)
+        self.assertEqual(self.client.get(self.comments_url).json(), [])
+        self.assertEqual(self.client.get(self.thread_url).json(), [])
+
     def test_shadow_banned_commenters_comment_is_dropped(self):
         UserBan.objects.create(
             user=get_user_with_username(self.commenter['username']), ban_type=BAN_TYPE_SHADOW)

--- a/backend/user_system/urls.py
+++ b/backend/user_system/urls.py
@@ -163,8 +163,10 @@ urlpatterns = [
     # =========================================================================
     # These back a shared https://smiling.social/post/<id> link for a recipient
     # who has no account. They serve only public, approved, non-shadow-banned
-    # content by an adult author; everything else 404s exactly like a missing
-    # post. See the PUBLIC SHARE VIEWS section in views.py.
+    # content whose author is not a verified minor — an account that never
+    # verified an age has an unknown one and stays in the general pool, so
+    # "not a verified minor" is the rule, not "an adult". Everything else 404s
+    # exactly like a missing post. See the PUBLIC SHARE VIEWS section in views.py.
 
     # GET /public/posts/<uuid:post_identifier>/details/
     path('public/posts/<uuid:post_identifier>/details/', views.get_public_post_details,

--- a/backend/user_system/urls.py
+++ b/backend/user_system/urls.py
@@ -159,6 +159,31 @@ urlpatterns = [
         views.retract_report_comment, name='retract_report_comment'),
 
     # =========================================================================
+    # PUBLIC SHARE VIEWS (issue #381) — no token, IP rate limited
+    # =========================================================================
+    # These back a shared https://smiling.social/post/<id> link for a recipient
+    # who has no account. They serve only public, approved, non-shadow-banned
+    # content by an adult author; everything else 404s exactly like a missing
+    # post. See the PUBLIC SHARE VIEWS section in views.py.
+
+    # GET /public/posts/<uuid:post_identifier>/details/
+    path('public/posts/<uuid:post_identifier>/details/', views.get_public_post_details,
+         name='get_public_post_details'),
+
+    # GET /public/posts/<uuid:post_identifier>/comments/<int:batch>/
+    path('public/posts/<uuid:post_identifier>/comments/<int:batch>/', views.get_public_comments_for_post,
+         name='get_public_comments_for_post'),
+
+    # GET /public/threads/<uuid:comment_thread_identifier>/comments/<int:batch>/
+    path('public/threads/<uuid:comment_thread_identifier>/comments/<int:batch>/',
+         views.get_public_comments_for_thread, name='get_public_comments_for_thread'),
+
+    # GET /public/posts/<uuid:post_identifier>/preview/ — Open Graph HTML for
+    # link-preview crawlers, which CloudFront routes here by user-agent.
+    path('public/posts/<uuid:post_identifier>/preview/', views.get_post_link_preview,
+         name='get_post_link_preview'),
+
+    # =========================================================================
     # USER & PROFILE
     # =========================================================================
     # GET /users/search/<str:username_fragment>/ (Token in header)

--- a/backend/user_system/views.py
+++ b/backend/user_system/views.py
@@ -16,14 +16,14 @@ from django.contrib.auth.hashers import check_password, make_password
 from django.core.mail import send_mail
 from django.db import transaction, IntegrityError
 from django.db.models import Count, Max, OuterRef, Subquery
-from django.http import JsonResponse
+from django.http import HttpResponse, JsonResponse
 from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST, require_GET, require_http_methods
 from django_ratelimit.decorators import ratelimit
 from django_ratelimit.exceptions import Ratelimited
 
-from . import tasks
+from . import link_preview, tasks
 from .classifiers import image_classifier, text_classifier, interest_classifier
 from .classifiers.classifier_constants import REASON_PHRASES, GENERIC_REASON_CODE
 from .classifiers.prefilter import prefilter_text
@@ -60,7 +60,7 @@ from .s3 import delete_image, generate_presigned_upload, image_url_to_key, is_so
     strip_query_and_fragment
 from .tags import set_post_tags
 from .visibility import audience_admits, can_view_post, in_same_age_band, searchable_users, \
-    visible_comment_threads, visible_comments, visible_posts
+    visible_comment_threads, visible_comments, visible_posts, PUBLIC_VIEWER
 
 
 def _age_from_dob(dob):
@@ -3186,6 +3186,223 @@ def get_comments_for_thread(request, comment_thread_identifier, batch):
         for comment in batched_comments
     ]
     return log_and_return_json("get_comments_for_thread", comments_data, safe=False)
+
+
+# =============================================================================
+# PUBLIC (SIGNED-OUT) SHARE VIEWS — issue #381
+# =============================================================================
+#
+# A shared link (`https://smiling.social/post/<id>`, optionally with a
+# `#comment-<id>` fragment) has to open something usable for a recipient who has
+# no account. These endpoints are the read-only, unauthenticated half of that:
+# the post, its comment threads, and an HTML document a link-preview crawler can
+# unfurl.
+#
+# Every one of them resolves visibility against `PUBLIC_VIEWER` rather than
+# `request.user`, so the answer does not depend on who is asking — a signed-in
+# browser, a signed-out one, and Slack's crawler all get identical bytes. That
+# makes the public surface exactly: not hidden, not pending, not a
+# final-rejection tombstone, author not shadow banned, `audience` public, and
+# author not a verified minor. Anything else is reported as 404, the same as a
+# post that never existed, so the endpoints cannot be used to probe moderation
+# state or enumerate restricted-audience posts.
+#
+# They are rate limited by client IP (there is no user to key on) and never
+# serialize per-viewer state (is_liked / is_saved / is_reported / report_reason)
+# or the author-only classification fields — there is no viewer to have it.
+
+# Comment exposure for the `#comment-<id>` fragment shipped in Scope A (#34):
+# the public view serves the *whole* thread list, exactly like the signed-in
+# view, and the fragment is resolved client-side by scrolling to that comment.
+# Serving a single comment in isolation would strip the conversation a shared
+# reply only makes sense inside of, and would need its own endpoint to say
+# "this comment lives in that thread" anyway.
+
+def _public_post_fields(post):
+    """A post serialized for a signed-out viewer.
+
+    The signed-in payload minus everything that is about the viewer: no
+    like/save/report flags (nobody to have them) and no author-only
+    classification status (a public post is approved by construction)."""
+    return {
+        Fields.post_identifier: post.post_identifier,
+        Fields.image_url: sign_compressed_url(post.image_url),
+        # Full-res original, used as a client fallback while the async
+        # Lambda-generated compressed copy is still missing (#252/#254).
+        Fields.original_image_url: sign_original_url(post.image_url),
+        Fields.image_blurhash: post.image_blurhash,
+        Fields.caption: post.caption,
+        **_caption_style_fields(post),
+        Fields.creation_time: post.creation_time,
+        Fields.post_likes: post.postlike_set.count(),
+        Fields.author_username: post.author.username,
+        Fields.audience: post.audience,
+        **_author_avatar_fields(post.author),
+        **_post_tags(post),
+    }
+
+
+def _get_public_post(post_identifier):
+    """The post behind a shared link, or None when it is missing or not public.
+
+    Collapsing "no such post" and "not publicly visible" into one None is the
+    point: callers turn both into the same 404."""
+    if not is_valid_pattern(post_identifier, Patterns.uuid4):
+        return None
+    post = get_post_with_identifier(post_identifier)
+    if post is None or not can_view_post(post, PUBLIC_VIEWER):
+        return None
+    return post
+
+
+@ratelimit(key=_get_client_ip, rate='60/m', block=True)
+@require_GET
+def get_public_post_details(request, post_identifier):
+    """A shared post, for a recipient who is not logged in (issue #381)."""
+    logger.info("Endpoint get_public_post_details invoked by IP")
+    post = _get_public_post(post_identifier)
+    if post is None:
+        logger.warning(f"Public post details failed: Post {post_identifier} not publicly visible")
+        return log_and_return_json(
+            "get_public_post_details", {'error': "No post with that identifier"}, status=404)
+    return log_and_return_json("get_public_post_details", _public_post_fields(post))
+
+
+@ratelimit(key=_get_client_ip, rate='60/m', block=True)
+@require_GET
+def get_public_comments_for_post(request, post_identifier, batch):
+    """Comment threads on a shared post, for a signed-out viewer.
+
+    No `?category=` filter: the relationship toggle (issue #445) is meaningless
+    without a viewer to have relationships."""
+    logger.info("Endpoint get_public_comments_for_post invoked by IP")
+    if batch < 0:
+        return log_and_return_json(
+            "get_public_comments_for_post", {'error': "Invalid batch parameter"}, status=400)
+
+    post = _get_public_post(post_identifier)
+    if post is None:
+        logger.warning(f"Public comments for post failed: Post {post_identifier} not publicly visible")
+        return log_and_return_json(
+            "get_public_comments_for_post", {'error': "No post with that identifier"}, status=404)
+
+    comment_threads = visible_comment_threads(post.commentthread_set.all(), PUBLIC_VIEWER)
+    relevant_comment_threads = feed_algorithm_class.get_comment_threads_weighted_for_post(comment_threads)
+    if not relevant_comment_threads.count() > 0:
+        return log_and_return_json("get_public_comments_for_post", [], safe=False)
+
+    batched_comment_threads = get_batch(batch, COMMENT_THREAD_BATCH_SIZE, relevant_comment_threads)
+    data = [{Fields.comment_thread_identifier: ct.comment_thread_identifier} for ct in batched_comment_threads]
+    return log_and_return_json("get_public_comments_for_post", data, safe=False)
+
+
+@ratelimit(key=_get_client_ip, rate='60/m', block=True)
+@require_GET
+def get_public_comments_for_thread(request, comment_thread_identifier, batch):
+    """Comments within a thread on a shared post, for a signed-out viewer.
+
+    A thread on a post that is not publicly visible 404s even when the thread id
+    is known, so a leaked thread id cannot be used to read a restricted post's
+    conversation."""
+    logger.info("Endpoint get_public_comments_for_thread invoked by IP")
+    if not is_valid_pattern(comment_thread_identifier, Patterns.uuid4):
+        return log_and_return_json(
+            "get_public_comments_for_thread", {'error': "Invalid comment thread identifier"}, status=400)
+    if batch < 0:
+        return log_and_return_json(
+            "get_public_comments_for_thread", {'error': "Invalid batch parameter"}, status=400)
+
+    comment_thread = get_comment_thread_with_identifier(comment_thread_identifier)
+    if not comment_thread or not can_view_post(comment_thread.post, PUBLIC_VIEWER):
+        logger.warning(
+            f"Public comments for thread failed: Thread {comment_thread_identifier} not publicly visible")
+        return log_and_return_json(
+            "get_public_comments_for_thread", {'error': "No comment thread with that identifier"}, status=404)
+
+    # Mirrors get_comments_for_thread: resolve the visible ids first, then rank a
+    # clean queryset built from them, so the audience join's fan-out cannot
+    # inflate the like-count weighting.
+    visible_comment_ids = visible_comments(
+        comment_thread.comment_set.all(), PUBLIC_VIEWER
+    ).values_list('comment_identifier', flat=True)
+    comments = Comment.objects.filter(
+        comment_identifier__in=visible_comment_ids
+    ).select_related('author')
+    relevant_comments = feed_algorithm_class.get_comments_weighted_for_thread(comments)
+    if not relevant_comments.count() > 0:
+        return log_and_return_json("get_public_comments_for_thread", [], safe=False)
+
+    batched_comments = get_batch(batch, COMMENT_BATCH_SIZE, relevant_comments)
+    # Like counts for the whole batch in one grouped query (no N+1 COUNT).
+    like_counts = dict(
+        CommentLike.objects
+        .filter(comment__in=batched_comments)
+        .values('comment_id')
+        .annotate(count=Count('comment_id'))
+        .values_list('comment_id', 'count')
+    )
+    comments_data = [
+        {
+            Fields.comment_identifier: comment.comment_identifier,
+            Fields.body: comment.body,
+            Fields.body_formatting: comment.body_formatting,
+            Fields.audience: comment.audience,
+            Fields.author_username: comment.author.username,
+            **_author_avatar_fields(comment.author),
+            Fields.creation_time: comment.creation_time,
+            Fields.updated_time: comment.updated_time,
+            Fields.comment_likes: like_counts.get(comment.comment_identifier, 0),
+        }
+        for comment in batched_comments
+    ]
+    return log_and_return_json("get_public_comments_for_thread", comments_data, safe=False)
+
+
+def _post_canonical_url(post_identifier):
+    """The website URL a shared post link points at — the URL that was shared,
+    and the one a preview must declare as canonical."""
+    return f"{settings.FRONTEND_BASE_URL}/post/{post_identifier}"
+
+
+@ratelimit(key=_get_client_ip, rate='60/m', block=True)
+@require_GET
+def get_post_link_preview(request, post_identifier):
+    """Open Graph / Twitter Card HTML for a shared post link (issue #381).
+
+    The website is a client-only SPA, so a crawler fetching
+    `https://smiling.social/post/<id>` sees an empty root div. CloudFront routes
+    crawler user-agents here instead (see `website/cloudfront/link-preview.js`),
+    and this returns a tiny meta-only document describing the post.
+
+    A post that is missing or not publicly visible gets the generic site card
+    with a 404 status rather than an error page, so a crawler unfurls something
+    sane and cannot tell the two cases apart.
+
+    The response is cached only briefly: `og:image` is a CloudFront-signed URL
+    that expires, so a long-lived cached document would eventually hand crawlers
+    an image they cannot fetch.
+    """
+    logger.info("Endpoint get_post_link_preview invoked by IP")
+    post = _get_public_post(post_identifier)
+    if post is None:
+        logger.warning(f"Post link preview failed: Post {post_identifier} not publicly visible")
+        response = HttpResponse(
+            link_preview.render_missing_preview(site_url=settings.FRONTEND_BASE_URL),
+            content_type='text/html; charset=utf-8',
+            status=404,
+        )
+    else:
+        response = HttpResponse(
+            link_preview.render_post_preview(
+                title=f"{post.author.username} on {link_preview.SITE_NAME}",
+                description=link_preview.truncate_description(post.caption),
+                canonical_url=_post_canonical_url(post.post_identifier),
+                image_url=sign_compressed_url(post.image_url),
+            ),
+            content_type='text/html; charset=utf-8',
+        )
+    response['Cache-Control'] = 'public, max-age=300'
+    return response
 
 
 # =============================================================================

--- a/backend/user_system/views.py
+++ b/backend/user_system/views.py
@@ -3262,7 +3262,11 @@ def get_public_post_details(request, post_identifier):
     logger.info("Endpoint get_public_post_details invoked by IP")
     post = _get_public_post(post_identifier)
     if post is None:
-        logger.warning(f"Public post details failed: Post {post_identifier} not publicly visible")
+        # No explicit warning here: log_and_return_json already logs one for any
+        # status >= 400, and on an unauthenticated endpoint a 404 is a routine
+        # outcome anyone can trigger at will (a link to a deleted post, a probed
+        # uuid). Logging it twice at warning level is how a real signal gets
+        # buried. Same below, and in the other public views.
         return log_and_return_json(
             "get_public_post_details", {'error': "No post with that identifier"}, status=404)
     return log_and_return_json("get_public_post_details", _public_post_fields(post))
@@ -3282,7 +3286,6 @@ def get_public_comments_for_post(request, post_identifier, batch):
 
     post = _get_public_post(post_identifier)
     if post is None:
-        logger.warning(f"Public comments for post failed: Post {post_identifier} not publicly visible")
         return log_and_return_json(
             "get_public_comments_for_post", {'error': "No post with that identifier"}, status=404)
 
@@ -3314,8 +3317,6 @@ def get_public_comments_for_thread(request, comment_thread_identifier, batch):
 
     comment_thread = get_comment_thread_with_identifier(comment_thread_identifier)
     if not comment_thread or not can_view_post(comment_thread.post, PUBLIC_VIEWER):
-        logger.warning(
-            f"Public comments for thread failed: Thread {comment_thread_identifier} not publicly visible")
         return log_and_return_json(
             "get_public_comments_for_thread", {'error': "No comment thread with that identifier"}, status=404)
 
@@ -3385,7 +3386,11 @@ def get_post_link_preview(request, post_identifier):
     logger.info("Endpoint get_post_link_preview invoked by IP")
     post = _get_public_post(post_identifier)
     if post is None:
-        logger.warning(f"Post link preview failed: Post {post_identifier} not publicly visible")
+        # info, not warning: this path builds its own response rather than going
+        # through log_and_return_json, and unfurling a link to a since-deleted
+        # or moderated post is the expected case it exists to handle, not a
+        # problem worth paging anyone about.
+        logger.info(f"Post link preview: Post {post_identifier} not publicly visible")
         response = HttpResponse(
             link_preview.render_missing_preview(site_url=settings.FRONTEND_BASE_URL),
             content_type='text/html; charset=utf-8',

--- a/backend/user_system/visibility.py
+++ b/backend/user_system/visibility.py
@@ -9,6 +9,22 @@ from .constants import (
 from .models import Comment, UserBan, UserFollow
 
 
+# The viewer a signed-out visitor is represented by on the public share
+# endpoints (issue #381). Every helper below already reads a `None` viewer
+# correctly, so passing it through yields exactly the public rule without a
+# parallel set of query builders:
+#   - `Q(author=viewer)` becomes `author IS NULL`, which matches nothing (the FK
+#     is non-null), so the "you always see your own content" branch never fires
+#     and pending/hidden/report-hidden content stays invisible;
+#   - `_audience_q` / `_audience_allows` fall through to public-audience only,
+#     since an anonymous visitor is on nobody's follow list;
+#   - `_same_age_band_q` / `in_same_age_band` treat an unknown age as the adult
+#     band, so a verified minor's post is never served to the open internet.
+# Passed explicitly (rather than defaulting to `request.user`) so a signed-in
+# browser hitting a public URL gets the same bytes a crawler would.
+PUBLIC_VIEWER = None
+
+
 def _shadow_banned_user_ids():
     """User ids with a shadow ban currently in effect, usable as a subquery."""
     return UserBan.objects.active().filter(ban_type=BAN_TYPE_SHADOW).values_list('user_id', flat=True)

--- a/ios/DEEP_LINKING.md
+++ b/ios/DEEP_LINKING.md
@@ -1,0 +1,58 @@
+# iOS Universal Links (issue #382)
+
+A shared `https://smiling.social/post/<id>` link opens the app instead of Safari
+when the app is installed. If it isn't, the link opens the public web page
+(issue #381) — so nothing about this is load-bearing: a failed association just
+means links keep opening the browser.
+
+## What's wired (code)
+
+- `Positive Only Social.entitlements` carries
+  `com.apple.developer.associated-domains` = `applinks:smiling.social` and
+  `applinks:www.smiling.social`.
+- `VibesHelpers/ShareURL.swift` — `ShareURL.parse(_:)` turns an incoming URL
+  into a `SharedPostLink` (post id plus the optional `#comment-<id>` fragment),
+  or nil when the URL is not one of ours. It is the exact inverse of the
+  `ShareURL.post` / `ShareURL.comment` builders the share sheet uses, and is
+  unit tested in `Positive_Only_SocialTests_ShareURL`.
+- `Positive_Only_SocialApp.swift` — `.onOpenURL` parses the URL and hands the
+  post id to `PushRouter`, the same bus a tapped push notification writes to.
+  That is deliberate: the post detail lives inside `HomeView`, which only exists
+  once logged in, so a link opened while signed out parks there and routes as
+  soon as the user logs in rather than pushing an authenticated screen out of
+  the Welcome flow.
+- `https://smiling.social/.well-known/apple-app-site-association` is served from
+  `website/public/.well-known/`, published by `website/deploy-web.sh` with an
+  explicit `application/json` content type (the file has no extension, so a
+  plain `s3 sync` would guess `binary/octet-stream` and iOS would reject it).
+
+Only `/post/*` is claimed. Every other route belongs to the website, and
+claiming them would hijack links the app has no screen for.
+
+## To enable it (Apple Developer portal)
+
+1. Enable the **Associated Domains** capability on the App ID
+   `com.katsonsoftware.goodvibesonly`, then regenerate and re-download the
+   provisioning profiles. Without this the entitlement is present in the source
+   but signing fails, or the association is silently ignored.
+2. Deploy the website so the AASA file is live at
+   `https://smiling.social/.well-known/apple-app-site-association` over https,
+   with no redirect, as `application/json`. Apple's CDN fetches it — allow time
+   for it to pick up a change.
+3. Install the app (a fresh install or an update triggers the association
+   check) and tap a shared link from another app, e.g. Messages.
+
+Verify with `https://app-site-association.cdn-apple.com/a/v1/smiling.social`,
+which shows what Apple's CDN currently has cached for the domain.
+
+## Notes
+
+- The `appIDs` entry is `<Team ID>.<bundle id>` — `7L9M852R4K` and
+  `com.katsonsoftware.goodvibesonly`, both already in `project.pbxproj`. Change
+  either and the AASA file has to change with it.
+- CI overrides entitlements away with `CODE_SIGN_ENTITLEMENTS=""`
+  (`ios-tests.yml`), so the associated-domains key never reaches what the runner
+  builds — same as `aps-environment`, see `PUSH_SETUP.md`.
+- A `#comment-<id>` fragment is parsed and carried on `SharedPostLink`, and the
+  post opens. Scrolling to that specific comment is web-only today; the parsed
+  id is there for whoever wires it up.

--- a/ios/Positive Only Social/Positive Only Social/Positive Only Social.entitlements
+++ b/ios/Positive Only Social/Positive Only Social/Positive Only Social.entitlements
@@ -4,5 +4,14 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<!-- Universal Links for shared post links (issue #382). Both hosts serve
+	     the same site, so a link shared with the www. prefix opens the app too.
+	     Requires https://smiling.social/.well-known/apple-app-site-association
+	     to list this app id — see website/public/.well-known/. -->
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:smiling.social</string>
+		<string>applinks:www.smiling.social</string>
+	</array>
 </dict>
 </plist>

--- a/ios/Positive Only Social/Positive Only Social/VibesHelpers/Positive_Only_SocialApp.swift
+++ b/ios/Positive Only Social/Positive Only Social/VibesHelpers/Positive_Only_SocialApp.swift
@@ -59,12 +59,24 @@ struct Positive_Only_SocialApp: App {
     var body: some Scene {
         WindowGroup {
             // If logged in, show HomeView. Otherwise, show WelcomeView.
-            if authManager.isLoggedIn {
-                HomeView(api: api, keychainHelper: keychainHelper)
-                    .environmentObject(authManager) // Make the manager available to all subviews
-            } else {
-                WelcomeView(api: api, keychainHelper: keychainHelper)
-                    .environmentObject(authManager)
+            Group {
+                if authManager.isLoggedIn {
+                    HomeView(api: api, keychainHelper: keychainHelper)
+                        .environmentObject(authManager) // Make the manager available to all subviews
+                } else {
+                    WelcomeView(api: api, keychainHelper: keychainHelper)
+                        .environmentObject(authManager)
+                }
+            }
+            // A shared https://smiling.social/post/<id> link opened this app as
+            // a Universal Link (issue #382). Route it through the same bus a
+            // tapped push notification uses: HomeView consumes the pending id,
+            // so a link opened while signed out simply waits there until the
+            // user logs in rather than pushing an authenticated screen out of
+            // the Welcome flow. A URL that isn't one of ours is ignored.
+            .onOpenURL { url in
+                guard let link = ShareURL.parse(url) else { return }
+                PushRouter.shared.openPost(link.postIdentifier)
             }
         }
     }

--- a/ios/Positive Only Social/Positive Only Social/VibesHelpers/ShareURL.swift
+++ b/ios/Positive Only Social/Positive Only Social/VibesHelpers/ShareURL.swift
@@ -5,16 +5,27 @@
 
 import Foundation
 
-/// Builds website links for the iOS native share sheet (issue #34).
-///
-/// Scope A only: the shared content is a plain URL to the web app — no
-/// deep-linking into the app and no backend changes. These links currently
-/// require login on the website, which is expected for Scope A; making them
-/// publicly viewable / deep-linking into the app is a tracked follow-up
-/// (Scope B) and deliberately not attempted here.
-///
-/// The builders are pure functions (no I/O, no UIKit) so they're easy to unit
-/// test — see `Positive_Only_SocialTests_ShareURL`.
+// Both ends of a shared post link: the URL a post or comment is shared as
+// (issue #34), and the app-side parse of the same URL when iOS hands it back as
+// a Universal Link (issue #382).
+//
+// The website renders these links for signed-out recipients too (issue #381),
+// so a link is useful whether or not the app is installed — which is exactly
+// what makes claiming them with `applinks:smiling.social` safe: a device
+// without the app just opens the web page.
+//
+// Everything here is a pure function (no I/O, no UIKit) so it's easy to unit
+// test — see `Positive_Only_SocialTests_ShareURL`.
+
+/// A shared link that resolved to a post, and optionally to one comment on it.
+struct SharedPostLink: Equatable {
+    let postIdentifier: String
+    /// The comment a `#comment-<id>` fragment named, or nil for a plain post
+    /// link. Carried so a comment link routes to its post rather than being
+    /// rejected outright; the app opens the post detail either way.
+    let commentIdentifier: String?
+}
+
 enum ShareURL {
 
     /// The deployed web app's base URL. The share links point at the website
@@ -42,5 +53,48 @@ enum ShareURL {
         // so an identifier with reserved characters still yields a valid link.
         components.fragment = "comment-\(commentIdentifier)"
         return components.url
+    }
+
+    /// The website hosts this app claims as Universal Links. Both are listed in
+    /// the `associated-domains` entitlement and both serve the same site, so a
+    /// link shared with the `www.` prefix opens the app too.
+    static let linkHosts: Set<String> = ["smiling.social", "www.smiling.social"]
+
+    /// The inverse of the builders above: what a Universal Link opened by the
+    /// system refers to, or nil when the URL is not one of ours (issue #382).
+    ///
+    /// Deliberately strict. `.onOpenURL` receives whatever the system hands the
+    /// app, so the host, scheme and path shape are all checked before the
+    /// identifier is used to navigate — a URL that merely looks similar must not
+    /// send the user somewhere unexpected. A trailing slash is tolerated because
+    /// chat apps and link shorteners add one freely.
+    static func parse(_ url: URL) -> SharedPostLink? {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              components.scheme?.lowercased() == "https",
+              let host = components.host,
+              linkHosts.contains(host.lowercased()) else {
+            return nil
+        }
+
+        // ["", "post", "<id>"] for /post/<id>, with a trailing "" for a trailing
+        // slash. Anything longer is a different route we don't claim.
+        var segments = components.path.split(separator: "/", omittingEmptySubsequences: false).map(String.init)
+        if segments.last == "" { segments.removeLast() }
+        guard segments.count == 3, segments[0] == "", segments[1] == "post" else { return nil }
+
+        let postIdentifier = segments[2]
+        guard !postIdentifier.isEmpty else { return nil }
+
+        // URLComponents hands back the decoded fragment, matching what
+        // `comment(postIdentifier:commentIdentifier:)` encoded. An unrecognized
+        // fragment is ignored rather than failing the whole link: the post is
+        // still the right destination.
+        var commentIdentifier: String?
+        if let fragment = components.fragment, fragment.hasPrefix("comment-") {
+            let identifier = String(fragment.dropFirst("comment-".count))
+            if !identifier.isEmpty { commentIdentifier = identifier }
+        }
+
+        return SharedPostLink(postIdentifier: postIdentifier, commentIdentifier: commentIdentifier)
     }
 }

--- a/ios/Positive Only Social/Positive Only Social/state/PushRouter.swift
+++ b/ios/Positive Only Social/Positive Only Social/state/PushRouter.swift
@@ -8,13 +8,20 @@
 import Foundation
 import Combine
 
-/// A tiny shared bus the notification handler writes to and the UI observes, so
-/// tapping a "post rejected" notification opens that post. Kept separate from
-/// the notification plumbing so views depend only on this, not on UIKit/APNs.
+/// A tiny shared bus that writes "open this post" requests to the UI. Two things
+/// produce them: tapping a "post rejected" notification (issues #342/#343), and
+/// opening a shared `https://smiling.social/post/<id>` link as a Universal Link
+/// (issue #382). Kept separate from both bits of plumbing so views depend only
+/// on this, not on UIKit/APNs or URL parsing.
+///
+/// The request parks here until something consumes it, which is what makes a
+/// link opened while signed out work: `HomeView` only exists once logged in, so
+/// the id waits and routes as soon as it mounts rather than pushing an
+/// authenticated screen out of the Welcome flow.
 ///
 /// Push is a nudge, never the source of truth (#282 in-app reconciliation is):
-/// if nothing observes this — the app is mid-launch, the tab isn't mounted — the
-/// pending id is simply cleared and the user still finds the outcome in-app.
+/// if nothing ever observes this the pending id is simply cleared and the user
+/// still finds the outcome in-app.
 final class PushRouter: ObservableObject {
     static let shared = PushRouter()
 

--- a/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_ShareURL.swift
+++ b/ios/Positive Only Social/Positive Only SocialTests/Positive_Only_SocialTests_ShareURL.swift
@@ -40,4 +40,61 @@ struct Positive_Only_SocialTests_ShareURL {
         let url = ShareURL.post("xyz")
         #expect(url?.absoluteString.hasPrefix(ShareURL.webBaseURL) == true)
     }
+
+    // MARK: - Universal Link parsing (issue #382)
+
+    @Test func parseReadsBackTheLinksTheBuildersProduce() throws {
+        // Round trip: whatever we hand the share sheet, iOS can hand back.
+        let postURL = try #require(ShareURL.post("abc123"))
+        #expect(ShareURL.parse(postURL) == SharedPostLink(postIdentifier: "abc123",
+                                                          commentIdentifier: nil))
+
+        let commentURL = try #require(
+            ShareURL.comment(postIdentifier: "abc123", commentIdentifier: "def456"))
+        #expect(ShareURL.parse(commentURL) == SharedPostLink(postIdentifier: "abc123",
+                                                             commentIdentifier: "def456"))
+    }
+
+    @Test func parseAcceptsTheWwwHost() throws {
+        // Both hosts are claimed in the associated-domains entitlement.
+        let url = try #require(URL(string: "https://www.smiling.social/post/abc123"))
+        #expect(ShareURL.parse(url)?.postIdentifier == "abc123")
+    }
+
+    @Test func parseIsCaseInsensitiveAboutTheHost() throws {
+        let url = try #require(URL(string: "https://SMILING.social/post/abc123"))
+        #expect(ShareURL.parse(url)?.postIdentifier == "abc123")
+    }
+
+    @Test func parseToleratesATrailingSlash() throws {
+        // Chat apps and shorteners add one freely.
+        let url = try #require(URL(string: "https://smiling.social/post/abc123/"))
+        #expect(ShareURL.parse(url)?.postIdentifier == "abc123")
+    }
+
+    @Test func parseKeepsThePostWhenTheFragmentIsNotAComment() throws {
+        // An unrecognized fragment shouldn't cost the user the post.
+        let url = try #require(URL(string: "https://smiling.social/post/abc123#top"))
+        #expect(ShareURL.parse(url) == SharedPostLink(postIdentifier: "abc123",
+                                                      commentIdentifier: nil))
+    }
+
+    @Test func parseRejectsURLsThatAreNotOurs() throws {
+        // .onOpenURL receives whatever the system hands the app, so a URL that
+        // merely looks similar must not navigate anywhere.
+        let rejected = [
+            "https://smiling.social.evil.example/post/abc123",  // suffix, not our host
+            "https://evil.example/post/abc123",                 // wrong host entirely
+            "http://smiling.social/post/abc123",                // not https
+            "https://smiling.social/posts/abc123",              // different route
+            "https://smiling.social/post/",                     // no identifier
+            "https://smiling.social/post/abc123/extra",         // deeper path
+            "https://smiling.social/profile/ada",               // another route
+            "https://smiling.social/",                          // the site root
+        ]
+        for string in rejected {
+            let url = try #require(URL(string: string))
+            #expect(ShareURL.parse(url) == nil, "expected \(string) to be rejected")
+        }
+    }
 }

--- a/website/cloudfront/link-preview.js
+++ b/website/cloudfront/link-preview.js
@@ -1,0 +1,88 @@
+// CloudFront Function (viewer-request) for the website distribution — issue #381.
+//
+// The website is a client-only Vite SPA on S3, so every path CloudFront serves
+// returns the same index.html. A link-preview crawler never runs the router, so
+// a shared `https://smiling.social/post/<id>` link would unfurl as the generic
+// site card no matter which post it points at.
+//
+// This function redirects *crawlers only* to the backend's per-post Open Graph
+// document, which does know the post's title, caption and image. A real browser
+// is untouched and gets the SPA, which then renders the post itself through the
+// public endpoints — so the two paths never disagree about what is visible: the
+// preview endpoint applies the same public-visibility rule as the JSON API.
+//
+// A 302 (not a rewrite) is used deliberately: CloudFront Functions cannot pick
+// a different origin, and every major unfurler follows redirects and reads the
+// meta tags from the final URL. `Cache-Control: no-store` keeps the redirect
+// itself from being cached against a path a browser will later request.
+//
+// Deploy: CloudFront > distribution EMS8KP5TZ1KB3 > Functions, published and
+// associated with the default cache behavior on *viewer request*. Update
+// PREVIEW_ORIGIN if the API's base URL changes.
+//
+// Runs on the cloudfront-js-2.0 runtime: no ES modules, no async, no fetch.
+// Tested by link-preview.test.js, which loads this exact file.
+
+var PREVIEW_ORIGIN = 'https://api.smiling.social/user_index'
+
+// The unfurlers worth serving. Matching on an allowlist rather than "anything
+// that isn't a known browser" keeps a mis-detected human from being bounced off
+// the site — the cost of missing a crawler is a bland preview, the cost of a
+// false positive is a broken link.
+var CRAWLERS = new RegExp(
+  [
+    'facebookexternalhit',
+    'facebookcatalog',
+    'twitterbot',
+    'slackbot',
+    'slack-imgproxy',
+    'linkedinbot',
+    'discordbot',
+    'telegrambot',
+    'whatsapp',
+    'redditbot',
+    'pinterest',
+    'skypeuripreview',
+    'applebot',
+    'bingbot',
+    'googlebot',
+    'mastodon',
+    'bluesky',
+    'embedly',
+    'iframely',
+    'quora link preview',
+    'vkshare',
+    'snapchat',
+    'signal',
+  ].join('|'),
+  'i',
+)
+
+// `/post/<uuid>`, with or without a trailing slash. The uri CloudFront hands us
+// never includes the query string or the fragment, so a `#comment-<id>` link
+// resolves to the same preview as the post itself — which is correct: a shared
+// comment unfurls as the post it lives on.
+var POST_PATH = /^\/post\/([0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12})\/?$/
+
+function handler(event) {
+  var request = event.request
+
+  var match = POST_PATH.exec(request.uri)
+  if (!match) {
+    return request
+  }
+
+  var userAgent = request.headers['user-agent'] ? request.headers['user-agent'].value : ''
+  if (!CRAWLERS.test(userAgent)) {
+    return request
+  }
+
+  return {
+    statusCode: 302,
+    statusDescription: 'Found',
+    headers: {
+      location: { value: PREVIEW_ORIGIN + '/public/posts/' + match[1] + '/preview/' },
+      'cache-control': { value: 'no-store' },
+    },
+  }
+}

--- a/website/cloudfront/link-preview.test.js
+++ b/website/cloudfront/link-preview.test.js
@@ -1,0 +1,89 @@
+// Tests for the CloudFront viewer-request function that routes link-preview
+// crawlers to the backend's Open Graph document (issue #381).
+//
+// The function file is loaded and evaluated as source rather than imported:
+// CloudFront's runtime has no module system, so the deployable artifact cannot
+// carry an `export`. Reading it here means the tests exercise exactly the bytes
+// that get published, not a copy that can drift from them.
+
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const source = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), 'link-preview.js'),
+  'utf-8',
+)
+const handler = new Function(`${source}; return handler`)()
+
+const POST_ID = '3f1b9a2c-6d4e-4f8a-9b1c-2d3e4f5a6b7c'
+
+function request(uri, userAgent) {
+  const headers = userAgent === undefined ? {} : { 'user-agent': { value: userAgent } }
+  return handler({ request: { uri, headers } })
+}
+
+const CHROME =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0 Safari/537.36'
+
+describe('crawlers', () => {
+  it.each([
+    ['facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)'],
+    ['Twitterbot/1.0'],
+    ['Slackbot-LinkExpanding 1.0 (+https://api.slack.com/robots)'],
+    ['Mozilla/5.0 (compatible; Discordbot/2.0; +https://discordapp.com)'],
+    ['WhatsApp/2.23.20.0'],
+    ['Mozilla/5.0 (compatible; TelegramBot/1.0)'],
+    ['LinkedInBot/1.0 (compatible; Mozilla/5.0)'],
+    ['Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)'],
+  ])('%s is redirected to the preview endpoint', userAgent => {
+    const response = request(`/post/${POST_ID}`, userAgent)
+
+    expect(response.statusCode).toBe(302)
+    expect(response.headers.location.value).toBe(
+      `https://api.smiling.social/user_index/public/posts/${POST_ID}/preview/`,
+    )
+  })
+
+  it('does not let the redirect be cached against a path browsers also request', () => {
+    expect(request(`/post/${POST_ID}`, 'Twitterbot/1.0').headers['cache-control'].value).toBe(
+      'no-store',
+    )
+  })
+
+  it('accepts a trailing slash', () => {
+    expect(request(`/post/${POST_ID}/`, 'Twitterbot/1.0').statusCode).toBe(302)
+  })
+
+  it('matches the user agent case-insensitively', () => {
+    expect(request(`/post/${POST_ID}`, 'SLACKBOT 1.0').statusCode).toBe(302)
+  })
+})
+
+describe('everything else passes through untouched', () => {
+  it('a real browser gets the SPA', () => {
+    const result = request(`/post/${POST_ID}`, CHROME)
+
+    expect(result.uri).toBe(`/post/${POST_ID}`)
+    expect(result.statusCode).toBeUndefined()
+  })
+
+  it('a crawler on a non-post path gets the SPA', () => {
+    for (const uri of ['/', '/home', '/profile/someone', '/tags/sunset']) {
+      expect(request(uri, 'Twitterbot/1.0').uri).toBe(uri)
+    }
+  })
+
+  it('a missing user-agent header does not throw', () => {
+    expect(request(`/post/${POST_ID}`).uri).toBe(`/post/${POST_ID}`)
+  })
+
+  it('a post path whose id is not a uuid is not redirected', () => {
+    // The id goes straight into the preview URL, so only a well-formed one is
+    // ever forwarded.
+    for (const uri of ['/post/not-a-uuid', '/post/', `/post/${POST_ID}/extra`, '/post/../../etc']) {
+      expect(request(uri, 'Twitterbot/1.0').uri).toBe(uri)
+    }
+  })
+})

--- a/website/deploy-web.sh
+++ b/website/deploy-web.sh
@@ -22,6 +22,10 @@
 #      *viewer request*, so crawlers fetching /post/<id> are redirected to the
 #      backend's Open Graph document instead of the empty SPA shell.
 #
+# Mobile deep linking (issue #382) needs the /.well-known/ files this script
+# publishes explicitly (see below). The Android one needs the release signing
+# fingerprint in ANDROID_SHA256_CERT_FINGERPRINTS.
+#
 # Run from a machine with the AWS CLI + Node installed and credentials that can
 # write the bucket and create invalidations (s3:PutObject/DeleteObject/ListBucket
 # on the bucket, cloudfront:CreateInvalidation on the distribution). Works in CI
@@ -100,8 +104,56 @@ aws s3 sync dist/assets/ "s3://$BUCKET/assets/" --delete \
     --cache-control "public,max-age=31536000,immutable"
 
 print_status "Syncing the rest to s3://$BUCKET/ (no-cache)..."
-aws s3 sync dist/ "s3://$BUCKET/" --delete --exclude "assets/*" \
+# .well-known/ is excluded here and uploaded below instead. Two reasons: those
+# files need an explicit application/json content type (the AASA has no
+# extension, so sync would guess binary/octet-stream and iOS would reject it),
+# and --delete would otherwise remove a previously published assetlinks.json on
+# any deploy that runs without the Android signing fingerprint configured.
+aws s3 sync dist/ "s3://$BUCKET/" --delete --exclude "assets/*" --exclude ".well-known/*" \
     --cache-control "no-cache"
+
+# ---------------------------------------------------------------------------
+# Mobile deep linking (issue #382)
+# ---------------------------------------------------------------------------
+# iOS Universal Links and Android App Links are both claimed by a file under
+# /.well-known/, fetched by the OS at install time. Both must be served as
+# application/json, over https, with no redirect.
+print_status "Publishing /.well-known/apple-app-site-association ..."
+aws s3 cp dist/.well-known/apple-app-site-association \
+    "s3://$BUCKET/.well-known/apple-app-site-association" \
+    --content-type "application/json" --cache-control "public,max-age=3600"
+
+# assetlinks.json needs the release signing certificate's SHA-256 fingerprint,
+# which is not in the repo (Play App Signing holds it — read it from Play
+# Console > Setup > App integrity). Export it to enable Android App Links:
+#
+#   ANDROID_SHA256_CERT_FINGERPRINTS="AB:CD:...:EF" ./deploy-web.sh
+#
+# Comma-separate several to serve more than one signing key (e.g. while
+# migrating, or to also accept a local debug key). When unset the file is left
+# alone rather than published half-configured: a wrong fingerprint fails
+# verification silently and links quietly stop opening the app.
+if [ -n "${ANDROID_SHA256_CERT_FINGERPRINTS:-}" ]; then
+    print_status "Publishing /.well-known/assetlinks.json ..."
+    FINGERPRINT_JSON="$(printf '%s' "$ANDROID_SHA256_CERT_FINGERPRINTS" \
+        | awk -F, '{for (i=1;i<=NF;i++){gsub(/^[ \t]+|[ \t]+$/,"",$i); printf "%s\"%s\"", (i>1?", ":""), $i}}')"
+    cat > dist/.well-known/assetlinks.json <<EOF
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "${ANDROID_PACKAGE_NAME:-io.github.andrewkatson.positiveonlysocial}",
+      "sha256_cert_fingerprints": [$FINGERPRINT_JSON]
+    }
+  }
+]
+EOF
+    aws s3 cp dist/.well-known/assetlinks.json "s3://$BUCKET/.well-known/assetlinks.json" \
+        --content-type "application/json" --cache-control "public,max-age=3600"
+else
+    print_warning "ANDROID_SHA256_CERT_FINGERPRINTS is unset; leaving /.well-known/assetlinks.json untouched. Android App Links will not verify until it is published."
+fi
 
 # A shared /post/<id> link is a client-side route with nothing behind it in S3,
 # so CloudFront must rewrite the resulting 403/404 to /index.html with a 200 or

--- a/website/deploy-web.sh
+++ b/website/deploy-web.sh
@@ -10,6 +10,18 @@
 # Topology:
 #   smiling.social / www  ->  CloudFront (EMS8KP5TZ1KB3)  ->  S3 (smiling-social-web)
 #
+# Two pieces of distribution config this script does NOT manage, both needed for
+# shared post links (issue #381) — the script checks the first and warns:
+#
+#   1. SPA routing. /post/<id> is a client-side route with no object behind it
+#      in S3, so the distribution needs custom error responses mapping 403 and
+#      404 to /index.html with a 200, or a cold load of a shared link 404s.
+#
+#   2. Link previews. cloudfront/link-preview.js must be published as a
+#      CloudFront Function and associated with the default cache behavior on
+#      *viewer request*, so crawlers fetching /post/<id> are redirected to the
+#      backend's Open Graph document instead of the empty SPA shell.
+#
 # Run from a machine with the AWS CLI + Node installed and credentials that can
 # write the bucket and create invalidations (s3:PutObject/DeleteObject/ListBucket
 # on the bucket, cloudfront:CreateInvalidation on the distribution). Works in CI
@@ -90,6 +102,22 @@ aws s3 sync dist/assets/ "s3://$BUCKET/assets/" --delete \
 print_status "Syncing the rest to s3://$BUCKET/ (no-cache)..."
 aws s3 sync dist/ "s3://$BUCKET/" --delete --exclude "assets/*" \
     --cache-control "no-cache"
+
+# A shared /post/<id> link is a client-side route with nothing behind it in S3,
+# so CloudFront must rewrite the resulting 403/404 to /index.html with a 200 or
+# a cold load of the link fails (issue #381). Only a warning: the check needs
+# cloudfront:GetDistributionConfig, which a deploy role may not carry, and a
+# missing permission must not fail an otherwise good deploy.
+print_status "Checking SPA routing (403/404 -> /index.html) on $DISTRIBUTION_ID ..."
+SPA_ERRORS="$(aws cloudfront get-distribution-config --id "$DISTRIBUTION_ID" \
+    --query "DistributionConfig.CustomErrorResponses.Items[?ResponsePagePath=='/index.html' && ResponseCode=='200'].ErrorCode" \
+    --output text 2>/dev/null || true)"
+for code in 403 404; do
+    case " $SPA_ERRORS " in
+        *" $code "*) ;;
+        *) print_warning "No custom error response maps $code -> /index.html (200). A cold load of https://smiling.social/post/<id> will fail until one is added." ;;
+    esac
+done
 
 if [ "$SKIP_INVALIDATION" = "true" ]; then
     print_warning "Skipping CloudFront invalidation (--skip-invalidation)."

--- a/website/index.html
+++ b/website/index.html
@@ -5,6 +5,35 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Good Vibes Only</title>
+    <!--
+      Site-level link preview (issue #381). This is a client-only SPA, so a
+      crawler never runs the router and every path it fetches from S3 returns
+      this same document — these tags are what a link to the site itself
+      unfurls as.
+
+      A *post* link (https://smiling.social/post/<id>) needs the post's own
+      title and image, which cannot come from a static file. CloudFront routes
+      crawler user-agents for /post/* to the backend's preview endpoint
+      instead; see website/cloudfront/link-preview.js.
+    -->
+    <meta
+      name="description"
+      content="A positivity-only social network. Share what made your day better."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Good Vibes Only" />
+    <meta property="og:title" content="Good Vibes Only" />
+    <meta
+      property="og:description"
+      content="A positivity-only social network. Share what made your day better."
+    />
+    <meta property="og:url" content="https://smiling.social/" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="Good Vibes Only" />
+    <meta
+      name="twitter:description"
+      content="A positivity-only social network. Share what made your day better."
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/website/public/.well-known/apple-app-site-association
+++ b/website/public/.well-known/apple-app-site-association
@@ -1,0 +1,15 @@
+{
+  "applinks": {
+    "details": [
+      {
+        "appIDs": ["7L9M852R4K.com.katsonsoftware.goodvibesonly"],
+        "components": [
+          {
+            "/": "/post/*",
+            "comment": "Shared post links (issue #382) open the app; every other route stays on the website."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/website/src/api/PositiveOnlySocialAPI.ts
+++ b/website/src/api/PositiveOnlySocialAPI.ts
@@ -119,6 +119,20 @@ export interface PositiveOnlySocialAPI {
   /** Classification status of one of the caller's own posts (issue #282). */
   getPostStatus(postIdentifier: string): Promise<PostStatusResponse>
 
+  // Public share endpoints (issue #381). These need no session: they back a
+  // shared https://smiling.social/post/<id> link opened by someone who is not
+  // logged in. They serve only genuinely public content (not hidden, not
+  // pending, author not shadow banned, audience 'public', author not a verified
+  // minor) and carry no per-viewer state — `is_liked` / `is_saved` /
+  // `is_reported` / `report_reason` are absent, since there is no viewer to
+  // have them. Anything else 404s exactly like a post that never existed.
+  getPublicPostDetails(postIdentifier: string): Promise<PostDetails>
+  getPublicCommentsForPost(postIdentifier: string, batch: number): Promise<CommentThreadRef[]>
+  getPublicCommentsForThread(
+    commentThreadIdentifier: string,
+    batch: number,
+  ): Promise<Comment[]>
+
   // Comments. `formatting` carries optional inline styling spans (issue #318);
   // `audience` scopes who may see the comment (issue #445, omitted = 'public').
   commentOnPost(

--- a/website/src/api/StatefulStubbedAPI.ts
+++ b/website/src/api/StatefulStubbedAPI.ts
@@ -1105,8 +1105,16 @@ export class StatefulStubbedAPI implements PositiveOnlySocialAPI {
     return !!author?.isVerified && !author.isAdult
   }
 
-  /** Whether a post is visible to a signed-out visitor, mirroring the backend's
-   * PUBLIC_VIEWER rule: live, public-audience, and not by a verified minor. */
+  /** Whether a post is visible to a signed-out visitor: live, public-audience,
+   * and not by a verified minor.
+   *
+   * That is the backend's PUBLIC_VIEWER rule *minus the shadow-ban clause* —
+   * this stub has no ban model at all (no path here knows about UserBan,
+   * including the authenticated `canViewPost`), so a shadow-banned author's
+   * post stays visible in the stub where the real backend would hide it. Do
+   * not read this as production visibility: `visibility.py` is the authority,
+   * and the moderation rules are covered by the backend tests
+   * (`test_public_share_views.py`), not from here. */
   private isPubliclyVisible(post: PostMock): boolean {
     if (post.hiddenReason === 'classifier_final') return false
     if (post.hidden) return false
@@ -1119,7 +1127,9 @@ export class StatefulStubbedAPI implements PositiveOnlySocialAPI {
    * viewer: not hidden, public audience, and not by a verified minor — a
    * minor's comment is no more public than a minor's post, even on someone
    * else's public post. There is no viewer, so no author-owns-it or category
-   * rule applies. */
+   * rule applies, and the same shadow-ban caveat as `isPubliclyVisible` holds:
+   * the stub has no ban model, so a shadow-banned author's comment survives
+   * here where the backend drops it. */
   private publiclyVisibleComments(thread: CommentThreadMock): CommentMock[] {
     return thread.comments.filter(
       (c) => !c.hidden && c.audience === 'public' && !this.isVerifiedMinor(c.authorId),

--- a/website/src/api/StatefulStubbedAPI.ts
+++ b/website/src/api/StatefulStubbedAPI.ts
@@ -1096,22 +1096,34 @@ export class StatefulStubbedAPI implements PositiveOnlySocialAPI {
   // Public share endpoints (issue #381)
   // ---------------------------------------------------------------------------
 
+  /** Whether an author is a verified minor, whose content an anonymous visitor
+   * never sees: that visitor's age is unknown, so it sits in the adult band and
+   * the two bands are mutually invisible (issue #329). Mirrors
+   * visibility.is_minor. */
+  private isVerifiedMinor(authorId: string): boolean {
+    const author = this.users.find((u) => u.id === authorId)
+    return !!author?.isVerified && !author.isAdult
+  }
+
   /** Whether a post is visible to a signed-out visitor, mirroring the backend's
-   * PUBLIC_VIEWER rule: live, public-audience, and not by a verified minor
-   * (an anonymous visitor's age is unknown, so it sits in the adult band and
-   * never sees a minor's content — issue #329). */
+   * PUBLIC_VIEWER rule: live, public-audience, and not by a verified minor. */
   private isPubliclyVisible(post: PostMock): boolean {
     if (post.hiddenReason === 'classifier_final') return false
     if (post.hidden) return false
     if (post.audience !== 'public') return false
-    const author = this.users.find((u) => u.id === post.authorId)
-    return !(author?.isVerified && !author.isAdult)
+    return !this.isVerifiedMinor(post.authorId)
   }
 
-  /** Comments in a thread a signed-out visitor may see: not hidden and public
-   * audience. There is no viewer, so no author-owns-it or category rule. */
+  /** Comments in a thread a signed-out visitor may see. The same rule as posts,
+   * because the backend runs `visible_comments` against the same anonymous
+   * viewer: not hidden, public audience, and not by a verified minor — a
+   * minor's comment is no more public than a minor's post, even on someone
+   * else's public post. There is no viewer, so no author-owns-it or category
+   * rule applies. */
   private publiclyVisibleComments(thread: CommentThreadMock): CommentMock[] {
-    return thread.comments.filter((c) => !c.hidden && c.audience === 'public')
+    return thread.comments.filter(
+      (c) => !c.hidden && c.audience === 'public' && !this.isVerifiedMinor(c.authorId),
+    )
   }
 
   private requirePublicPost(postIdentifier: string): PostMock {

--- a/website/src/api/StatefulStubbedAPI.ts
+++ b/website/src/api/StatefulStubbedAPI.ts
@@ -1092,6 +1092,105 @@ export class StatefulStubbedAPI implements PositiveOnlySocialAPI {
     }
   }
 
+  // ---------------------------------------------------------------------------
+  // Public share endpoints (issue #381)
+  // ---------------------------------------------------------------------------
+
+  /** Whether a post is visible to a signed-out visitor, mirroring the backend's
+   * PUBLIC_VIEWER rule: live, public-audience, and not by a verified minor
+   * (an anonymous visitor's age is unknown, so it sits in the adult band and
+   * never sees a minor's content — issue #329). */
+  private isPubliclyVisible(post: PostMock): boolean {
+    if (post.hiddenReason === 'classifier_final') return false
+    if (post.hidden) return false
+    if (post.audience !== 'public') return false
+    const author = this.users.find((u) => u.id === post.authorId)
+    return !(author?.isVerified && !author.isAdult)
+  }
+
+  /** Comments in a thread a signed-out visitor may see: not hidden and public
+   * audience. There is no viewer, so no author-owns-it or category rule. */
+  private publiclyVisibleComments(thread: CommentThreadMock): CommentMock[] {
+    return thread.comments.filter((c) => !c.hidden && c.audience === 'public')
+  }
+
+  private requirePublicPost(postIdentifier: string): PostMock {
+    const post = this.posts.find((p) => p.postIdentifier === postIdentifier)
+    // A post that exists but isn't public reads exactly like a missing one, so
+    // the endpoint can't be used to probe moderation state.
+    if (!post || !this.isPubliclyVisible(post)) {
+      throw new ApiError(404, 'No post with that identifier')
+    }
+    return post
+  }
+
+  async getPublicPostDetails(postIdentifier: string): Promise<PostDetails> {
+    const post = this.requirePublicPost(postIdentifier)
+    const author = this.users.find((u) => u.id === post.authorId)
+    // No is_liked/is_saved/is_reported/report_reason and no author-only status:
+    // there is no viewer to have them.
+    return {
+      post_identifier: post.postIdentifier,
+      image_url: post.imageUrl,
+      original_image_url: post.imageUrl,
+      caption: post.caption,
+      caption_font: post.captionFont,
+      background_color: post.backgroundColor,
+      creation_time: new Date(post.creationTime).toISOString(),
+      post_likes: post.likes.size,
+      author_username: author ? author.username : '',
+      audience: post.audience,
+      tags: post.tags,
+      ...this.authorAvatarFields(post.authorId),
+    }
+  }
+
+  async getPublicCommentsForPost(
+    postIdentifier: string,
+    batch: number,
+  ): Promise<CommentThreadRef[]> {
+    const post = this.requirePublicPost(postIdentifier)
+    const threads = this.commentThreads
+      .filter((t) => t.postId === post.postIdentifier)
+      .filter((t) => this.publiclyVisibleComments(t).length > 0)
+    return this.batch(threads, batch, COMMENT_BATCH_SIZE).map((t) => ({
+      comment_thread_identifier: t.threadIdentifier,
+    }))
+  }
+
+  async getPublicCommentsForThread(
+    commentThreadIdentifier: string,
+    batch: number,
+  ): Promise<Comment[]> {
+    const thread = this.commentThreads.find(
+      (t) => t.threadIdentifier === commentThreadIdentifier,
+    )
+    // A leaked thread id is not a back door into a non-public post's
+    // conversation: the post must be public too.
+    if (!thread) {
+      throw new ApiError(404, 'No comment thread with that identifier')
+    }
+    this.requirePublicPost(thread.postId)
+    const visible = this.publiclyVisibleComments(thread).sort(
+      (a, b) => a.creationTime - b.creationTime,
+    )
+    return this.batch(visible, batch, COMMENT_BATCH_SIZE).map((c) => {
+      const author = this.users.find((u) => u.id === c.authorId)
+      const time = new Date(c.creationTime).toISOString()
+      return {
+        comment_identifier: c.commentIdentifier,
+        body: c.body,
+        body_formatting: c.bodyFormatting,
+        audience: c.audience,
+        author_username: author ? author.username : '',
+        ...this.authorAvatarFields(c.authorId),
+        creation_time: time,
+        updated_time: time,
+        comment_likes: c.likes.size,
+      }
+    })
+  }
+
   async getPostStatus(postIdentifier: string): Promise<PostStatusResponse> {
     const user = this.requireUser()
     const post = this.posts.find(

--- a/website/src/api/client.ts
+++ b/website/src/api/client.ts
@@ -558,6 +558,35 @@ export class ApiClient implements PositiveOnlySocialAPI {
   }
 
   // ===========================================================================
+  // PUBLIC SHARE ENDPOINTS (issue #381)
+  // ===========================================================================
+  // Deliberately sent without `auth: true` even when a session exists: the
+  // backend resolves these against a fixed anonymous viewer, so sending a token
+  // would change nothing but would leak the session to a read that does not
+  // need it.
+
+  getPublicPostDetails(postIdentifier: string): Promise<PostDetails> {
+    return this.request<PostDetails>('GET', `/public/posts/${postIdentifier}/details/`)
+  }
+
+  getPublicCommentsForPost(postIdentifier: string, batch: number): Promise<CommentThreadRef[]> {
+    return this.request<CommentThreadRef[]>(
+      'GET',
+      `/public/posts/${postIdentifier}/comments/${batch}/`,
+    )
+  }
+
+  getPublicCommentsForThread(
+    commentThreadIdentifier: string,
+    batch: number,
+  ): Promise<Comment[]> {
+    return this.request<Comment[]>(
+      'GET',
+      `/public/threads/${commentThreadIdentifier}/comments/${batch}/`,
+    )
+  }
+
+  // ===========================================================================
   // COMMENTS
   // ===========================================================================
 

--- a/website/src/pages/MainApp.css
+++ b/website/src/pages/MainApp.css
@@ -1208,6 +1208,22 @@
   cursor: pointer;
 }
 
+/* The comment a shared `#comment-<id>` link points at (issues #34/#381). The
+   page scrolls it into view; this marks which one of the thread it is. */
+.comment-row--shared {
+  background: rgba(91, 164, 220, 0.12);
+  border-left: 3px solid #5ba4dc;
+  border-radius: 6px;
+  padding: 0.5rem;
+  margin-left: -0.5rem;
+}
+
+/* Shown instead of the comment composer for a signed-out visitor who arrived
+   on a shared link (issue #381). */
+.signed-out-prompt a {
+  color: #5ba4dc;
+}
+
 .comment-row__avatar {
   font-size: 1.4rem;
   color: rgba(255, 255, 255, 0.5);

--- a/website/src/pages/PostDetailPage.test.tsx
+++ b/website/src/pages/PostDetailPage.test.tsx
@@ -11,6 +11,9 @@ vi.mock('../api/client', () => ({
     getPostDetails: vi.fn(),
     getCommentsForPost: vi.fn(),
     getCommentsForThread: vi.fn(),
+    getPublicPostDetails: vi.fn(),
+    getPublicCommentsForPost: vi.fn(),
+    getPublicCommentsForThread: vi.fn(),
     likePost: vi.fn(),
     unlikePost: vi.fn(),
     reportPost: vi.fn(),
@@ -30,6 +33,10 @@ import { apiClient } from '../api/client'
 const mockGetDetails = vi.mocked(apiClient.getPostDetails)
 const mockGetThreadRefs = vi.mocked(apiClient.getCommentsForPost)
 const mockGetThreadComments = vi.mocked(apiClient.getCommentsForThread)
+const mockIsAuthenticated = vi.mocked(apiClient.isAuthenticated)
+const mockGetPublicDetails = vi.mocked(apiClient.getPublicPostDetails)
+const mockGetPublicThreadRefs = vi.mocked(apiClient.getPublicCommentsForPost)
+const mockGetPublicThreadComments = vi.mocked(apiClient.getPublicCommentsForThread)
 const mockLikePost = vi.mocked(apiClient.likePost)
 const mockCommentOnPost = vi.mocked(apiClient.commentOnPost)
 const mockDeletePost = vi.mocked(apiClient.deletePost)
@@ -78,9 +85,13 @@ beforeEach(() => {
     removeItem: (key: string) => store.delete(key),
     clear: () => store.clear(),
   })
+  mockIsAuthenticated.mockReset().mockReturnValue(true)
   mockGetDetails.mockReset().mockResolvedValue(post)
   mockGetThreadRefs.mockReset().mockResolvedValue([])
   mockGetThreadComments.mockReset().mockResolvedValue([])
+  mockGetPublicDetails.mockReset().mockResolvedValue(post)
+  mockGetPublicThreadRefs.mockReset().mockResolvedValue([])
+  mockGetPublicThreadComments.mockReset().mockResolvedValue([])
   mockLikePost.mockReset().mockResolvedValue({ message: 'ok' })
   mockCommentOnPost.mockReset().mockResolvedValue({
     comment_thread_identifier: 't1',
@@ -444,15 +455,127 @@ test('sharing a comment copies a #comment-<id> deep link (issue #34)', async () 
   )
 })
 
-test('redirects to login when unauthenticated', () => {
-  vi.mocked(apiClient.isAuthenticated).mockReturnValueOnce(false)
-  render(
-    <MemoryRouter initialEntries={['/post/p1']}>
+// =============================================================================
+// Signed out — a shared link opened by someone with no account (issue #381)
+// =============================================================================
+
+function renderSignedOut(entry = '/post/p1') {
+  mockIsAuthenticated.mockReturnValue(false)
+  return render(
+    <MemoryRouter initialEntries={[entry]}>
       <Routes>
         <Route path="/post/:postId" element={<PostDetailPage />} />
         <Route path="/login" element={<div>Login page</div>} />
+        <Route path="/register" element={<div>Register page</div>} />
+        <Route path="/profile/:username" element={<div>Profile page</div>} />
       </Routes>
     </MemoryRouter>,
   )
-  expect(screen.getByText('Login page')).toBeInTheDocument()
+}
+
+test('a signed-out visitor reads the post through the public endpoints', async () => {
+  mockGetPublicThreadRefs.mockResolvedValue([{ comment_thread_identifier: 't1' }])
+  mockGetPublicThreadComments.mockResolvedValue([comment])
+  renderSignedOut()
+
+  expect(await screen.findByText('sunshine')).toBeInTheDocument()
+  expect(await screen.findByText('love this')).toBeInTheDocument()
+  expect(mockGetPublicDetails).toHaveBeenCalledWith('p1')
+  expect(mockGetPublicThreadRefs).toHaveBeenCalledWith('p1', 0)
+  expect(mockGetPublicThreadComments).toHaveBeenCalledWith('t1', 0)
+  // No session, so the authenticated endpoints are never reached for.
+  expect(mockGetDetails).not.toHaveBeenCalled()
+  expect(mockGetThreadRefs).not.toHaveBeenCalled()
+})
+
+test('a signed-out visitor is no longer bounced to the login page', async () => {
+  renderSignedOut()
+
+  expect(await screen.findByText('sunshine')).toBeInTheDocument()
+  expect(screen.queryByText('Login page')).not.toBeInTheDocument()
+})
+
+test('a signed-out visitor gets a sign-in prompt instead of the session-only controls', async () => {
+  mockGetPublicThreadRefs.mockResolvedValue([{ comment_thread_identifier: 't1' }])
+  mockGetPublicThreadComments.mockResolvedValue([comment])
+  renderSignedOut()
+  await screen.findByText('love this')
+
+  expect(screen.getByRole('link', { name: 'Log in' })).toBeInTheDocument()
+  expect(screen.getByRole('link', { name: 'join' })).toBeInTheDocument()
+  expect(screen.queryByRole('button', { name: 'Add a comment...' })).not.toBeInTheDocument()
+  expect(screen.queryByRole('button', { name: 'Reply' })).not.toBeInTheDocument()
+  expect(screen.queryByRole('button', { name: 'Like post' })).not.toBeInTheDocument()
+  expect(screen.queryByRole('button', { name: 'Like comment' })).not.toBeInTheDocument()
+  // The relationship filter needs relationships, which an anonymous visitor
+  // does not have.
+  expect(screen.queryByLabelText('Filter comments by group')).not.toBeInTheDocument()
+  // Read-only detail is still all there.
+  expect(screen.getByText('3 likes')).toBeInTheDocument()
+})
+
+test('a signed-out visitor is offered Share and nothing that needs a session', async () => {
+  renderSignedOut()
+  await screen.findByText('sunshine')
+
+  await userEvent.click(screen.getByRole('button', { name: 'Post options' }))
+  const menu = screen.getByRole('dialog', { name: 'Post options' })
+  expect(within(menu).getByRole('button', { name: 'Share' })).toBeInTheDocument()
+  expect(within(menu).queryByRole('button', { name: 'Report' })).not.toBeInTheDocument()
+  expect(within(menu).queryByRole('button', { name: 'Delete' })).not.toBeInTheDocument()
+})
+
+test('a signed-out visitor is told a missing post may just be private', async () => {
+  mockGetPublicDetails.mockRejectedValue(new Error('404'))
+  renderSignedOut()
+
+  expect(await screen.findByText('Post not found.')).toBeInTheDocument()
+  expect(screen.getByText(/shared with a narrower audience/)).toBeInTheDocument()
+})
+
+// =============================================================================
+// The #comment-<id> fragment a shared comment link carries (issues #34/#381)
+// =============================================================================
+
+// The fragment is only honored for a well-formed comment id, so these use real
+// UUIDs rather than the short ids the rest of the file uses.
+const ROOT_ID = 'bbbbbbbb-cccc-4ddd-8eee-ffffffffffff'
+const REPLY_ID = '12345678-90ab-4cde-8f01-234567890abc'
+const rootComment: Comment = { ...comment, comment_identifier: ROOT_ID }
+const replyComment: Comment = {
+  ...comment,
+  comment_identifier: REPLY_ID,
+  body: 'totally agree',
+  author_username: 'cara',
+  creation_time: '2024-01-02T00:00:00.000Z',
+}
+
+test('every comment is addressable by a #comment-<id> anchor', async () => {
+  mockGetThreadRefs.mockResolvedValue([{ comment_thread_identifier: 't1' }])
+  mockGetThreadComments.mockResolvedValue([rootComment])
+  renderDetail()
+  await screen.findByText('love this')
+
+  expect(document.getElementById(`comment-${ROOT_ID}`)).toBeInTheDocument()
+})
+
+test('a shared comment link marks out the comment it points at', async () => {
+  mockGetPublicThreadRefs.mockResolvedValue([{ comment_thread_identifier: 't1' }])
+  mockGetPublicThreadComments.mockResolvedValue([rootComment, replyComment])
+  renderSignedOut(`/post/p1#comment-${REPLY_ID}`)
+  await screen.findByText('totally agree')
+
+  await waitFor(() =>
+    expect(document.getElementById(`comment-${REPLY_ID}`)).toHaveClass('comment-row--shared'),
+  )
+  expect(document.getElementById(`comment-${ROOT_ID}`)).not.toHaveClass('comment-row--shared')
+})
+
+test('a plain post link marks out nothing', async () => {
+  mockGetPublicThreadRefs.mockResolvedValue([{ comment_thread_identifier: 't1' }])
+  mockGetPublicThreadComments.mockResolvedValue([rootComment, replyComment])
+  renderSignedOut()
+  await screen.findByText('totally agree')
+
+  expect(document.querySelector('.comment-row--shared')).toBeNull()
 })

--- a/website/src/pages/PostDetailPage.test.tsx
+++ b/website/src/pages/PostDetailPage.test.tsx
@@ -571,6 +571,32 @@ test('a shared comment link marks out the comment it points at', async () => {
   expect(document.getElementById(`comment-${ROOT_ID}`)).not.toHaveClass('comment-row--shared')
 })
 
+test('a shared comment link scrolls that comment into view', async () => {
+  // The highlight and the scroll are separate mechanisms: a comment that is
+  // marked but off-screen is still a broken share link, so assert the scroll
+  // itself rather than inferring it from the class.
+  const scrollIntoView = vi.spyOn(Element.prototype, 'scrollIntoView')
+  mockGetPublicThreadRefs.mockResolvedValue([{ comment_thread_identifier: 't1' }])
+  mockGetPublicThreadComments.mockResolvedValue([rootComment, replyComment])
+  renderSignedOut(`/post/p1#comment-${REPLY_ID}`)
+  await screen.findByText('totally agree')
+
+  await waitFor(() => expect(scrollIntoView).toHaveBeenCalled())
+  expect(scrollIntoView.mock.instances[0]).toBe(document.getElementById(`comment-${REPLY_ID}`))
+  scrollIntoView.mockRestore()
+})
+
+test('a plain post link scrolls nowhere', async () => {
+  const scrollIntoView = vi.spyOn(Element.prototype, 'scrollIntoView')
+  mockGetPublicThreadRefs.mockResolvedValue([{ comment_thread_identifier: 't1' }])
+  mockGetPublicThreadComments.mockResolvedValue([rootComment, replyComment])
+  renderSignedOut()
+  await screen.findByText('totally agree')
+
+  expect(scrollIntoView).not.toHaveBeenCalled()
+  scrollIntoView.mockRestore()
+})
+
 test('a plain post link marks out nothing', async () => {
   mockGetPublicThreadRefs.mockResolvedValue([{ comment_thread_identifier: 't1' }])
   mockGetPublicThreadComments.mockResolvedValue([rootComment, replyComment])

--- a/website/src/pages/PostDetailPage.tsx
+++ b/website/src/pages/PostDetailPage.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
-import { Navigate, useNavigate, useParams } from 'react-router'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Link, useLocation, useNavigate, useParams } from 'react-router'
 import { apiClient } from '../api/client'
 import { getCurrentUsername } from '../api/session'
 import type {
@@ -26,7 +26,12 @@ import {
 } from '../components/commentFormatting'
 import { formatRelativeTime } from '../utils/relativeTime'
 import { profilePathFor } from '../utils/profilePath'
-import { commentShareUrl, postShareUrl, shareLink } from '../utils/shareLink'
+import {
+  commentShareUrl,
+  postShareUrl,
+  shareLink,
+  sharedCommentId,
+} from '../utils/shareLink'
 import './MainApp.css'
 
 /** A comment enriched with per-user like/report state for the UI. */
@@ -101,6 +106,11 @@ type ComposerTarget = { type: 'post' } | { type: 'reply'; thread: ThreadView }
  * replies, and a three-dots menu per item offering Report / Retract Report /
  * Delete (issues #304, #176). Mirrors iOS PostDetailView / PostDetailViewModel.
  *
+ * This is also the page a shared link opens (issue #381), so it renders for
+ * signed-out visitors too: they read the post and its comments through the
+ * public endpoints and see a prompt to sign in instead of the controls that
+ * need a session.
+ *
  * Per-user like/report state comes from the API (is_liked / is_reported /
  * report_reason); local refs only backstop responses that omit those fields.
  *
@@ -109,19 +119,25 @@ type ComposerTarget = { type: 'post' } | { type: 'reply'; thread: ThreadView }
  */
 function PostDetailPage() {
   const { postId = '' } = useParams<{ postId: string }>()
-  // Comments/likes/reports require a session, so require one like HomePage.
-  if (!apiClient.isAuthenticated()) {
-    return <Navigate to="/login" replace />
-  }
-  return <PostDetailView key={postId} postId={postId} />
+  // Read once per mount rather than per render: the session cannot change
+  // underneath this page without a navigation, and a stable value keeps the
+  // load effect from re-running.
+  const [isSignedIn] = useState(() => apiClient.isAuthenticated())
+  return <PostDetailView key={postId} postId={postId} isSignedIn={isSignedIn} />
 }
 
-function PostDetailView({ postId }: { postId: string }) {
+function PostDetailView({ postId, isSignedIn }: { postId: string; isSignedIn: boolean }) {
   const navigate = useNavigate()
+  const location = useLocation()
 
   // The signed-in user, read once. Used to hide the like control on the user's
-  // own post/comments since the backend rejects liking your own content.
-  const [currentUsername] = useState(() => getCurrentUsername())
+  // own post/comments since the backend rejects liking your own content. Null
+  // for a signed-out visitor, who owns nothing on the page.
+  const [currentUsername] = useState(() => (isSignedIn ? getCurrentUsername() : null))
+
+  // The comment a shared `#comment-<id>` link points at, so the page can scroll
+  // to it once the threads have rendered.
+  const targetCommentId = useMemo(() => sharedCommentId(location.hash), [location.hash])
 
   // Track mount state so async loads that resolve after navigating away don't
   // set state on an unmounted view.
@@ -246,7 +262,9 @@ function PostDetailView({ postId }: { postId: string }) {
       // a post that loaded fine.
       let details: PostDetails
       try {
-        details = await apiClient.getPostDetails(postId)
+        details = isSignedIn
+          ? await apiClient.getPostDetails(postId)
+          : await apiClient.getPublicPostDetails(postId)
       } catch {
         if (isMounted.current) {
           setNotFound(true)
@@ -268,16 +286,22 @@ function PostDetailView({ postId }: { postId: string }) {
       // Read from the ref (not a captured value) so a coalesced re-run always
       // uses the latest requested group rather than a stale closure value.
       const group = requestedGroupRef.current
-      const groupFilter = group === 'all' ? undefined : group
+      // A signed-out visitor has no relationships, so the public endpoints take
+      // no category filter and the chips that set it are not rendered.
+      const groupFilter = !isSignedIn || group === 'all' ? undefined : group
       try {
-        const refs = await apiClient.getCommentsForPost(postId, 0, groupFilter)
+        const refs = isSignedIn
+          ? await apiClient.getCommentsForPost(postId, 0, groupFilter)
+          : await apiClient.getPublicCommentsForPost(postId, 0)
         const threadLists = await Promise.all(
           refs.map(async ref => {
-            const comments = await apiClient.getCommentsForThread(
-              ref.comment_thread_identifier,
-              0,
-              groupFilter,
-            )
+            const comments = isSignedIn
+              ? await apiClient.getCommentsForThread(
+                  ref.comment_thread_identifier,
+                  0,
+                  groupFilter,
+                )
+              : await apiClient.getPublicCommentsForThread(ref.comment_thread_identifier, 0)
             return { threadId: ref.comment_thread_identifier, comments }
           }),
         )
@@ -315,13 +339,26 @@ function PostDetailView({ postId }: { postId: string }) {
     } finally {
       isLoadingRef.current = false
     }
-  }, [postId, currentUsername, commentGroup])
+  }, [postId, currentUsername, commentGroup, isSignedIn])
 
   // Kick the initial load off a microtask so the fetch's setState calls don't
   // run synchronously inside the effect (React flags that as cascading renders).
   useEffect(() => {
     void Promise.resolve().then(loadAll)
   }, [loadAll])
+
+  // Bring the comment a shared `#comment-<id>` link points at into view once its
+  // thread has rendered (issue #381). The browser cannot do this itself: the
+  // element does not exist yet when the fragment is resolved on load. Runs at
+  // most once — after that the user is in charge of the scroll position.
+  const scrolledToSharedComment = useRef(false)
+  useEffect(() => {
+    if (!targetCommentId || scrolledToSharedComment.current || threads.length === 0) return
+    const element = document.getElementById(`comment-${targetCommentId}`)
+    if (!element) return
+    scrolledToSharedComment.current = true
+    element.scrollIntoView({ block: 'center' })
+  }, [targetCommentId, threads])
 
   // Manual refresh — the web equivalent of the iOS/Android pull-to-refresh — so
   // comments added by others can be pulled in without a full page reload.
@@ -341,7 +378,7 @@ function PostDetailView({ postId }: { postId: string }) {
   const isOwnPost = post?.author_username === currentUsername
 
   async function togglePostLike() {
-    if (isOwnPost) return
+    if (isOwnPost || !isSignedIn) return
     const liking = !postLiked
     setPostLiked(liking)
     setPostLikeCount(n => (liking ? n + 1 : Math.max(0, n - 1)))
@@ -368,7 +405,7 @@ function PostDetailView({ postId }: { postId: string }) {
   }
 
   async function toggleCommentLike(comment: CommentView) {
-    if (comment.isOwn) return
+    if (comment.isOwn || !isSignedIn) return
     const liking = !comment.isLiked
     if (liking) likedCommentIds.current.add(comment.id)
     else likedCommentIds.current.delete(comment.id)
@@ -572,10 +609,17 @@ function PostDetailView({ postId }: { postId: string }) {
     }
   }
 
+  // A shared link opened cold has no history entry to pop, so Back would be a
+  // dead control (issue #381). Send those visitors somewhere real instead.
+  function goBack() {
+    if (window.history.length <= 1) navigate(isSignedIn ? '/home' : '/')
+    else navigate(-1)
+  }
+
   if (isLoading && !post) {
     return (
       <div className="app-shell">
-        <DetailBar onBack={() => navigate(-1)} />
+        <DetailBar onBack={goBack} />
         <div className="center-spinner">
           <span className="spinner" />
         </div>
@@ -586,9 +630,18 @@ function PostDetailView({ postId }: { postId: string }) {
   if (notFound || !post) {
     return (
       <div className="app-shell">
-        <DetailBar onBack={() => navigate(-1)} />
+        <DetailBar onBack={goBack} />
         <main className="app-content">
           <p className="muted">Post not found.</p>
+          {/* Only public posts are readable without a session, so a shared link
+              to a friends-only post lands here — say so rather than leaving the
+              recipient thinking it was deleted. */}
+          {!isSignedIn && (
+            <p className="muted">
+              It may have been removed, or shared with a narrower audience.{' '}
+              <Link to="/login">Log in</Link> to check.
+            </p>
+          )}
         </main>
       </div>
     )
@@ -600,7 +653,7 @@ function PostDetailView({ postId }: { postId: string }) {
 
   return (
     <div className="app-shell">
-      <DetailBar onBack={() => navigate(-1)} />
+      <DetailBar onBack={goBack} />
 
       <main className="app-content">
         {errorMessage && (
@@ -621,11 +674,11 @@ function PostDetailView({ postId }: { postId: string }) {
           post={post}
           className="detail-image"
           variant="detail"
-          onDoubleClick={isOwnPost ? undefined : togglePostLike}
+          onDoubleClick={isOwnPost || !isSignedIn ? undefined : togglePostLike}
         />
 
         <div className="detail-meta">
-          {!isOwnPost && (
+          {!isOwnPost && isSignedIn && (
             <button
               type="button"
               className="heart"
@@ -684,40 +737,53 @@ function PostDetailView({ postId }: { postId: string }) {
             unparseable — omit the label rather than render an empty line. */}
         {postTime && <p className="detail-time">{postTime}</p>}
 
-        <div className="comment-form">
-          <button
-            type="button"
-            className="comment-compose-trigger"
-            onClick={() => openComposer({ type: 'post' })}
-          >
-            Add a comment...
-          </button>
-        </div>
+        {isSignedIn ? (
+          <div className="comment-form">
+            <button
+              type="button"
+              className="comment-compose-trigger"
+              onClick={() => openComposer({ type: 'post' })}
+            >
+              Add a comment...
+            </button>
+          </div>
+        ) : (
+          /* A shared link opened by someone with no account (issue #381): the
+             post and its comments are readable, but liking, commenting and
+             reporting all need one. */
+          <p className="muted signed-out-prompt">
+            <Link to="/login">Log in</Link> or <Link to="/register">join</Link> to like,
+            comment, and share the good vibes.
+          </p>
+        )}
 
         <h2 className="app-bar__title" style={{ fontSize: '1rem' }}>
           Comments
         </h2>
 
         {/* Filter the comment list by relationship group — the same toggles the
-            Following feed offers (issue #445). */}
-        <label className="comment-group-filter">
-          Show
-          <select
-            className="select-input"
-            aria-label="Filter comments by group"
-            value={commentGroup}
-            onChange={e => {
-              const next = e.target.value as CommentGroup
-              if (next !== commentGroup) setCommentGroup(next)
-            }}
-          >
-            {COMMENT_GROUP_OPTIONS.map(opt => (
-              <option key={opt.value} value={opt.value}>
-                {opt.label}
-              </option>
-            ))}
-          </select>
-        </label>
+            Following feed offers (issue #445). A signed-out visitor has no
+            relationships to filter by, so the chips are theirs to skip. */}
+        {isSignedIn && (
+          <label className="comment-group-filter">
+            Show
+            <select
+              className="select-input"
+              aria-label="Filter comments by group"
+              value={commentGroup}
+              onChange={e => {
+                const next = e.target.value as CommentGroup
+                if (next !== commentGroup) setCommentGroup(next)
+              }}
+            >
+              {COMMENT_GROUP_OPTIONS.map(opt => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
 
         <button
           type="button"
@@ -745,6 +811,8 @@ function PostDetailView({ postId }: { postId: string }) {
                 {root && (
                   <CommentRow
                     comment={root}
+                    canLike={isSignedIn}
+                    isShared={root.id === targetCommentId}
                     isCollapsed={collapsedIds.has(root.id)}
                     onToggleCollapse={() => toggleCollapsed(root.id)}
                     onToggleLike={() => toggleCommentLike(root)}
@@ -754,19 +822,23 @@ function PostDetailView({ postId }: { postId: string }) {
                     }
                   />
                 )}
-                <button
-                  type="button"
-                  className="comment-reply-btn"
-                  onClick={() => openComposer({ type: 'reply', thread })}
-                >
-                  Reply
-                </button>
+                {isSignedIn && (
+                  <button
+                    type="button"
+                    className="comment-reply-btn"
+                    onClick={() => openComposer({ type: 'reply', thread })}
+                  >
+                    Reply
+                  </button>
+                )}
                 {replies.length > 0 && (
                   <div className="comment-replies">
                     {replies.map(reply => (
                       <CommentRow
                         key={reply.id}
                         comment={reply}
+                        canLike={isSignedIn}
+                        isShared={reply.id === targetCommentId}
                         isCollapsed={collapsedIds.has(reply.id)}
                         onToggleCollapse={() => toggleCollapsed(reply.id)}
                         onToggleLike={() => toggleCommentLike(reply)}
@@ -928,7 +1000,9 @@ function PostDetailView({ postId }: { postId: string }) {
               >
                 Share
               </button>
-              {menuState(menuTarget).isOwn ? (
+              {/* Report / Retract / Delete all need a session; a signed-out
+                  visitor gets Share and nothing else (issue #381). */}
+              {!isSignedIn ? null : menuState(menuTarget).isOwn ? (
                 <button
                   type="button"
                   className="modal__confirm"
@@ -1086,6 +1160,11 @@ function DetailBar({ onBack }: { onBack: () => void }) {
 
 interface CommentRowProps {
   comment: CommentView
+  /** False for a signed-out visitor, who has no session to like with. */
+  canLike: boolean
+  /** True when a `#comment-<id>` share link points at this comment, so it is
+   * marked out from the rest of the thread (issue #381). */
+  isShared: boolean
   isCollapsed: boolean
   onToggleCollapse: () => void
   onToggleLike: () => void
@@ -1095,6 +1174,8 @@ interface CommentRowProps {
 
 function CommentRow({
   comment,
+  canLike,
+  isShared,
   isCollapsed,
   onToggleCollapse,
   onToggleLike,
@@ -1102,7 +1183,11 @@ function CommentRow({
   onNavigate,
 }: CommentRowProps) {
   return (
-    <div className="comment-row">
+    // The id is the anchor a shared `#comment-<id>` link resolves against.
+    <div
+      id={`comment-${comment.id}`}
+      className={`comment-row${isShared ? ' comment-row--shared' : ''}`}
+    >
       <Avatar
         src={comment.authorAvatarUrl}
         originalSrc={comment.authorAvatarOriginalUrl}
@@ -1167,7 +1252,7 @@ function CommentRow({
           <FormattedText text={comment.body} spans={comment.formatting} />
         </p>
         <div className="comment-row__info">
-          {!comment.isOwn && (
+          {!comment.isOwn && canLike && (
             <button
               type="button"
               className="heart"

--- a/website/src/pages/PostDetailPage.tsx
+++ b/website/src/pages/PostDetailPage.tsx
@@ -750,10 +750,11 @@ function PostDetailView({ postId, isSignedIn }: { postId: string; isSignedIn: bo
         ) : (
           /* A shared link opened by someone with no account (issue #381): the
              post and its comments are readable, but liking, commenting and
-             reporting all need one. */
+             reporting all need one. Sharing deliberately isn't listed — it
+             still works signed out, so naming it here would imply the opposite. */
           <p className="muted signed-out-prompt">
             <Link to="/login">Log in</Link> or <Link to="/register">join</Link> to like,
-            comment, and share the good vibes.
+            comment, and post your own good vibes.
           </p>
         )}
 

--- a/website/src/test/setup.ts
+++ b/website/src/test/setup.ts
@@ -1,1 +1,8 @@
 import '@testing-library/jest-dom/vitest'
+
+// jsdom has no layout engine, so it does not implement scrollIntoView. The post
+// detail page calls it to bring a shared `#comment-<id>` into view (issue #381);
+// without a stub the call throws and takes the whole render down.
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {}
+}

--- a/website/src/utils/shareLink.test.ts
+++ b/website/src/utils/shareLink.test.ts
@@ -28,8 +28,10 @@ describe('sharedCommentId', () => {
     expect(sharedCommentId(`#${url.split('#')[1]}`)).toBe(COMMENT_ID)
   })
 
-  test('is case-insensitive about the uuid', () => {
-    expect(sharedCommentId(`#comment-${COMMENT_ID.toUpperCase()}`)).toBe(COMMENT_ID.toUpperCase())
+  test('accepts an upper-cased uuid and normalizes it to match rendered ids', () => {
+    // A link that passed through something that upper-cased the URL still has
+    // to match the lowercase ids the backend serves.
+    expect(sharedCommentId(`#comment-${COMMENT_ID.toUpperCase()}`)).toBe(COMMENT_ID)
   })
 
   test('ignores a hash that is not a comment link', () => {

--- a/website/src/utils/shareLink.test.ts
+++ b/website/src/utils/shareLink.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test, vi } from 'vitest'
-import { commentShareUrl, postShareUrl, shareLink } from './shareLink'
+import { commentShareUrl, postShareUrl, shareLink, sharedCommentId } from './shareLink'
 
 // jsdom serves window.location.origin as http://localhost:3000 by default.
 const ORIGIN = window.location.origin
@@ -16,6 +16,37 @@ describe('postShareUrl / commentShareUrl', () => {
 
   test('comment URL appends a #comment-<id> fragment to the post URL', () => {
     expect(commentShareUrl('abc-123', 'def-456')).toBe(`${ORIGIN}/post/abc-123#comment-def-456`)
+  })
+})
+
+describe('sharedCommentId', () => {
+  const COMMENT_ID = '3f1b9a2c-6d4e-4f8a-9b1c-2d3e4f5a6b7c'
+
+  test('round-trips the fragment commentShareUrl produces', () => {
+    const url = commentShareUrl('9a1e0b6f-1111-4222-8333-444455556666', COMMENT_ID)
+
+    expect(sharedCommentId(`#${url.split('#')[1]}`)).toBe(COMMENT_ID)
+  })
+
+  test('is case-insensitive about the uuid', () => {
+    expect(sharedCommentId(`#comment-${COMMENT_ID.toUpperCase()}`)).toBe(COMMENT_ID.toUpperCase())
+  })
+
+  test('ignores a hash that is not a comment link', () => {
+    for (const hash of ['', '#', '#top', '#comment-', '#comment-not-a-uuid', `#post-${COMMENT_ID}`]) {
+      expect(sharedCommentId(hash)).toBeNull()
+    }
+  })
+
+  test('ignores anything that could be smuggled into a DOM id or selector', () => {
+    // The value builds a DOM id; a hash is attacker-supplied whenever a link is.
+    for (const hash of [
+      '#comment-<script>alert(1)</script>',
+      `#comment-${COMMENT_ID}"]`,
+      `#comment-${COMMENT_ID} extra`,
+    ]) {
+      expect(sharedCommentId(hash)).toBeNull()
+    }
   })
 })
 

--- a/website/src/utils/shareLink.ts
+++ b/website/src/utils/shareLink.ts
@@ -29,10 +29,15 @@ export function commentShareUrl(postIdentifier: string, commentIdentifier: strin
  * The id must look like a UUID. The value is used to build a DOM id and to
  * match against rendered comments, so anything else is ignored rather than
  * trusted — a hash is attacker-supplied whenever a link is.
+ *
+ * The result is lowercased. A hash can arrive upper- or mixed-case (a chat app
+ * or link shortener that "normalizes" URLs, a hand-typed link), while the ids
+ * the backend serves are always lowercase UUIDs — without normalizing, an
+ * uppercase hash would parse cleanly and then silently match no comment.
  */
 export function sharedCommentId(hash: string): string | null {
   const match = /^#comment-([0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12})$/.exec(hash)
-  return match ? match[1] : null
+  return match ? match[1].toLowerCase() : null
 }
 
 /**

--- a/website/src/utils/shareLink.ts
+++ b/website/src/utils/shareLink.ts
@@ -1,8 +1,9 @@
-// Sharing posts and comments (issues #34, #381). The share action hands off a
-// link to the website's /post/:postId route, which renders for signed-out
+// Sharing posts and comments (issues #34, #381, #382). The share action hands
+// off a link to the website's /post/:postId route, which renders for signed-out
 // recipients too — a shared post is readable without an account as long as it
-// is public. Deep-linking the same URL into the mobile apps is tracked
-// separately (#382).
+// is public. The same URL is claimed by the mobile apps as an iOS Universal
+// Link / Android App Link, so on a phone with the app installed it opens there
+// instead of the browser; see ios/DEEP_LINKING.md.
 
 /**
  * The absolute URL for a post's detail page, rooted at the current deployment's

--- a/website/src/utils/shareLink.ts
+++ b/website/src/utils/shareLink.ts
@@ -1,8 +1,8 @@
-// Sharing posts and comments (issue #34). Scope A is an in-app share/copy-link
-// action; the URL points at the website's existing /post/:postId route. Making
-// that route publicly viewable and deep-linking it into the mobile apps is a
-// tracked follow-up (Scope B), so a shared link currently opens the site and
-// prompts login for signed-out recipients.
+// Sharing posts and comments (issues #34, #381). The share action hands off a
+// link to the website's /post/:postId route, which renders for signed-out
+// recipients too — a shared post is readable without an account as long as it
+// is public. Deep-linking the same URL into the mobile apps is tracked
+// separately (#382).
 
 /**
  * The absolute URL for a post's detail page, rooted at the current deployment's
@@ -15,11 +15,24 @@ export function postShareUrl(postIdentifier: string): string {
 
 /**
  * The URL for a specific comment: the post page plus a `#comment-<id>` fragment.
- * Nothing consumes the fragment yet, but it is forward-compatible with scrolling
- * to the comment once the detail page honors it, and it is harmless today.
+ * The detail page resolves the fragment by scrolling to (and marking out) that
+ * comment within its thread — see `sharedCommentId`.
  */
 export function commentShareUrl(postIdentifier: string, commentIdentifier: string): string {
   return `${postShareUrl(postIdentifier)}#comment-${commentIdentifier}`
+}
+
+/**
+ * The inverse of `commentShareUrl`: the comment id a location hash points at,
+ * or null when the hash is absent or is not a comment link.
+ *
+ * The id must look like a UUID. The value is used to build a DOM id and to
+ * match against rendered comments, so anything else is ignored rather than
+ * trusted — a hash is attacker-supplied whenever a link is.
+ */
+export function sharedCommentId(hash: string): string | null {
+  const match = /^#comment-([0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12})$/.exec(hash)
+  return match ? match[1] : null
 }
 
 /**


### PR DESCRIPTION
Closes #382. **Stacked on #468** — it branches off that work, so its commit shows in this diff until #468 merges. Per CLAUDE.md this still targets `dev`; merge #468 first.

A shared `https://smiling.social/post/<id>` link opened the **browser** on mobile even with the app installed. Now it opens the app — and still opens the public web page (#381) when the app isn't there, so the link works either way. That's what makes claiming the domain safe: a failed association just means links keep opening the browser.

## iOS — Universal Links

- `com.apple.developer.associated-domains` in the entitlements, claiming `applinks:smiling.social` and `applinks:www.smiling.social`.
- `ShareURL.parse(_:)` — the exact inverse of the existing `ShareURL.post` / `ShareURL.comment` builders, living beside them, returning a `SharedPostLink` (post id + optional `#comment-<id>`).
- `.onOpenURL` in `Positive_Only_SocialApp` hands the post id to `PushRouter`.
- `website/public/.well-known/apple-app-site-association`, scoped to `/post/*`.
- `ios/DEEP_LINKING.md` documents the Apple-portal steps (Associated Domains capability + regenerated profiles) that can't live in the repo.

## Android — App Links

- An `autoVerify` `VIEW` intent-filter for `https://smiling.social/post/*` (and the `www.` host).
- `ShareLinks.parseSharedPostLink` — same inverse-of-the-builders shape, pure (`java.net.URI`, not `android.net.Uri`) so it unit-tests on the JVM.
- `MainActivity` parses the intent's data in both `onCreate` and `onNewIntent` and hands the post id to `PushNavigator`, clearing the data so an Activity recreation can't re-navigate.
- `assetlinks.json` generated at deploy time (below).

## Two deliberate deviations from the issue

**No `navDeepLink` on the `PostDetail` route.** `PostDetail` is an *authenticated* screen. With a `navDeepLink`, `NavHost` resolves the incoming `VIEW` intent itself and builds a back stack straight to it — even when the user is signed out, landing them on a screen with no session behind it. Routing through `PushNavigator` instead reuses the existing "hold the request until `isLoggedIn`" effect that the push flow already has, so a link opened while signed out waits for login. Same reasoning on iOS, where `HomeView` (which consumes the request) doesn't exist until logged in. Both are commented at the point of decision.

**The `#comment-<id>` fragment is parsed and carried, but the post is what opens.** Scrolling to the specific comment stays web-only — doing it on mobile means plumbing a highlighted-comment id through the thread and row views on both platforms, which is a much larger change than this issue describes. The parsed id is on the link model for whoever wires it up.

## Association files

`apple-app-site-association` is checked in — the Team ID (`7L9M852R4K`) and bundle id are already in `project.pbxproj`. `deploy-web.sh` uploads it with an explicit `application/json` content type: it has no extension, so a plain `s3 sync` guesses `binary/octet-stream` and iOS rejects it.

`assetlinks.json` is **generated at deploy time** from `ANDROID_SHA256_CERT_FINGERPRINTS`, because the release signing fingerprint lives in Play Console, not the repo. Unset, the deploy leaves the file untouched and warns, rather than publishing a half-configured one — a wrong fingerprint fails verification silently. Both files are excluded from the sync's `--delete` for that reason.

## Tests

Parsing is where the risk is, since an `.onOpenURL` callback or a `VIEW` intent can carry any URL, so both platforms cover: round-tripping a link the builders produced, the `www.` host, case-insensitive scheme/host, a trailing slash, a query string, an unrecognized fragment (post still opens), and rejection of look-alike hosts (`smiling.social.evil.example`), `http://`, `/posts/`, `/post/` with no id, deeper paths, and other routes.

`android/.../ShareLinksTest.kt` runs in the existing `./gradlew test` job; `Positive_Only_SocialTests_ShareURL.swift` runs in the iOS `Unit_Tests` group. `ShareURL.swift` was already in both pbxproj `membershipExceptions` lists, so no project-file change was needed.

**I can't build iOS or Android locally** (no Xcode on Windows, no JDK on this machine) — those two suites are on CI. The website's four checks and both backend suites (974 Django tests + pytest) were run locally and pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)