### PR TITLE
Release: merge dev into main (Google sign-in button dark-mode fix)

### DIFF
--- a/website/src/components/GoogleSignInButton.tsx
+++ b/website/src/components/GoogleSignInButton.tsx
@@ -10,7 +10,7 @@ interface GoogleSignInButtonProps {
   onCredential: (idToken: string) => void
   /** Called when Google itself could not be reached or set up. */
   onError?: (message: string) => void
-  /** Google's button is an iframe we cannot disable, so it is hidden instead. */
+  /** Google's button takes no `disabled` attribute, so it is hidden instead. */
   disabled?: boolean
   /** 'signin_with' on the login page, 'signup_with' on the register page. */
   text?: 'signin_with' | 'signup_with' | 'continue_with'
@@ -108,9 +108,9 @@ function GoogleSignInButton({
       <div
         ref={containerRef}
         className="auth-google__button"
-        // Google renders an iframe we cannot put a `disabled` attribute on, so
-        // it is hidden outright while a request is in flight — a click that
-        // arrived mid-login would start a second one.
+        // Google renders a `div[role=button]`, which takes no `disabled`
+        // attribute, so it is hidden outright while a request is in flight — a
+        // click that arrived mid-login would start a second one.
         hidden={disabled}
         data-testid="google-sign-in-button"
       />

--- a/website/src/pages/LoginPage.css
+++ b/website/src/pages/LoginPage.css
@@ -444,3 +444,25 @@
 .auth-google__button[hidden] {
   display: none;
 }
+
+/* Google's `filled_black` button is dark (#202124) apart from one thing: it
+   seats the "G" on a hard-coded white 36px plate, the tile from its older
+   button artwork. On a page whose background is pure black that plate is the
+   only white pixels on the screen, so the button reads as a white box with a
+   dark border rather than as a dark button. Clearing the plate leaves the
+   coloured G directly on the pill, which is how Google's own current dark
+   button looks; nothing about the logo itself is altered.
+
+   Two things this selector is doing deliberately:
+
+     - It names Google's obfuscated class, which is not a public API. That is
+       the only handle the plate has. If Google renames it the rule stops
+       matching and the button falls back to today's appearance — the failure
+       is cosmetic, never broken layout, so this is safe to leave in place.
+     - It carries three classes to outrank Google's own two-class rule. Google
+       injects its stylesheet at render time, i.e. *after* this bundled one, so
+       an equal-specificity rule here would lose the tie on document order and
+       silently do nothing. */
+.auth-google__button .nsm7Bb-HzV7m-LgbsSe .nsm7Bb-HzV7m-LgbsSe-Bz112c-haAclf {
+  background-color: transparent;
+}

--- a/website/src/pages/LoginPage.css
+++ b/website/src/pages/LoginPage.css
@@ -402,8 +402,14 @@
   opacity: 0.85;
 }
 
-/* Google sign-in (issue #10). The button itself is an iframe Google renders and
-   styles; everything here is the space around it. */
+/* Google sign-in (issue #10). Google draws the button itself and ships the
+   stylesheet for it, so most of what follows is the space around it — but not
+   all of it. Despite the name, GIS renders the button as ordinary elements in
+   *our* document (a `div[role=button]`, class `.nsm7Bb-HzV7m-LgbsSe`), not in
+   an iframe; the one iframe it appends is 0×0 and carries no UI. Google's
+   internals are therefore reachable from here, which is what lets the last rule
+   in this section repaint part of the button. Reach in only where there is no
+   supported option, and expect the class names to be obfuscated. */
 .auth-google {
   display: flex;
   flex-direction: column;
@@ -432,8 +438,8 @@
   background: rgba(255, 255, 255, 0.15);
 }
 
-/* Google's iframe has a fixed pixel width; centring it keeps it aligned with
-   the full-width controls above even though it can't stretch to match them. */
+/* Google sizes the button to its own label — 187px, not the 420px card — so
+   centring is what keeps it aligned with the full-width controls above. */
 .auth-google__button {
   display: flex;
   justify-content: center;


### PR DESCRIPTION
## What

Release PR promoting `dev` to `main` for deployment.

`dev` differs from `main` by two merged PRs, both website-only:

```
 website/src/components/GoogleSignInButton.tsx |  8 +++---
 website/src/pages/LoginPage.css               | 36 ++++++++++++++++++++++++---
 2 files changed, 36 insertions(+), 8 deletions(-)
```

## The changes

**[#500](https://github.com/andrewkatson/pos/pull/500) — the actual fix.** One CSS rule that clears the hard-coded white plate Google seats its "G" logo on inside the sign-in button. The button already rendered dark (`filled_black` → `#202124`), but that 36×36 white plate was the only white pixels on the pure-black auth pages, so the button read as a white box. Clearing it leaves the coloured G directly on the dark pill, matching Google's current dark button. See #500 for why the selector needs three classes to outrank Google's runtime-injected stylesheet.

**[#502](https://github.com/andrewkatson/pos/pull/502) — comment accuracy, no behaviour change.** Review feedback on this PR caught that the surrounding comments called the button an iframe. It isn't one: GIS renders a `div[role=button]` in our own document, and the only iframe it appends is 0×0 with no UI — which is exactly why #500's override works at all. Corrected in the CSS header, the `.auth-google__button` comment, and twice in `GoogleSignInButton.tsx`, where the same claim justifies hiding the button rather than disabling it (still the right call: a `div[role=button]` takes no `disabled` attribute either).

So of the diff above, only the CSS rule in #500 changes what renders. Everything in `GoogleSignInButton.tsx` and the rest of the `LoginPage.css` delta is comments.

## Deploy notes

- **Website only.** No backend, iOS, or Android changes.
- **No migrations**, so no dual-leaf concern on this merge and no backend restart needed.
- Ships via `website/deploy-web.sh` (S3 + CloudFront). Remember the CloudFront invalidation so the new bundle is actually served.

## Verification

All four website CI checks passed on both #500 and #502 — `npm run lint`, `npx tsc -b --noEmit`, `npm test` (544 tests), `npm run build` — alongside CodeQL and GitGuardian. The fix itself was verified against the live button on https://smiling.social/login before and after, and the DOM claims in #502 were checked against the live button rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
