### PR TITLE
Fix 500 when remember_me is omitted from login or registration

### DIFF
--- a/backend/user_system/tests/test_convert_to_bool.py
+++ b/backend/user_system/tests/test_convert_to_bool.py
@@ -1,0 +1,46 @@
+"""Tests for `convert_to_bool`.
+
+Its contract is "returns a bool or raises TypeError", and callers lean on that:
+every view that reads an optional boolean field wraps it in `except TypeError`
+to turn a bad value into a 400. When a non-string slipped through to `.lower()`
+it raised AttributeError instead, which no caller catches — so a request that
+merely omitted `remember_me` came back as a 500.
+"""
+
+from django.test import SimpleTestCase
+
+from ..utils import convert_to_bool
+
+
+class ConvertToBoolTests(SimpleTestCase):
+
+    def test_parses_the_string_forms_in_any_case(self):
+        for value, expected in [
+            ('true', True), ('True', True), ('TRUE', True),
+            ('false', False), ('False', False), ('FALSE', False),
+        ]:
+            with self.subTest(value=value):
+                self.assertIs(convert_to_bool(value), expected)
+
+    def test_passes_an_actual_bool_straight_through(self):
+        self.assertIs(convert_to_bool(True), True)
+        self.assertIs(convert_to_bool(False), False)
+
+    def test_an_unparseable_string_raises_type_error(self):
+        with self.assertRaises(TypeError):
+            convert_to_bool('perhaps')
+        with self.assertRaises(TypeError):
+            convert_to_bool('')
+
+    def test_none_raises_type_error_rather_than_attribute_error(self):
+        """The regression: `None.lower()` raised AttributeError, which escaped
+        every caller's except clause and turned a missing field into a 500."""
+        with self.assertRaises(TypeError):
+            convert_to_bool(None)
+
+    def test_non_string_types_raise_type_error(self):
+        """A JSON body can carry a number, a list or an object here."""
+        for value in (1, 0, 1.5, [], {}, object()):
+            with self.subTest(value=value):
+                with self.assertRaises(TypeError):
+                    convert_to_bool(value)

--- a/backend/user_system/tests/test_login_view.py
+++ b/backend/user_system/tests/test_login_view.py
@@ -85,6 +85,38 @@ class LoginUserTests(PositiveOnlySocialTestCase):
 
         self.assertEqual(response.status_code, 400)
 
+    def test_non_string_remember_me_is_a_validation_error_not_a_crash(self):
+        """
+        A JSON number is neither a bool nor a parseable string. It used to reach
+        `.lower()` and raise AttributeError, which no caller catches, so the
+        request came back as a 500 instead of a validation error.
+        """
+        data = self.valid_data.copy()
+        data['remember_me'] = 1
+
+        response = self.client.post(self.url, data=data, content_type='application/json')
+
+        self.assertEqual(response.status_code, 400)
+
+    def test_omitted_remember_me_logs_in_without_remembering(self):
+        """
+        'remember_me' is optional — the website's own LoginRequest type marks it
+        so, and its API tests call login without it. Leaving it out must mean
+        "don't remember me", not a 500 (which is what the AttributeError from
+        `None.lower()` used to produce).
+        """
+        data = self.valid_data.copy()
+        del data['remember_me']
+
+        response = self.client.post(self.url, data=data, content_type='application/json')
+
+        self.assertEqual(response.status_code, 200)
+        fields = response.json()
+        self.assertIn(Fields.session_management_token, fields)
+        # No remembered device was asked for, so none is issued.
+        self.assertNotIn(Fields.series_identifier, fields)
+        self.assertNotIn(Fields.login_cookie_token, fields)
+
     def test_user_with_remember_me_and_username_returns_good_response(self):
         """
         Tests "happy path": login with username and remember_me=true.

--- a/backend/user_system/tests/test_login_view.py
+++ b/backend/user_system/tests/test_login_view.py
@@ -98,6 +98,21 @@ class LoginUserTests(PositiveOnlySocialTestCase):
 
         self.assertEqual(response.status_code, 400)
 
+    def test_null_remember_me_is_treated_as_omitted(self):
+        """
+        An explicit JSON null means "no value", exactly like leaving the key out.
+        This API does not distinguish the two anywhere — date_of_birth and the
+        interest fields are read the same way — and a client that serializes an
+        unset optional as null rather than dropping the key must not be rejected.
+        """
+        data = self.valid_data.copy()
+        data['remember_me'] = None
+
+        response = self.client.post(self.url, data=data, content_type='application/json')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn(Fields.login_cookie_token, response.json())
+
     def test_omitted_remember_me_logs_in_without_remembering(self):
         """
         'remember_me' is optional — the website's own LoginRequest type marks it

--- a/backend/user_system/tests/test_register_view.py
+++ b/backend/user_system/tests/test_register_view.py
@@ -89,6 +89,40 @@ class RegisterTests(PositiveOnlySocialTestCase):
 
         self.assertEqual(response.status_code, 400)
 
+    def test_non_string_remember_me_is_a_validation_error_not_a_crash(self):
+        """
+        A JSON number is neither a bool nor a parseable string. It used to reach
+        `.lower()` and raise AttributeError, which no caller catches, so the
+        request came back as a 500 instead of a validation error.
+        """
+        data = self.valid_data.copy()
+        data['remember_me'] = 1
+
+        response = self.client.post(self.url, data=data, content_type='application/json')
+
+        self.assertEqual(response.status_code, 400)
+
+    @patch.dict(os.environ, {"TESTING": "True"}, clear=True)
+    def test_omitted_remember_me_registers_without_remembering(self):
+        """
+        'remember_me' is optional — the website's own RegisterRequest type marks
+        it so. Leaving it out must create the account without a remembered
+        device, not fail with a 500 (which is what the AttributeError from
+        `None.lower()` used to produce).
+        """
+        data = self.valid_data.copy()
+        del data['remember_me']
+
+        response = self.client.post(self.url, data=data, content_type='application/json')
+
+        self.assertEqual(response.status_code, 201)
+        fields = response.json()
+        self.assertIn(Fields.session_management_token, fields)
+        # No remembered device was asked for, so none is issued.
+        self.assertNotIn(Fields.series_identifier, fields)
+        self.assertNotIn(Fields.login_cookie_token, fields)
+        self.assertIsNotNone(get_user_model().objects.filter(username=self.local_username).first())
+
     @patch.dict(os.environ, {"TESTING": "True"}, clear=True)
     def test_user_already_exists_returns_bad_response(self):
         """

--- a/backend/user_system/tests/test_register_view.py
+++ b/backend/user_system/tests/test_register_view.py
@@ -103,6 +103,22 @@ class RegisterTests(PositiveOnlySocialTestCase):
         self.assertEqual(response.status_code, 400)
 
     @patch.dict(os.environ, {"TESTING": "True"}, clear=True)
+    def test_null_remember_me_is_treated_as_omitted(self):
+        """
+        An explicit JSON null means "no value", exactly like leaving the key out.
+        This API does not distinguish the two anywhere — date_of_birth and the
+        interest fields are read the same way — and a client that serializes an
+        unset optional as null rather than dropping the key must not be rejected.
+        """
+        data = self.valid_data.copy()
+        data['remember_me'] = None
+
+        response = self.client.post(self.url, data=data, content_type='application/json')
+
+        self.assertEqual(response.status_code, 201)
+        self.assertNotIn(Fields.login_cookie_token, response.json())
+
+    @patch.dict(os.environ, {"TESTING": "True"}, clear=True)
     def test_omitted_remember_me_registers_without_remembering(self):
         """
         'remember_me' is optional — the website's own RegisterRequest type marks

--- a/backend/user_system/utils.py
+++ b/backend/user_system/utils.py
@@ -38,14 +38,28 @@ def hash_string_sha256(input_string):
 
 
 def convert_to_bool(str_value):
-    """Converts a string to boolean."""
+    """Convert a bool, or the string 'true'/'false' in any case, to a bool.
 
-    if type(str_value) == bool:
+    Raises TypeError for everything else — including None and non-string types
+    like an int or a dict, which arrive whenever a client sends
+    `"remember_me": 1` or omits the field entirely.
+
+    That "everything else" matters: callers catch TypeError to turn a bad value
+    into a 400, so a non-string input has to raise TypeError and not the
+    AttributeError a bare `.lower()` used to raise. AttributeError escaped every
+    caller's except clause, so a request that merely left the field out came back
+    as a 500 instead of a validation error.
+    """
+    if isinstance(str_value, bool):
         return str_value
 
-    if str_value.lower() == 'true':
+    if not isinstance(str_value, str):
+        raise TypeError('Invalid input')
+
+    lowered = str_value.lower()
+    if lowered == 'true':
         return True
-    elif str_value.lower() == 'false':
+    elif lowered == 'false':
         return False
     else:
         raise TypeError('Invalid input')

--- a/backend/user_system/views.py
+++ b/backend/user_system/views.py
@@ -612,6 +612,31 @@ def _issue_recovery_codes(user):
     return raw_codes
 
 
+def _read_remember_me(data, invalid_fields):
+    """Read the optional `remember_me` flag from a request body.
+
+    Omitting it means "don't remember me". Every client already treats the field
+    as optional — the website's own LoginRequest/RegisterRequest types mark it
+    so, and the API tests call login without it — and a caller that never wants a
+    remembered device should not have to say so.
+
+    A value that is *present but unparseable* stays a validation error: that is a
+    caller sending something it believes means yes or no, and quietly reading it
+    as "no" would hide the mistake rather than report it.
+
+    Shared by register and login_user so the two cannot drift apart on what a
+    missing or malformed flag means.
+    """
+    raw = data.get(Fields.remember_me)
+    if raw is None:
+        return False
+    try:
+        return convert_to_bool(raw)
+    except TypeError:
+        invalid_fields.append(Params.remember_me)
+        return False
+
+
 def _create_authenticated_session(view_name, request, user, ip, remember_me):
     """Final step of a successful authentication: Django session login, the
     remember-me cookie (when requested), the API session token, and the
@@ -667,7 +692,6 @@ def register(request):
     username = data.get(Fields.username)
     email = data.get(Fields.email)
     password = data.get(Fields.password)
-    remember_me_str = data.get(Fields.remember_me)
     ip = _get_client_ip(None, request)
     date_of_birth_str = data.get('date_of_birth')
 
@@ -705,11 +729,7 @@ def register(request):
         # rejected — the age gate only bites once an age is actually given.
         pass
 
-    try:
-        remember_me = convert_to_bool(remember_me_str)
-    except TypeError:
-        remember_me = False  # Default to false if invalid
-        invalid_fields.append(Params.remember_me)
+    remember_me = _read_remember_me(data, invalid_fields)
 
     if len(invalid_fields) > 0:
         logger.warning(f"Registration failed: Invalid fields {invalid_fields}")
@@ -871,7 +891,6 @@ def login_user(request):
 
     username_or_email = data.get(Fields.username_or_email)
     password = data.get(Fields.password)
-    remember_me_str = data.get(Fields.remember_me)
     ip = _get_client_ip(None, request)
 
     invalid_fields = []
@@ -882,11 +901,7 @@ def login_user(request):
     if not password or not is_valid_pattern(password, Patterns.login_password):
         invalid_fields.append(Params.password)
 
-    try:
-        remember_me = convert_to_bool(remember_me_str)
-    except TypeError:
-        remember_me = False
-        invalid_fields.append(Params.remember_me)
+    remember_me = _read_remember_me(data, invalid_fields)
     if len(invalid_fields) > 0:
         return log_and_return_json("login_user", {'error': f"Invalid fields {invalid_fields}"}, status=400)
 

--- a/backend/user_system/views.py
+++ b/backend/user_system/views.py
@@ -615,14 +615,22 @@ def _issue_recovery_codes(user):
 def _read_remember_me(data, invalid_fields):
     """Read the optional `remember_me` flag from a request body.
 
-    Omitting it means "don't remember me". Every client already treats the field
+    **No value means "don't remember me".** Every client already treats the field
     as optional — the website's own LoginRequest/RegisterRequest types mark it
     so, and the API tests call login without it — and a caller that never wants a
     remembered device should not have to say so.
 
-    A value that is *present but unparseable* stays a validation error: that is a
-    caller sending something it believes means yes or no, and quietly reading it
-    as "no" would hide the mistake rather than report it.
+    "No value" covers both an absent key and an explicit JSON `null`, which
+    `data.get` cannot tell apart and which this API deliberately does not
+    distinguish anywhere: `date_of_birth`, `interest_categories` and
+    `interest_freeform` are all read the same way. Rejecting a `null` here alone
+    would be inconsistent, and would break any client that serializes an unset
+    optional as null rather than dropping the key — which is exactly the class of
+    failure this helper exists to stop.
+
+    **A value that is present and not null but unparseable is a validation
+    error**: that is a caller sending something it believes means yes or no, and
+    quietly reading it as "no" would hide the mistake rather than report it.
 
     Shared by register and login_user so the two cannot drift apart on what a
     missing or malformed flag means.


### PR DESCRIPTION
A request that simply leaves `remember_me` out of the body gets a **500** from `POST /user_index/login/` and `POST /user_index/register/`, instead of being handled.

## Why

`convert_to_bool` (`backend/user_system/utils.py`) is documented as raising `TypeError`, and both endpoints lean on that:

```python
try:
    remember_me = convert_to_bool(remember_me_str)
except TypeError:
    remember_me = False
    invalid_fields.append(Params.remember_me)
```

But it reached `str_value.lower()` for anything that wasn't a `bool`, so `None` raised **`AttributeError`** — which escapes both `except` clauses and becomes an unhandled 500. `"remember_me": 1` did the same. Only a bad *string* ("perhaps") was ever actually handled.

This is reachable from our own clients, not just hand-rolled requests: the website's `LoginRequest` and `RegisterRequest` types both mark `remember_me` optional, and `client.test.ts` already calls `client.login({ username_or_email, password })` with no flag at all.

## The fix

**`convert_to_bool` honours its contract.** Bools pass through, `'true'`/`'false'` parse in any case, and everything else — `None`, ints, lists, dicts — raises `TypeError`. Callers written against the documented behaviour now actually catch what it throws.

**A shared `_read_remember_me` helper** replaces the duplicated block in `register` and `login_user`, so they cannot drift on what a missing or malformed flag means:

- **Omitted → `false`.** The field is optional on every client, and a caller that never wants a remembered device shouldn't have to say so.
- **Present but unparseable → 400.** That's a caller sending something it believes means yes or no; silently reading it as "no" would hide the mistake rather than report it.

No behaviour changes for any request that already sent a valid flag.

## Tests

- `test_convert_to_bool.py` — new unit tests for the function itself, including `None` and the non-string types a JSON body can carry.
- `test_login_view.py` / `test_register_view.py` — regression tests for an omitted flag (now a normal 200/201 with no remember-me tokens issued) and a non-string one (now a 400).

I confirmed the four new endpoint tests genuinely bite: reverting `utils.py` and `views.py` and re-running them fails every one with exactly `AttributeError: 'NoneType' object has no attribute 'lower'` and `'int' object has no attribute 'lower'`.

Run locally from `backend/`: `python -m pytest tests` (23 passed) and the full `python manage.py test user_system.tests` suite.

## Note for whoever merges the Google sign-in PR

`login_user_google` on that branch guards this case itself (defaults a missing flag to `false`, catches `(TypeError, AttributeError)`). Once both land, that endpoint should switch to `_read_remember_me` too so all three read the flag identically — happy to do that as a follow-up on whichever branch merges second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
