### PR TITLE
website: the Google sign-in button is not an iframe, so stop saying it is

### DIFF
--- a/website/src/components/GoogleSignInButton.tsx
+++ b/website/src/components/GoogleSignInButton.tsx
@@ -10,7 +10,7 @@ interface GoogleSignInButtonProps {
   onCredential: (idToken: string) => void
   /** Called when Google itself could not be reached or set up. */
   onError?: (message: string) => void
-  /** Google's button is an iframe we cannot disable, so it is hidden instead. */
+  /** Google's button takes no `disabled` attribute, so it is hidden instead. */
   disabled?: boolean
   /** 'signin_with' on the login page, 'signup_with' on the register page. */
   text?: 'signin_with' | 'signup_with' | 'continue_with'
@@ -108,9 +108,9 @@ function GoogleSignInButton({
       <div
         ref={containerRef}
         className="auth-google__button"
-        // Google renders an iframe we cannot put a `disabled` attribute on, so
-        // it is hidden outright while a request is in flight — a click that
-        // arrived mid-login would start a second one.
+        // Google renders a `div[role=button]`, which takes no `disabled`
+        // attribute, so it is hidden outright while a request is in flight — a
+        // click that arrived mid-login would start a second one.
         hidden={disabled}
         data-testid="google-sign-in-button"
       />

--- a/website/src/pages/LoginPage.css
+++ b/website/src/pages/LoginPage.css
@@ -402,8 +402,14 @@
   opacity: 0.85;
 }
 
-/* Google sign-in (issue #10). The button itself is an iframe Google renders and
-   styles; everything here is the space around it. */
+/* Google sign-in (issue #10). Google draws the button itself and ships the
+   stylesheet for it, so most of what follows is the space around it — but not
+   all of it. Despite the name, GIS renders the button as ordinary elements in
+   *our* document (a `div[role=button]`, class `.nsm7Bb-HzV7m-LgbsSe`), not in
+   an iframe; the one iframe it appends is 0×0 and carries no UI. Google's
+   internals are therefore reachable from here, which is what lets the last rule
+   in this section repaint part of the button. Reach in only where there is no
+   supported option, and expect the class names to be obfuscated. */
 .auth-google {
   display: flex;
   flex-direction: column;
@@ -432,8 +438,8 @@
   background: rgba(255, 255, 255, 0.15);
 }
 
-/* Google's iframe has a fixed pixel width; centring it keeps it aligned with
-   the full-width controls above even though it can't stretch to match them. */
+/* Google sizes the button to its own label — 187px, not the 420px card — so
+   centring is what keeps it aligned with the full-width controls above. */
 .auth-google__button {
   display: flex;
   justify-content: center;


### PR DESCRIPTION
## Why

Review feedback on the release PR [#501](https://github.com/andrewkatson/pos/pull/501). Copilot flagged that the header comment for the Google sign-in styles says the button is an iframe and that "everything here is the space around it" — which [#500](https://github.com/andrewkatson/pos/pull/500) then contradicted by reaching in and repainting part of the button.

The comment turned out to be not just stale but **wrong**. Despite the framing, GIS renders the button as ordinary elements in our own document — a `div[role=button]` with class `.nsm7Bb-HzV7m-LgbsSe`. The only iframe it appends is 0×0 and carries no UI. That is exactly why #500 works at all: you cannot style across an iframe boundary, and this was never one.

Verified against the live button rather than assumed:

```
buttonTag: "DIV", buttonRole: "button", buttonIsDisableable: false
buttonWidth: 187.39, containerWidth: 420
iframes: [{ cls: "L5Fo6c-PQbLGe", w: 0, h: 0 }]
```

## What changed

Comments only, in three places, and now explicit that Google's internals *are* reachable so the override rule isn't a surprise to the next reader:

- **The section header** — carried the iframe claim.
- **`.auth-google__button`** — credited the centring to "Google's iframe has a fixed pixel width". Right conclusion, wrong subject: Google sizes the button to its own label (187px against the 420px card), so centring is still what aligns it.
- **`GoogleSignInButton.tsx`, twice** — the same claim is what justifies hiding the button instead of disabling it. That decision still stands, but for the accurate reason: a `div[role=button]` takes no `disabled` attribute either.

No rule, selector, or behaviour changes.

## Testing

All four website CI checks pass locally: `npm run lint`, `npx tsc -b --noEmit`, `npm test` (45 files, 544 tests), `npm run build`.

## Note on the release

[#501](https://github.com/andrewkatson/pos/pull/501) is `dev` → `main`, so merging this updates that PR automatically — no need to reopen it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
