### PR TITLE
backend: give gunicorn a keepalive that outlives the load balancer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1319,6 +1319,42 @@ nginx, the classification worker (active/enabled, or "stranding!" if enabled but
 dead), the two timers (last/next run), and best-effort `classification` queue
 depth — so a silently dead worker is visible at a glance.
 
+### gunicorn tuning, and the keepalive that must beat the load balancer
+
+`backend/gunicorn.conf.py` holds the gunicorn settings that are the same on every
+host. **Nothing passes it with `-c`** — gunicorn auto-loads `./gunicorn.conf.py`
+from its working directory, and the systemd unit's `WorkingDirectory` is
+`backend/`. Reading the unit alone gives no hint the file exists, so look for it
+before concluding a setting "isn't configured anywhere".
+
+Command-line flags in `ExecStart` override the file, so the split is: per-host
+wiring (`--bind`, `--workers`) in the unit, everything shared in the file.
+
+The one setting there is `keepalive = 75`, and it needs to stay **above the ALB's
+idle timeout** (60s). The API is reached through CloudFront → ALB → gunicorn, and
+the ALB pools upstream connections. If gunicorn's keepalive is the shorter of the
+two, the ALB reuses a connection gunicorn has already begun closing, the request
+lands in a socket being torn down, and the client gets a **502** — intermittently,
+under load, in a way that looks like an application fault rather than a timeout
+mismatch. Gunicorn's default is 2 seconds, so this is not a value to leave unset.
+
+Two ways it silently reverts to 2 seconds:
+
+- **Misspelling it.** The config-file setting is `keepalive`; the *command-line
+  flag* is `--keep-alive`. Gunicorn's loader skips names it does not recognize,
+  so `keep_alive = 5` in this file is accepted, ignored, and never warned about.
+- **Raising the ALB's idle timeout above 75** without raising this to match.
+
+Check the ALB's current value with:
+
+```bash
+aws elbv2 describe-load-balancer-attributes --region us-east-2 \
+    --load-balancer-arn <arn> \
+    --query "Attributes[?Key=='idle_timeout.timeout_seconds'].Value" --output text
+```
+
+Changing this file needs only a `sudo systemctl restart gunicorn`, not a deploy.
+
 ### Backend logs (issue #484)
 
 Every unit in the table above logs to the **same** file,

--- a/backend/gunicorn.conf.py
+++ b/backend/gunicorn.conf.py
@@ -1,0 +1,31 @@
+# gunicorn configuration for the API host.
+#
+# Gunicorn loads this file automatically when its working directory is the one
+# holding it, so no -c flag appears in the systemd unit and none is needed: the
+# unit sets WorkingDirectory to this directory. That auto-discovery is easy to
+# miss when reading the unit alone — nothing there mentions this file.
+#
+# Command-line flags in the unit's ExecStart still win over anything set here.
+#
+# This file deliberately holds ONLY settings that are the same on every host.
+# Per-host wiring — the bind address and the worker count — stays in the systemd
+# unit, because a unix-socket host and a TCP host genuinely disagree about it and
+# a value here would be silently overridden on whichever host passes the flag.
+
+# Longer than the idle timeout of the load balancer in front of this host (60s on
+# the ALB), so gunicorn is never the side that closes a pooled connection first.
+#
+# When the application's keepalive is the SHORTER of the two, the balancer keeps
+# reusing a connection gunicorn has already decided to close: the request lands in
+# a socket being torn down and the client gets a 502. It is intermittent and
+# load-dependent, so it is painful to attribute to the right layer.
+#
+# Gunicorn's default is 2 seconds, well under any balancer's idle timeout. Raise
+# this if the ALB's idle_timeout.timeout_seconds is ever raised above 75.
+#
+# NOTE the spelling. The config-file setting is `keepalive`, one word, while the
+# command-line flag is `--keep-alive`, hyphenated — so translating the flag into
+# this file invites writing `keep_alive`. Gunicorn skips names it does not
+# recognize ("Ignore unknown names" in its config loader), so that misspelling
+# produces no error, no warning, and no effect: the value silently stays 2.
+keepalive = 75

--- a/backend/tools/setup-django.sh
+++ b/backend/tools/setup-django.sh
@@ -412,6 +412,14 @@ run_django_setup() {
 }
 
 setup_gunicorn_service() {
+    # WorkingDirectory below is also where gunicorn looks for its config file:
+    # it auto-loads ./gunicorn.conf.py (checked in at backend/gunicorn.conf.py)
+    # without any -c flag. Nothing in this unit says so, which is exactly why it
+    # is worth saying here — that file is where `keepalive` is set, and a 502
+    # traced to keepalive would otherwise send you looking at this ExecStart.
+    #
+    # Flags below still override the file, so keep host-specific wiring (--bind,
+    # --workers) here and settings common to every host there.
     print_status "Setting up Gunicorn systemd service..."
 
     sudo tee /etc/systemd/system/gunicorn.service > /dev/null << EOF


### PR DESCRIPTION
Fixes an intermittent-502 setup found while walking the release deployment. Independent of the release itself.

## The problem

The API is reached through CloudFront → ALB → gunicorn, and the ALB pools upstream connections with a **60s idle timeout**. Gunicorn's `keepalive` default is **2 seconds**, so gunicorn is always the side that closes first: the ALB reuses a connection gunicorn has already begun tearing down, the request lands in a dying socket, and the client gets a 502. Intermittent, load-dependent, and easy to blame on the application.

The production host had an untracked `backend/gunicorn.conf.py` attempting to address this with `keep_alive = 5`. Two things were wrong with it:

1. **`keep_alive` is not a gunicorn setting.** The config-file name is `keepalive`, one word; the *command-line flag* is `--keep-alive`, hyphenated. Gunicorn's loader skips names it does not recognize — the comment in its source is literally "Ignore unknown names" — so the line produced no error, no warning, and no effect.
2. **5 seconds wouldn't have been enough anyway**, being well under the ALB's 60.

Every other line in that file (`bind`, `workers`, `timeout`, `graceful_timeout`) either restated a gunicorn default or duplicated a flag already in the unit's `ExecStart`, so the file as it stood changed nothing at all.

## The change

Adds `backend/gunicorn.conf.py` with `keepalive = 75` — above the ALB's idle timeout, so gunicorn is never the side that hangs up first.

Gunicorn **auto-loads `./gunicorn.conf.py` from its working directory**; no `-c` flag appears in the systemd unit and none is needed, because the unit's `WorkingDirectory` is `backend/`. That auto-discovery is invisible when reading the unit alone, which is how the file went unnoticed in the first place — so `setup-django.sh` now says so where the unit is written.

The file deliberately holds **only settings identical on every host**. Per-host wiring (`--bind`, `--workers`) stays in the unit, because a unix-socket host and a TCP host genuinely disagree about it and a value here would be silently overridden on whichever passes the flag.

`README.md` documents the file, the ALB relationship, and both ways the value silently reverts to 2 seconds (misspelling it, or raising the ALB's idle timeout past 75).

## Testing

`python -m pytest tests` passes (28 passed, 2 skipped). The Django suite is left to CI at the author's direction — this adds a file Django never imports plus comments in a shell script and the README, so no runtime behavior is touched by either suite.

## Deploying

Not a code deploy — takes effect on `sudo systemctl restart gunicorn` after the file is on the host. The production box's untracked copy should be deleted so the tracked one is the only source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)