### PR TITLE
Give the likes lists their avatar BlurHash, and clear a stale blur

### DIFF
--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/LikesDialog.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/LikesDialog.kt
@@ -101,7 +101,8 @@ fun LikesDialog(
                             imageUrl = user.authorProfileImageUrl,
                             originalImageUrl = user.authorProfileImageOriginalUrl,
                             contentDescription = null,
-                            size = 28.dp
+                            size = 28.dp,
+                            blurHash = user.authorProfileImageBlurHash
                         )
                         Spacer(Modifier.width(8.dp))
                         Text(user.username)

--- a/ios/Positive Only Social/Positive Only Social/VibesViews/LikesView.swift
+++ b/ios/Positive Only Social/Positive Only Social/VibesViews/LikesView.swift
@@ -43,6 +43,7 @@ struct LikesView: View {
                             ProfileAvatarView(
                                 imageUrl: user.authorProfileImageUrl,
                                 originalImageUrl: user.authorProfileImageOriginalUrl,
+                                blurHash: user.authorProfileImageBlurHash,
                                 size: 28
                             )
                             Text(user.username)

--- a/website/src/components/BlurhashCanvas.test.tsx
+++ b/website/src/components/BlurhashCanvas.test.tsx
@@ -1,0 +1,76 @@
+import { render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import BlurhashCanvas from './BlurhashCanvas'
+
+// A valid canonical BlurHash (the Wolt example string), and one that isn't.
+const BLURHASH = 'LEHV6nWB2yk8pyo0adR*.7kCMdnj'
+const OTHER_BLURHASH = 'L6PZfSi_.AyE_3t7t7R**0o#DgR4'
+const MALFORMED = 'not-a-blurhash'
+
+/**
+ * jsdom implements no 2d context, so `getContext('2d')` returns null and the
+ * component's draw is skipped entirely. Stand a minimal one in and record what
+ * it is asked to do, which is the only way to assert on pixels here.
+ */
+function stubContext() {
+  const ctx = {
+    createImageData: (width: number, height: number) => ({
+      data: new Uint8ClampedArray(width * height * 4),
+    }),
+    putImageData: vi.fn(),
+    clearRect: vi.fn(),
+  }
+  vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
+    ctx as unknown as CanvasRenderingContext2D,
+  )
+  return ctx
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('BlurhashCanvas', () => {
+  it('draws the decoded preview for a valid hash', () => {
+    const ctx = stubContext()
+
+    render(<BlurhashCanvas hash={BLURHASH} className="avatar__blur" />)
+
+    expect(ctx.putImageData).toHaveBeenCalledTimes(1)
+    expect(ctx.clearRect).not.toHaveBeenCalled()
+  })
+
+  it('redraws when the hash changes to another valid one', () => {
+    const ctx = stubContext()
+    const { rerender } = render(<BlurhashCanvas hash={BLURHASH} className="avatar__blur" />)
+
+    rerender(<BlurhashCanvas hash={OTHER_BLURHASH} className="avatar__blur" />)
+
+    expect(ctx.putImageData).toHaveBeenCalledTimes(2)
+    expect(ctx.clearRect).not.toHaveBeenCalled()
+  })
+
+  it('clears the canvas when a valid hash is replaced by a malformed one', () => {
+    // The canvas is reused across hash changes, so bailing out of the decode
+    // without clearing would leave the first hash's pixels standing in as the
+    // second image's placeholder — a blurred preview of the wrong photo.
+    const ctx = stubContext()
+    const { rerender } = render(<BlurhashCanvas hash={BLURHASH} className="avatar__blur" />)
+    expect(ctx.putImageData).toHaveBeenCalledTimes(1)
+
+    rerender(<BlurhashCanvas hash={MALFORMED} className="avatar__blur" />)
+
+    expect(ctx.clearRect).toHaveBeenCalledTimes(1)
+    // And nothing new was drawn over it.
+    expect(ctx.putImageData).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders without throwing when the hash is malformed from the start', () => {
+    const ctx = stubContext()
+
+    const { container } = render(<BlurhashCanvas hash={MALFORMED} className="avatar__blur" />)
+
+    expect(container.querySelector('canvas.avatar__blur')).not.toBeNull()
+    expect(ctx.putImageData).not.toHaveBeenCalled()
+  })
+})

--- a/website/src/components/BlurhashCanvas.tsx
+++ b/website/src/components/BlurhashCanvas.tsx
@@ -20,16 +20,21 @@ function BlurhashCanvas({ hash, className }: { hash: string; className: string }
   useEffect(() => {
     const canvas = canvasRef.current
     if (!canvas) return
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
     // A malformed hash makes decode throw; swallow it so a bad value just
-    // yields no placeholder rather than crashing the render.
+    // yields no placeholder rather than crashing the render. Clear the canvas
+    // rather than simply bailing: this effect re-runs on the same canvas when
+    // `hash` changes, so returning early would leave the *previous* hash's
+    // pixels standing in as this image's placeholder — a blurred preview of the
+    // wrong photo, which is worse than no preview at all.
     let pixels: Uint8ClampedArray
     try {
       pixels = decode(hash, BLUR_DECODE_SIZE, BLUR_DECODE_SIZE)
     } catch {
+      ctx.clearRect(0, 0, BLUR_DECODE_SIZE, BLUR_DECODE_SIZE)
       return
     }
-    const ctx = canvas.getContext('2d')
-    if (!ctx) return
     const imageData = ctx.createImageData(BLUR_DECODE_SIZE, BLUR_DECODE_SIZE)
     imageData.data.set(pixels)
     ctx.putImageData(imageData, 0, 0)

--- a/website/src/components/LikesModal.test.tsx
+++ b/website/src/components/LikesModal.test.tsx
@@ -34,6 +34,9 @@ function liker(username: string): UserSearchResult {
   return { username, identity_is_verified: false }
 }
 
+// A valid canonical BlurHash (the Wolt example string).
+const BLURHASH = 'LEHV6nWB2yk8pyo0adR*.7kCMdnj'
+
 beforeEach(() => {
   mockPostLikers.mockReset().mockResolvedValue([])
   mockCommentLikers.mockReset().mockResolvedValue([])
@@ -145,6 +148,21 @@ test('a first load that fails shows the error instead of claiming nobody liked i
 
   expect(await screen.findByRole('alert')).toHaveTextContent('Network is down')
   expect(screen.queryByText('No one has liked this yet.')).not.toBeInTheDocument()
+})
+
+test('a liker’s avatar gets its BlurHash preview, like every other avatar list', async () => {
+  mockPostLikers.mockResolvedValue([
+    { ...liker('alice'), author_profile_image_url: 'http://compressed/a.jpg', author_profile_image_blurhash: BLURHASH },
+  ])
+  const onClose = vi.fn()
+  const { container } = render(
+    <MemoryRouter initialEntries={['/post/post-1']}>
+      <LikesModal target={POST_TARGET} onClose={onClose} />
+    </MemoryRouter>,
+  )
+
+  await screen.findByText('alice')
+  expect(container.querySelector('canvas.avatar__blur')).not.toBeNull()
 })
 
 test('switching to another target clears the previous list rather than showing it stale', async () => {

--- a/website/src/components/LikesModal.tsx
+++ b/website/src/components/LikesModal.tsx
@@ -163,6 +163,7 @@ function LikesModal({ target, onClose }: LikesModalProps) {
               <Avatar
                 src={user.author_profile_image_url}
                 originalSrc={user.author_profile_image_original_url}
+                blurhash={user.author_profile_image_blurhash}
                 username={user.username}
                 size="sm"
               />


### PR DESCRIPTION
Addresses the two review findings on [#489](https://github.com/andrewkatson/pos/pull/489) (the `dev` → `main` release merge). Targets `dev` per CLAUDE.md, so the fix reaches #489 through the branch rather than by pushing to a shared branch.

## 1. `BlurhashCanvas` left stale pixels on a failed decode

The effect bailed out of a malformed-hash `decode` without touching the canvas. It re-runs on the *same* canvas when `hash` changes, so valid → malformed left the first hash's pixels standing in as the second image's placeholder — a blurred preview of the wrong photo, which is worse than no preview at all. Now it clears the canvas on the failed decode.

New `BlurhashCanvas.test.tsx` covers the transition, plus the valid→valid redraw and the malformed-from-the-start case. jsdom implements no 2d context, so the test stands one in and asserts on `putImageData`/`clearRect`.

## 2. The likes lists dropped the avatar BlurHash

The one avatar list added in #478 rendered avatars without the BlurHash, so it fell back to the flat placeholder while every other list (feed, comments, followers, blocked users) showed a blur. The backend has been sending `author_profile_image_blurhash` for likers all along via `_author_avatar_fields`.

The review flagged this on iOS only — **web and Android had the identical omission**, so all three surfaces are fixed:

- `LikesView.swift` → `blurHash: user.authorProfileImageBlurHash`
- `LikesModal.tsx` → `blurhash={user.author_profile_image_blurhash}`
- `LikesDialog.kt` → `blurHash = user.authorProfileImageBlurHash`

iOS is now the only avatar call site list with no omissions; `LikesView` was the last one.

## Testing

Website (all four CI checks, from `website/`): `npm run lint`, `npx tsc -b --noEmit`, `npm test` (535 passed / 44 files), `npm run build` — all clean.

No backend files touched, so the backend suites are unaffected. iOS and Android are one-line call-site changes to existing files (no new files, so no pbxproj membership work) and are left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)