### PR TITLE
website: read the GIS id API from google.accounts.id, where it lives

### DIFF
--- a/website/src/auth/googleIdentity.test.ts
+++ b/website/src/auth/googleIdentity.test.ts
@@ -7,13 +7,22 @@ import {
   resetGoogleIdentityServicesForTests,
 } from './googleIdentity'
 
-/** Stand-in for the `google` global the real GIS script installs. */
+/** Stand-in for the `google` global the real GIS script installs.
+ *
+ * The `accounts` layer is not decoration: the real script installs
+ * `google.accounts.id`, and a fake that flattens it to `google.id` will happily
+ * pass a suite written against the same mistake while the browser sees a
+ * `google` global the code cannot find its way into. Keep this shaped like the
+ * script's actual output, not like whatever the code currently reads.
+ */
 function fakeGoogle() {
   return {
-    id: {
-      initialize: vi.fn(),
-      renderButton: vi.fn(),
-      disableAutoSelect: vi.fn(),
+    accounts: {
+      id: {
+        initialize: vi.fn(),
+        renderButton: vi.fn(),
+        disableAutoSelect: vi.fn(),
+      },
     },
   }
 }
@@ -106,6 +115,22 @@ test('a failed load rejects and can be retried', async () => {
 
 test('a script that loads without installing an id API is a failure', async () => {
   const pending = loadGoogleIdentityServices()
+  scriptTag()?.dispatchEvent(new Event('load'))
+  await expect(pending).rejects.toThrow('without an id API')
+})
+
+test('the id API is looked for under accounts, not on the google global itself', async () => {
+  // Regression guard. GIS installs `google.accounts.id`; reading `google.id`
+  // instead produced a global that was present but never found, so the loader
+  // reported "loaded without an id API" and the button never rendered — while
+  // every test passed, because the fakes were flattened the same way.
+  //
+  // Installing the WRONG shape must therefore still be a failure. If someone
+  // reintroduces the flattened lookup, this is the test that fails.
+  const pending = loadGoogleIdentityServices()
+  window.google = {
+    id: { initialize: vi.fn(), renderButton: vi.fn(), disableAutoSelect: vi.fn() },
+  } as unknown as typeof window.google
   scriptTag()?.dispatchEvent(new Event('load'))
   await expect(pending).rejects.toThrow('without an id API')
 })

--- a/website/src/auth/googleIdentity.ts
+++ b/website/src/auth/googleIdentity.ts
@@ -42,28 +42,37 @@ export interface GoogleCredentialResponse {
   credential: string
 }
 
+// The script installs a single `window.google` global and hangs everything off
+// `google.accounts` — the ID-token API this app uses is `google.accounts.id`,
+// NOT `google.id`. The namespace is easy to drop when writing the type by hand,
+// and dropping it fails in the worst possible way: the script loads fine, the
+// `google` global is present, and only the lookup misses, so the loader reports
+// "loaded but installed nothing usable" and the button never renders. Tests
+// cannot catch that on their own — a fake shaped like the mistake passes.
 export interface GoogleIdentityServices {
-  id: {
-    initialize(config: {
-      client_id: string
-      callback: (response: GoogleCredentialResponse) => void
-      auto_select?: boolean
-      cancel_on_tap_outside?: boolean
-      use_fedcm_for_prompt?: boolean
-    }): void
-    renderButton(
-      parent: HTMLElement,
-      options: {
-        type?: 'standard' | 'icon'
-        theme?: 'outline' | 'filled_blue' | 'filled_black'
-        size?: 'small' | 'medium' | 'large'
-        text?: 'signin_with' | 'signup_with' | 'continue_with' | 'signin'
-        shape?: 'rectangular' | 'pill' | 'circle' | 'square'
-        width?: number
-        logo_alignment?: 'left' | 'center'
-      },
-    ): void
-    disableAutoSelect(): void
+  accounts: {
+    id: {
+      initialize(config: {
+        client_id: string
+        callback: (response: GoogleCredentialResponse) => void
+        auto_select?: boolean
+        cancel_on_tap_outside?: boolean
+        use_fedcm_for_prompt?: boolean
+      }): void
+      renderButton(
+        parent: HTMLElement,
+        options: {
+          type?: 'standard' | 'icon'
+          theme?: 'outline' | 'filled_blue' | 'filled_black'
+          size?: 'small' | 'medium' | 'large'
+          text?: 'signin_with' | 'signup_with' | 'continue_with' | 'signin'
+          shape?: 'rectangular' | 'pill' | 'circle' | 'square'
+          width?: number
+          logo_alignment?: 'left' | 'center'
+        },
+      ): void
+      disableAutoSelect(): void
+    }
   }
 }
 
@@ -80,7 +89,7 @@ let loadPromise: Promise<GoogleIdentityServices> | null = null
 
 /** Load the GIS script, resolving with the `google` global it installs. */
 export function loadGoogleIdentityServices(): Promise<GoogleIdentityServices> {
-  if (window.google?.id) {
+  if (window.google?.accounts?.id) {
     return Promise.resolve(window.google)
   }
   if (loadPromise) {
@@ -108,7 +117,7 @@ export function loadGoogleIdentityServices(): Promise<GoogleIdentityServices> {
     script.addEventListener(
       'load',
       () => {
-        if (window.google?.id) {
+        if (window.google?.accounts?.id) {
           resolve(window.google)
         } else {
           // Loaded but installed nothing usable, which is no better than not

--- a/website/src/components/GoogleSignInButton.test.tsx
+++ b/website/src/components/GoogleSignInButton.test.tsx
@@ -13,19 +13,21 @@ vi.mock('../auth/googleIdentity', async importOriginal => {
 /** Captures the callback GIS would invoke, so a test can "pick an account". */
 function fakeGoogle() {
   let callback: ((response: GoogleCredentialResponse) => void) | null = null
-  const google = {
-    id: {
-      initialize: vi.fn((config: { callback: (r: GoogleCredentialResponse) => void }) => {
-        callback = config.callback
-      }),
-      renderButton: vi.fn(),
-      disableAutoSelect: vi.fn(),
-    },
+  // Shaped like what the real script installs — `google.accounts.id`, not
+  // `google.id`. Flattening it here would let the component read a namespace
+  // the browser never exposes and still pass every test.
+  const id = {
+    initialize: vi.fn((config: { callback: (r: GoogleCredentialResponse) => void }) => {
+      callback = config.callback
+    }),
+    renderButton: vi.fn(),
+    disableAutoSelect: vi.fn(),
   }
+  const google = { accounts: { id } }
   return {
     google: google as unknown as GoogleIdentityServices,
     signInAs: (credential: string) => callback?.({ credential }),
-    google_: google,
+    google_: { id },
   }
 }
 

--- a/website/src/components/GoogleSignInButton.tsx
+++ b/website/src/components/GoogleSignInButton.tsx
@@ -62,7 +62,7 @@ function GoogleSignInButton({
     loadGoogleIdentityServices()
       .then(google => {
         if (cancelled || !containerRef.current) return
-        google.id.initialize({
+        google.accounts.id.initialize({
           client_id: googleClientId(),
           callback: response => onCredentialRef.current(response.credential),
           // Never sign someone in without them asking: a returning visitor
@@ -70,7 +70,7 @@ function GoogleSignInButton({
           // Google session they forgot they had.
           auto_select: false,
         })
-        google.id.renderButton(containerRef.current, {
+        google.accounts.id.renderButton(containerRef.current, {
           type: 'standard',
           theme: 'filled_black',
           size: 'large',


### PR DESCRIPTION
**Google sign-in has never worked on the website.** Found while debugging a live "Google sign-in is unavailable right now" on production.

## The bug

The GIS script installs one `window.google` global with everything under `google.accounts` — the ID-token API is **`google.accounts.id`**. The code looked for `window.google.id`:

| Site | Was | Now |
|---|---|---|
| `googleIdentity.ts` short-circuit | `window.google?.id` | `window.google?.accounts?.id` |
| `googleIdentity.ts` load handler | `window.google?.id` | `window.google?.accounts?.id` |
| `GoogleSignInButton.tsx` | `google.id.initialize` | `google.accounts.id.initialize` |
| `GoogleSignInButton.tsx` | `google.id.renderButton` | `google.accounts.id.renderButton` |

The hand-written `GoogleIdentityServices` interface was missing the `accounts` layer, so TypeScript agreed with the mistake throughout.

## Why it looked like something else

The failure mode is close to the worst available. The script loads fine and the global *is* installed — only the lookup misses. So the loader takes its "loaded but installed nothing usable" branch, rejects, and the page renders:

> Google sign-in is unavailable right now. Please use your password.

That copy exists for a blocked or unreachable Google. So a pure code bug impersonates a network problem **on the user's end**, and is indistinguishable from an ad blocker doing its job — which is exactly how it was misdiagnosed in the field before `Object.keys(window.google)` came back as `['accounts']`.

## Why the tests passed

Both fakes were flattened the same way the code was:

```js
function fakeGoogle() {
  return { id: { initialize: vi.fn(), ... } }   // not what GIS installs
}
```

A mock shaped like the mistake cannot catch the mistake. The suite was green over a feature that could never work in a browser.

Both fakes are now shaped like the script's real output, and a **regression test installs the wrong shape and asserts the loader still rejects**:

```js
test('the id API is looked for under accounts, not on the google global itself', ...)
```

Verified it has teeth rather than assuming: restoring the old lookup fails 7 tests, including that one.

## Testing

All four CI checks from `website/`: `npm run lint`, `npx tsc -b --noEmit`, `npm test` (544 passed / 45 files), `npm run build` — clean. No backend, iOS, or Android files touched.

## Deploying

Needs a website redeploy to reach users (`deploy-web.sh` with the usual `VITE_*` vars). Nothing server-side changes — `GOOGLE_OAUTH_CLIENT_IDS` and the backend endpoint were never reached by the broken client, so that half of the feature is still unverified end to end and gets its first real exercise once this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)