### PR TITLE
Label the like count on your own posts as "n likes" (#476)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,10 @@ Posts can be acted on directly from any list — the Profile grid, another user'
 profile grid, and the Feed — without opening the post first:
 
 - **Like / unlike**, with the current like count. Hidden on your own posts,
-  which the backend refuses to let you like.
+  which the backend refuses to let you like. The count stays either way, but
+  without the heart to explain it the bare number is ambiguous, so on your own
+  posts it reads "n likes" — the label the post detail already uses (issue
+  #476).
 - **Save / unsave** (issue #193), a personal bookmark. Unlike a like it is
   offered on every post, including your own, since the saved list is a private
   collection rather than a public signal. Saved posts are collected on the

--- a/android/PositiveOnlySocial/app/src/androidTest/java/com/example/positiveonlysocial/PositiveOnlySocialIntegrationTests.kt
+++ b/android/PositiveOnlySocial/app/src/androidTest/java/com/example/positiveonlysocial/PositiveOnlySocialIntegrationTests.kt
@@ -798,6 +798,8 @@ class PositiveOnlySocialIntegrationTests {
         // No like control on your own post — the backend rejects it.
         composeTestRule.onAllNodesWithContentDescription("Like post by $testUsername")
             .assertCountEquals(0)
+        // With no heart beside it, the count says what it counts (issue #476).
+        composeTestRule.onAllNodesWithText("0 likes").onFirst().assertExists()
 
         composeTestRule.onAllNodesWithContentDescription("Options for post by $testUsername")
             .onFirst().performClick()

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/PostActions.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/PostActions.kt
@@ -84,8 +84,12 @@ fun PostActionBar(
             }
         }
 
+        // With no heart beside it the bare number says nothing about what it
+        // counts, so your own posts spell it out the way PostDetailScreen does
+        // (issue #476).
+        val likeCount = post.likeCount ?: 0
         Text(
-            text = "${post.likeCount ?: 0}",
+            text = if (isOwnPost) "$likeCount likes" else "$likeCount",
             style = if (compact) MaterialTheme.typography.labelSmall
             else MaterialTheme.typography.bodyMedium
         )

--- a/ios/Positive Only Social/Positive Only Social/VibesHelpers/HomeView.swift
+++ b/ios/Positive Only Social/Positive Only Social/VibesHelpers/HomeView.swift
@@ -241,7 +241,10 @@ struct PostActionBar: View {
                 .accessibilityIdentifier("PostListLikeButton")
                 .accessibilityLabel(state.isLiked ? "Unlike post" : "Like post")
             }
-            Text("\(state.likeCount)")
+            // With no heart beside it the bare number says nothing about what it
+            // counts, so your own posts spell it out the way PostDetailView does
+            // (issue #476).
+            Text(state.isOwn ? "\(state.likeCount) likes" : "\(state.likeCount)")
                 .foregroundColor(.secondary)
                 .accessibilityIdentifier("PostListLikeCount")
             if state.isReported {

--- a/ios/Positive Only Social/Positive Only SocialUITests/Positive_Only_SocialUITests.swift
+++ b/ios/Positive Only Social/Positive Only SocialUITests/Positive_Only_SocialUITests.swift
@@ -1340,6 +1340,12 @@ final class Positive_Only_SocialUITests: XCTestCase {
         expectation(for: NSPredicate(format: "count >= 1"), evaluatedWith: myPosts, handler: nil)
         waitForExpectations(timeout: TestConstants.timeout, handler: nil)
 
+        // Your own posts have no heart beside the count, so it says what it
+        // counts rather than showing a bare number (issue #476).
+        let likeCount = app.staticTexts.matching(identifier: "PostListLikeCount").element(boundBy: 0)
+        XCTAssertTrue(likeCount.waitForExistence(timeout: TestConstants.shortTimeout))
+        waitForLabel(likeCount, toEqual: "0 likes")
+
         let firstPost = myPosts.element(boundBy: 0)
         XCTAssertTrue(firstPost.waitForExistence(timeout: TestConstants.shortTimeout))
         firstPost.tap()

--- a/website/src/components/PostActionBar.tsx
+++ b/website/src/components/PostActionBar.tsx
@@ -55,7 +55,12 @@ function PostActionBar({
           {state.isLiked ? '♥' : '♡'}
         </button>
       )}
-      <span className="post-actions__count">{state.likeCount}</span>
+      {/* With no heart beside it the bare number says nothing about what it
+          counts, so your own posts spell it out the way the post detail does
+          (issue #476). */}
+      <span className="post-actions__count">
+        {state.isOwn ? `${state.likeCount} likes` : state.likeCount}
+      </span>
 
       {/* Tapping the comment count opens the post, where the threads live. */}
       {showDetails && onOpenPost && commentCount !== undefined && (

--- a/website/src/components/ProfileTab.test.tsx
+++ b/website/src/components/ProfileTab.test.tsx
@@ -174,6 +174,21 @@ test('does not offer a like control on your own posts', async () => {
   expect(screen.queryByRole('button', { name: 'Like post' })).not.toBeInTheDocument()
 })
 
+test('labels the like count on your own posts, which have no heart (#476)', async () => {
+  // Without the heart the number needs to say what it counts.
+  mockGetPosts.mockResolvedValue([
+    {
+      post_identifier: 'p1',
+      image_url: 'http://img/1.jpg',
+      author_username: 'ada',
+      caption: 'hi',
+      post_likes: 5,
+    },
+  ])
+  renderTab()
+  expect(await screen.findByText('5 likes')).toBeInTheDocument()
+})
+
 test('refresh reloads the user posts from the first page', async () => {
   mockGetPosts.mockResolvedValue([
     { post_identifier: 'p1', image_url: 'http://img/1.jpg', author_username: 'ada', caption: 'hi' },


### PR DESCRIPTION
Closes #476.

## The problem

The shared list action bar hides the heart on your own posts (the backend rejects liking them) but keeps the count. That leaves a bare number with nothing beside it to say what it counts — most visibly under the photos in your own Profile grid.

## The change

Label the count `"n likes"` exactly when the heart is absent, reusing the string the post detail already shows on every platform (including its existing un-pluralized `1 likes`). The condition is per-post (`isOwn`), not per-screen, so it also covers your own posts in the feed and the saved/tag lists, where the number was equally unexplained. Other people's posts keep the bare number — the adjacent heart already explains it.

- `website/src/components/PostActionBar.tsx`
- `ios/.../VibesHelpers/HomeView.swift` (iOS `PostActionBar` lives here)
- `android/.../ui/main/PostActions.kt`
- `README.md` — the post-actions spec records the label

## Tests

- New web test asserting `5 likes` on your own grid post (`ProfileTab.test.tsx`).
- Assertions folded into the existing own-post tests on iOS (`testOpenPostDetailFromHomeGrid`) and Android (`testDeleteOwnPostFromFeed`) — neither platform had any view-level coverage of this count before.
- The existing `ProfilePage.test.tsx` like tests view someone else's profile, so their bare-number assertions are unaffected.

## Verification

- Website: `npm run lint`, `npx tsc -b --noEmit`, `npm test` (427 passed), `npm run build` — all green locally.
- Android: `./gradlew test assembleDebug assembleAndroidTest` — BUILD SUCCESSFUL locally.
- iOS: not buildable on this machine; relying on CI for the UI test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
