### PR TITLE
Android: fix blank Feed and Profile on a restored device (#503)

### DIFF
--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/auth/AuthenticationManager.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/auth/AuthenticationManager.kt
@@ -1,6 +1,7 @@
 package com.example.positiveonlysocial.data.auth
 
 import android.util.Log
+import com.example.positiveonlysocial.data.constants.Constants
 import com.example.positiveonlysocial.data.model.UserSession
 import com.example.positiveonlysocial.data.security.KeychainHelperProtocol
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -10,6 +11,18 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
 private const val TAG = "AuthenticationManager"
+
+/**
+ * Thrown by [AuthenticationManager.login] when a freshly issued session could not
+ * be written to secure storage (issue #503).
+ *
+ * Screens read the session back out of the keychain rather than from memory, so a
+ * session that was never persisted can't load anything. Swallowing the failure
+ * put the user inside a signed-in shell where every screen rendered blank; the
+ * caller must keep them on the login screen and say what happened instead.
+ */
+class SessionPersistenceException(cause: Throwable) :
+    Exception(Constants.SESSION_STORAGE_FAILED_MESSAGE, cause)
 
 /**
  * Manages the user's authentication state and session data.
@@ -116,6 +129,9 @@ class AuthenticationManager(
      * This function is 'suspend' as it performs secure disk I/O.
      *
      * @param sessionData The new session to save and publish.
+     * @throws SessionPersistenceException if the session could not be written to
+     * secure storage. The manager stays logged out in that case, because a
+     * session only this object knows about is one no screen can load with.
      */
     suspend fun login(sessionData: UserSession) {
         // Use mutex.withLock to ensure atomic operation
@@ -127,15 +143,16 @@ class AuthenticationManager(
                     service = keychainService,
                     account = sessionAccount
                 )
-
-                // Publish the new session and state
-                _session.value = sessionData
-                _isLoggedIn.value = true
-
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to save session", e)
-                // Here you might want to propagate the error
+                _session.value = null
+                _isLoggedIn.value = false
+                throw SessionPersistenceException(e)
             }
+
+            // Publish the new session and state
+            _session.value = sessionData
+            _isLoggedIn.value = true
         }
     }
 

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/auth/AuthenticationManager.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/auth/AuthenticationManager.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import com.example.positiveonlysocial.data.constants.Constants
 import com.example.positiveonlysocial.data.model.UserSession
 import com.example.positiveonlysocial.data.security.KeychainHelperProtocol
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -143,6 +144,15 @@ class AuthenticationManager(
                     service = keychainService,
                     account = sessionAccount
                 )
+            } catch (e: CancellationException) {
+                // A cancelled login is not a failed one. Without this, the catch
+                // below would rewrite it as a SessionPersistenceException, which
+                // the login screen shows to the user as "we couldn't save your
+                // login" — a report of something that never happened. Not
+                // reachable while the only call in the try is a blocking write,
+                // but this is a suspend function, so anything suspending added
+                // in here later would make it so silently.
+                throw e
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to save session", e)
                 _session.value = null

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/auth/AuthenticationManager.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/auth/AuthenticationManager.kt
@@ -133,6 +133,14 @@ class AuthenticationManager(
      * @throws SessionPersistenceException if the session could not be written to
      * secure storage. The manager stays logged out in that case, because a
      * session only this object knows about is one no screen can load with.
+     *
+     * A failed write clears [session] and [isLoggedIn] rather than leaving them
+     * untouched, which matters if this is ever used to refresh a live session
+     * rather than to establish a first one. Holding "logged in" while the store
+     * that every screen reads from has just refused a write is the precise state
+     * issue #503 was: signed-in shell, nothing behind it. Whatever was in the
+     * keychain before is not a fallback — when the store is unopenable it can't
+     * be read either, and no screen consults this object's copy.
      */
     suspend fun login(sessionData: UserSession) {
         // Use mutex.withLock to ensure atomic operation

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/constants/Constants.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/constants/Constants.kt
@@ -20,6 +20,17 @@ object Constants {
     const val EMAIL_NOT_VERIFIED_MESSAGE =
         "Please verify your email address first — check your inbox for the verification link."
 
+    // Shown when a session was issued but couldn't be written to secure storage
+    // (issue #503). Every screen reads the session back out of the keychain, so
+    // an unpersisted session can't load anything — the user is told instead of
+    // being dropped into an empty signed-in shell.
+    const val SESSION_STORAGE_FAILED_MESSAGE =
+        "We couldn't save your login on this device. Please try again, or restart the app if this keeps happening."
+
+    // Shown on a screen whose data needs a session that isn't there.
+    const val SESSION_MISSING_MESSAGE =
+        "You're not signed in on this device anymore. Please sign in again."
+
     // Error code the backend returns from login/2fa/ when the challenge is gone
     // (expired, already used, or invalidated). A stable code like the two above,
     // so the login screen can drop back to the password form without depending

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/security/KeychainHelper.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/security/KeychainHelper.kt
@@ -2,12 +2,16 @@ package com.example.positiveonlysocial.data.security
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.util.Log
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
 import com.google.gson.Gson
 import java.io.IOException
 import java.security.GeneralSecurityException
+import java.security.KeyStore
 import androidx.core.content.edit
+
+private const val TAG = "KeychainHelper"
 
 /**
  * Kotlin equivalent of the KeychainHelperProtocol.
@@ -63,25 +67,89 @@ class KeychainHelper(context: Context) : KeychainHelperProtocol {
 
     private val gson = Gson()
 
+    private val appContext = context.applicationContext
+
     // A single, hardcoded file name for all secure preferences.
     // The 'service' and 'account' params will be used to create unique *keys*
     // inside this one encrypted file.
+    //
+    // Kept in sync with the <exclude> entries in res/xml/backup_rules.xml and
+    // res/xml/data_extraction_rules.xml, which keep this file (and only this
+    // file) out of cloud backup and device-to-device transfer.
     private val prefsFilename = "positive_only_social_secure_prefs"
 
-    private val encryptedPrefs: SharedPreferences by lazy {
+    private val encryptedPrefs: SharedPreferences by lazy { openEncryptedPrefs() }
+
+    private fun createEncryptedPrefs(): SharedPreferences {
         // 1. Create the Master Key from the Android Keystore
-        val masterKey = MasterKey.Builder(context.applicationContext)
+        val masterKey = MasterKey.Builder(appContext)
             .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
             .build()
 
         // 2. Create the EncryptedSharedPreferences instance
-        EncryptedSharedPreferences.create(
-            context.applicationContext,
+        return EncryptedSharedPreferences.create(
+            appContext,
             prefsFilename,
             masterKey,
             EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
             EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
         )
+    }
+
+    /**
+     * Opens the encrypted store, discarding and rebuilding it if the existing
+     * one can't be read (issue #503).
+     *
+     * The store is only openable while the AndroidKeyStore still holds the
+     * master key that encrypted it. That pairing breaks when the file outlives
+     * the key — a backup restored onto a new device, a keystore entry
+     * invalidated by a lock-screen credential reset, a vendor keystore that
+     * loses entries across an update. When it does, *every* open throws, so the
+     * app can no longer read or write a session and each screen silently
+     * renders nothing.
+     *
+     * Recovery deliberately throws the contents away rather than trying to
+     * salvage them: undecryptable ciphertext has no salvage path, and what is
+     * stored here is a session token and remember-me tokens, so the whole cost
+     * of being wrong is one sign-in. Being wrong the other way — leaving the
+     * store unopenable — bricks the app until the user clears its data.
+     *
+     * Catching broadly is deliberate for the same reason. Tink surfaces a
+     * damaged keyset as several unrelated types (an [IOException] subclass, a
+     * [GeneralSecurityException], or a plain [RuntimeException] out of the
+     * keystore), and there is no benefit to staying wedged on the ones we
+     * failed to enumerate.
+     */
+    private fun openEncryptedPrefs(): SharedPreferences = try {
+        createEncryptedPrefs()
+    } catch (e: Exception) {
+        Log.w(TAG, "Secure storage is unreadable; discarding it and starting fresh", e)
+        discardUnreadableStore()
+        // Not caught: if a store we just deleted still can't be created, the
+        // device's keystore is broken in a way we can't paper over, and the
+        // callers report it rather than pretending the write succeeded.
+        createEncryptedPrefs()
+    }
+
+    /**
+     * Removes both halves of the broken pairing: the preferences file (which
+     * also holds Tink's data keysets) and the master key that encrypts them.
+     * Each step is independently best-effort — a partial cleanup still leaves
+     * [createEncryptedPrefs] a consistent pair to rebuild from.
+     */
+    private fun discardUnreadableStore() {
+        try {
+            appContext.deleteSharedPreferences(prefsFilename)
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to delete $prefsFilename", e)
+        }
+        try {
+            KeyStore.getInstance("AndroidKeyStore")
+                .apply { load(null) }
+                .deleteEntry(MasterKey.DEFAULT_MASTER_KEY_ALIAS)
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to delete the master key", e)
+        }
     }
 
     /**

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/FeedViewModel.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/FeedViewModel.kt
@@ -79,8 +79,12 @@ class FeedViewModel(
                     currentPage = if (newPosts.isEmpty()) 0 else 1
                     _loadError.value = null
                 } else {
-                    Log.e(TAG, "Failed to refresh feed: ${response.errorBody()?.string()}")
-                    _loadError.value = ApiErrors.messageFor(response, fallback = FEED_LOAD_FAILED)
+                    // Resolve the message before logging: the error body is a
+                    // one-shot stream, so reading it here would leave ApiErrors
+                    // nothing to extract the backend's own wording from.
+                    val message = ApiErrors.messageFor(response, fallback = FEED_LOAD_FAILED)
+                    Log.e(TAG, "Failed to refresh feed: ${response.code()} $message")
+                    _loadError.value = message
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to refresh feed", e)
@@ -118,8 +122,11 @@ class FeedViewModel(
                     }
                     _loadError.value = null
                 } else {
-                    Log.e(TAG, "Failed to fetch feed: ${response.errorBody()?.string()}")
-                    _loadError.value = ApiErrors.messageFor(response, fallback = FEED_LOAD_FAILED)
+                    // See refreshFeed: the message has to be resolved before the
+                    // one-shot error body is read for the log.
+                    val message = ApiErrors.messageFor(response, fallback = FEED_LOAD_FAILED)
+                    Log.e(TAG, "Failed to fetch feed: ${response.code()} $message")
+                    _loadError.value = message
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to fetch feed", e)

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/FeedViewModel.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/FeedViewModel.kt
@@ -3,7 +3,9 @@ package com.example.positiveonlysocial.models.viewmodels
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.positiveonlysocial.api.ApiErrors
 import com.example.positiveonlysocial.api.PositiveOnlySocialAPI
+import com.example.positiveonlysocial.data.constants.Constants
 import com.example.positiveonlysocial.data.model.Post
 import com.example.positiveonlysocial.data.model.UserSession
 import com.example.positiveonlysocial.data.security.KeychainHelperProtocol
@@ -31,6 +33,15 @@ class FeedViewModel(
     val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
 
     /**
+     * Why the feed is empty, when it's empty because something went wrong rather
+     * than because there is nothing to show (issue #503). Every one of these was
+     * previously a log line and nothing else, so a missing session or a failing
+     * backend was indistinguishable from a blank screen.
+     */
+    private val _loadError = MutableStateFlow<String?>(null)
+    val loadError: StateFlow<String?> = _loadError.asStateFlow()
+
+    /**
      * Like / report / retract-report / delete for the posts in this feed, so they
      * can be acted on without opening each one (issue #267). Deleting drops the
      * post from [feedPosts] rather than reloading, which would reshuffle the
@@ -53,9 +64,10 @@ class FeedViewModel(
 
         viewModelScope.launch {
             try {
-                val userSession = keychainHelper.load(UserSession::class.java, service, account)
+                val userSession = loadSession()
                 if (userSession == null) {
                     Log.e(TAG, "No active session found — cannot refresh feed")
+                    _loadError.value = Constants.SESSION_MISSING_MESSAGE
                     return@launch
                 }
 
@@ -65,11 +77,14 @@ class FeedViewModel(
                     _feedPosts.value = newPosts
                     canLoadMore = newPosts.isNotEmpty()
                     currentPage = if (newPosts.isEmpty()) 0 else 1
+                    _loadError.value = null
                 } else {
                     Log.e(TAG, "Failed to refresh feed: ${response.errorBody()?.string()}")
+                    _loadError.value = ApiErrors.messageFor(response, fallback = FEED_LOAD_FAILED)
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to refresh feed", e)
+                _loadError.value = ApiErrors.messageFor(e, fallback = FEED_LOAD_FAILED)
             } finally {
                 _isRefreshing.value = false
             }
@@ -85,9 +100,10 @@ class FeedViewModel(
 
         viewModelScope.launch {
             try {
-                val userSession = keychainHelper.load(UserSession::class.java, service, account)
+                val userSession = loadSession()
                 if (userSession == null) {
                     Log.e(TAG, "No active session found — cannot fetch feed")
+                    _loadError.value = Constants.SESSION_MISSING_MESSAGE
                     return@launch
                 }
 
@@ -100,14 +116,32 @@ class FeedViewModel(
                         _feedPosts.value += newPosts
                         currentPage += 1
                     }
+                    _loadError.value = null
                 } else {
                     Log.e(TAG, "Failed to fetch feed: ${response.errorBody()?.string()}")
+                    _loadError.value = ApiErrors.messageFor(response, fallback = FEED_LOAD_FAILED)
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to fetch feed", e)
+                _loadError.value = ApiErrors.messageFor(e, fallback = FEED_LOAD_FAILED)
             } finally {
                 _isLoadingNextPage.value = false
             }
         }
     }
+
+    /**
+     * The stored session, or null when there isn't one. A keychain read can also
+     * *throw* (secure storage unreadable, issue #503); that is the same "no
+     * usable session" outcome to the caller, so it is reported as one rather
+     * than escaping as a generic network-shaped error.
+     */
+    private fun loadSession(): UserSession? = try {
+        keychainHelper.load(UserSession::class.java, service, account)
+    } catch (e: Exception) {
+        Log.e(TAG, "Failed to read the stored session", e)
+        null
+    }
 }
+
+private const val FEED_LOAD_FAILED = "We couldn't load the feed. Pull down to try again."

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/FeedViewModel.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/FeedViewModel.kt
@@ -9,6 +9,7 @@ import com.example.positiveonlysocial.data.constants.Constants
 import com.example.positiveonlysocial.data.model.Post
 import com.example.positiveonlysocial.data.model.UserSession
 import com.example.positiveonlysocial.data.security.KeychainHelperProtocol
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -86,6 +87,10 @@ class FeedViewModel(
                     Log.e(TAG, "Failed to refresh feed: ${response.code()} $message")
                     _loadError.value = message
                 }
+            } catch (e: CancellationException) {
+                // The scope going away isn't a load failure, and must not leave
+                // an error message behind on the way out.
+                throw e
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to refresh feed", e)
                 _loadError.value = ApiErrors.messageFor(e, fallback = FEED_LOAD_FAILED)
@@ -128,6 +133,8 @@ class FeedViewModel(
                     Log.e(TAG, "Failed to fetch feed: ${response.code()} $message")
                     _loadError.value = message
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to fetch feed", e)
                 _loadError.value = ApiErrors.messageFor(e, fallback = FEED_LOAD_FAILED)

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/FollowingFeedViewModel.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/FollowingFeedViewModel.kt
@@ -3,7 +3,9 @@ package com.example.positiveonlysocial.models.viewmodels
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.positiveonlysocial.api.ApiErrors
 import com.example.positiveonlysocial.api.PositiveOnlySocialAPI
+import com.example.positiveonlysocial.data.constants.Constants
 import com.example.positiveonlysocial.data.model.FollowCategory
 import com.example.positiveonlysocial.data.model.Post
 import com.example.positiveonlysocial.data.model.UserSession
@@ -29,6 +31,13 @@ class FollowingFeedViewModel(
 
     private val _isRefreshing = MutableStateFlow(false)
     val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
+
+    /**
+     * Why the feed is empty, when it's empty because something went wrong rather
+     * than because there is nothing to show (issue #503). Mirrors [FeedViewModel].
+     */
+    private val _loadError = MutableStateFlow<String?>(null)
+    val loadError: StateFlow<String?> = _loadError.asStateFlow()
 
     // Optional group filter (issue #392): null is the whole following feed.
     private val _selectedCategory = MutableStateFlow<FollowCategory?>(null)
@@ -66,9 +75,10 @@ class FollowingFeedViewModel(
 
         viewModelScope.launch {
             try {
-                val userSession = keychainHelper.load(UserSession::class.java, service, account)
+                val userSession = loadSession()
                 if (userSession == null) {
                     Log.e(TAG, "No active session found — cannot refresh following feed")
+                    _loadError.value = Constants.SESSION_MISSING_MESSAGE
                     return@launch
                 }
 
@@ -78,11 +88,14 @@ class FollowingFeedViewModel(
                     _followingPosts.value = newPosts
                     canLoadMore = newPosts.isNotEmpty()
                     currentPage = if (newPosts.isEmpty()) 0 else 1
+                    _loadError.value = null
                 } else {
                     Log.e(TAG, "Failed to refresh following feed: ${response.errorBody()?.string()}")
+                    _loadError.value = ApiErrors.messageFor(response, fallback = FOLLOWING_FEED_LOAD_FAILED)
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to refresh following feed", e)
+                _loadError.value = ApiErrors.messageFor(e, fallback = FOLLOWING_FEED_LOAD_FAILED)
             } finally {
                 _isRefreshing.value = false
             }
@@ -98,9 +111,10 @@ class FollowingFeedViewModel(
 
         viewModelScope.launch {
             try {
-                val userSession = keychainHelper.load(UserSession::class.java, service, account)
+                val userSession = loadSession()
                 if (userSession == null) {
                     Log.e(TAG, "No active session found — cannot fetch following feed")
+                    _loadError.value = Constants.SESSION_MISSING_MESSAGE
                     return@launch
                 }
 
@@ -113,14 +127,28 @@ class FollowingFeedViewModel(
                         _followingPosts.value += newPosts
                         currentPage += 1
                     }
+                    _loadError.value = null
                 } else {
                     Log.e(TAG, "Failed to fetch following feed: ${response.errorBody()?.string()}")
+                    _loadError.value = ApiErrors.messageFor(response, fallback = FOLLOWING_FEED_LOAD_FAILED)
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to fetch following feed", e)
+                _loadError.value = ApiErrors.messageFor(e, fallback = FOLLOWING_FEED_LOAD_FAILED)
             } finally {
                 _isLoadingNextPage.value = false
             }
         }
     }
+
+    /** See [FeedViewModel.loadSession] — a read that throws is "no session" too. */
+    private fun loadSession(): UserSession? = try {
+        keychainHelper.load(UserSession::class.java, service, account)
+    } catch (e: Exception) {
+        Log.e(TAG, "Failed to read the stored session", e)
+        null
+    }
 }
+
+private const val FOLLOWING_FEED_LOAD_FAILED =
+    "We couldn't load this feed. Pull down to try again."

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/FollowingFeedViewModel.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/FollowingFeedViewModel.kt
@@ -90,8 +90,12 @@ class FollowingFeedViewModel(
                     currentPage = if (newPosts.isEmpty()) 0 else 1
                     _loadError.value = null
                 } else {
-                    Log.e(TAG, "Failed to refresh following feed: ${response.errorBody()?.string()}")
-                    _loadError.value = ApiErrors.messageFor(response, fallback = FOLLOWING_FEED_LOAD_FAILED)
+                    // Resolve the message before logging: the error body is a
+                    // one-shot stream, so reading it here would leave ApiErrors
+                    // nothing to extract the backend's own wording from.
+                    val message = ApiErrors.messageFor(response, fallback = FOLLOWING_FEED_LOAD_FAILED)
+                    Log.e(TAG, "Failed to refresh following feed: ${response.code()} $message")
+                    _loadError.value = message
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to refresh following feed", e)
@@ -129,8 +133,11 @@ class FollowingFeedViewModel(
                     }
                     _loadError.value = null
                 } else {
-                    Log.e(TAG, "Failed to fetch following feed: ${response.errorBody()?.string()}")
-                    _loadError.value = ApiErrors.messageFor(response, fallback = FOLLOWING_FEED_LOAD_FAILED)
+                    // See refreshFollowingFeed: the message has to be resolved
+                    // before the one-shot error body is read for the log.
+                    val message = ApiErrors.messageFor(response, fallback = FOLLOWING_FEED_LOAD_FAILED)
+                    Log.e(TAG, "Failed to fetch following feed: ${response.code()} $message")
+                    _loadError.value = message
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to fetch following feed", e)

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/FollowingFeedViewModel.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/FollowingFeedViewModel.kt
@@ -10,6 +10,7 @@ import com.example.positiveonlysocial.data.model.FollowCategory
 import com.example.positiveonlysocial.data.model.Post
 import com.example.positiveonlysocial.data.model.UserSession
 import com.example.positiveonlysocial.data.security.KeychainHelperProtocol
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -97,6 +98,10 @@ class FollowingFeedViewModel(
                     Log.e(TAG, "Failed to refresh following feed: ${response.code()} $message")
                     _loadError.value = message
                 }
+            } catch (e: CancellationException) {
+                // The scope going away isn't a load failure, and must not leave
+                // an error message behind on the way out.
+                throw e
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to refresh following feed", e)
                 _loadError.value = ApiErrors.messageFor(e, fallback = FOLLOWING_FEED_LOAD_FAILED)
@@ -139,6 +144,8 @@ class FollowingFeedViewModel(
                     Log.e(TAG, "Failed to fetch following feed: ${response.code()} $message")
                     _loadError.value = message
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to fetch following feed", e)
                 _loadError.value = ApiErrors.messageFor(e, fallback = FOLLOWING_FEED_LOAD_FAILED)

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/auth/LoginScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/auth/LoginScreen.kt
@@ -28,6 +28,7 @@ import com.example.positiveonlysocial.data.auth.AuthenticationManager
 import com.example.positiveonlysocial.data.auth.GoogleSignInFailure
 import com.example.positiveonlysocial.data.auth.GoogleSignInProvider
 import com.example.positiveonlysocial.data.auth.GoogleSignInProviding
+import com.example.positiveonlysocial.data.auth.SessionPersistenceException
 import com.example.positiveonlysocial.data.constants.Constants
 import com.example.positiveonlysocial.data.model.GoogleLoginRequest
 import com.example.positiveonlysocial.data.model.LoginRequest
@@ -104,7 +105,17 @@ fun LoginScreen(
                 userId = userId,
                 isIdentityVerified = false
             )
-            authManager.login(session)
+            // A session that can't be written to secure storage is useless: every
+            // screen loads it back from the keychain, so entering the app anyway
+            // meant a signed-in shell where everything rendered blank (issue
+            // #503). Stay on the login screen and say so instead.
+            try {
+                authManager.login(session)
+            } catch (e: SessionPersistenceException) {
+                errorMessage = e.message ?: Constants.SESSION_STORAGE_FAILED_MESSAGE
+                showingErrorAlert = true
+                return
+            }
 
             // Persist (or clear) the remember-me tokens so WelcomeScreen can
             // silently re-authenticate on the next launch. Mirrors iOS

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/FeedScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/FeedScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyItemScope
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -16,6 +17,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -79,6 +81,7 @@ fun ForYouFeed(
     val posts by viewModel.feedPosts.collectAsState()
     val isLoadingNextPage by viewModel.isLoadingNextPage.collectAsState()
     val isRefreshing by viewModel.isRefreshing.collectAsState()
+    val loadError by viewModel.loadError.collectAsState()
 
     val postActions = viewModel.postActions
     val currentUsername by postActions.currentUsername.collectAsState()
@@ -125,10 +128,38 @@ fun ForYouFeed(
                     }
                 }
             }
+
+            if (posts.isEmpty() && !isLoadingNextPage && !isRefreshing) {
+                item { FeedPlaceholder(loadError) }
+            }
         }
 
         // One set of confirmations for every post in the feed.
         PostActionDialogs(postActions, navController)
+    }
+}
+
+/**
+ * What an empty feed says for itself (issue #503). Before this, a feed that
+ * failed to load — no readable session, an unreachable backend — was
+ * indistinguishable from one that had simply scrolled to its end: both were a
+ * blank screen under the tab bar. Rendered as a lazy item so the pull-to-refresh
+ * gesture still works with nothing in the list.
+ */
+@Composable
+private fun LazyItemScope.FeedPlaceholder(loadError: String?) {
+    Box(
+        modifier = Modifier.fillParentMaxSize(),
+        contentAlignment = androidx.compose.ui.Alignment.Center
+    ) {
+        Text(
+            text = loadError ?: "No posts yet. Pull down to refresh.",
+            textAlign = TextAlign.Center,
+            color = if (loadError != null) MaterialTheme.colorScheme.error else Color.Gray,
+            modifier = Modifier
+                .padding(24.dp)
+                .testTag("FeedPlaceholder")
+        )
     }
 }
 
@@ -145,6 +176,7 @@ fun FollowingFeed(
     val posts by viewModel.followingPosts.collectAsState()
     val isLoadingNextPage by viewModel.isLoadingNextPage.collectAsState()
     val isRefreshing by viewModel.isRefreshing.collectAsState()
+    val loadError by viewModel.loadError.collectAsState()
     val selectedCategory by viewModel.selectedCategory.collectAsState()
 
     val postActions = viewModel.postActions
@@ -215,6 +247,10 @@ fun FollowingFeed(
                         CircularProgressIndicator()
                     }
                 }
+            }
+
+            if (posts.isEmpty() && !isLoadingNextPage && !isRefreshing) {
+                item { FeedPlaceholder(loadError) }
             }
         }
 

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/HomeScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/HomeScreen.kt
@@ -16,10 +16,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.example.positiveonlysocial.api.PositiveOnlySocialAPI
+import com.example.positiveonlysocial.data.constants.Constants
 import com.example.positiveonlysocial.data.security.KeychainHelperProtocol
 import com.example.positiveonlysocial.models.viewmodels.HomeViewModel
 import com.example.positiveonlysocial.models.viewmodels.HomeViewModelFactory
@@ -130,9 +132,9 @@ fun HomeScreen(
                     }
                 }
             } else {
-                // The signed-in user's own profile. Null only before the stored
-                // session has been read, which is effectively never once signed in.
-                currentUsername?.let { username ->
+                // The signed-in user's own profile.
+                val username = currentUsername
+                if (username != null) {
                     ProfileBody(
                         navController = navController,
                         api = api,
@@ -141,6 +143,28 @@ fun HomeScreen(
                         // Takes the space left under the search bar.
                         modifier = Modifier.weight(1f)
                     )
+                } else {
+                    // No readable session behind this screen. That should be
+                    // unreachable — you can't get here without signing in — but
+                    // when secure storage failed it *was* reachable, and the
+                    // `?.let` that used to be here rendered nothing at all, so
+                    // the whole profile silently vanished (issue #503). Say what
+                    // happened instead of showing an empty tab.
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .weight(1f),
+                        contentAlignment = androidx.compose.ui.Alignment.Center
+                    ) {
+                        Text(
+                            text = Constants.SESSION_MISSING_MESSAGE,
+                            textAlign = TextAlign.Center,
+                            color = MaterialTheme.colorScheme.error,
+                            modifier = Modifier
+                                .padding(24.dp)
+                                .testTag("NoSessionNotice")
+                        )
+                    }
                 }
             }
         }

--- a/android/PositiveOnlySocial/app/src/main/res/xml/backup_rules.xml
+++ b/android/PositiveOnlySocial/app/src/main/res/xml/backup_rules.xml
@@ -1,13 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-   Sample backup rules file; uncomment and customize as necessary.
-   See https://developer.android.com/guide/topics/data/autobackup
-   for details.
-   Note: This file is ignored for devices older than API 31
-   See https://developer.android.com/about/versions/12/backup-restore
+   Auto-backup rules for devices older than Android 12 (API 31); API 31+ uses
+   `data_extraction_rules.xml`, which carries the same exclusion and explains
+   why it exists (issue #503).
 -->
 <full-backup-content>
-    <!--
-   <include domain="sharedpref" path="."/>
-   <exclude domain="sharedpref" path="device.xml"/>
--->
+    <exclude domain="sharedpref" path="positive_only_social_secure_prefs.xml"/>
 </full-backup-content>

--- a/android/PositiveOnlySocial/app/src/main/res/xml/data_extraction_rules.xml
+++ b/android/PositiveOnlySocial/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,19 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-   Sample data extraction rules file; uncomment and customize as necessary.
-   See https://developer.android.com/about/versions/12/backup-restore#xml-changes
-   for details.
+   Backup / device-transfer rules for Android 12 (API 31) and above. The older
+   `backup_rules.xml` carries the same exclusion for earlier releases.
+
+   The one thing that must never travel between devices is the encrypted
+   preferences file behind KeychainHelper (issue #503). It is encrypted with a
+   MasterKey held in the AndroidKeyStore, and that key is hardware-bound: it is
+   never backed up and never transferred. Copy the file to a new device — a
+   cloud restore, or the device-to-device transfer used when setting up a new
+   phone or tablet — and it arrives without the key that decrypts it, so every
+   EncryptedSharedPreferences open throws and the app can neither read nor write
+   a session. Leaving the file behind costs one sign-in; carrying it over
+   wedged the app entirely.
 -->
 <data-extraction-rules>
     <cloud-backup>
-        <!-- TODO: Use <include> and <exclude> to control what is backed up.
-        <include .../>
-        <exclude .../>
-        -->
+        <exclude domain="sharedpref" path="positive_only_social_secure_prefs.xml"/>
     </cloud-backup>
-    <!--
     <device-transfer>
-        <include .../>
-        <exclude .../>
+        <exclude domain="sharedpref" path="positive_only_social_secure_prefs.xml"/>
     </device-transfer>
-    -->
 </data-extraction-rules>

--- a/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/data/auth/AuthenticationManagerTest.kt
+++ b/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/data/auth/AuthenticationManagerTest.kt
@@ -2,6 +2,7 @@ package com.example.positiveonlysocial.data.auth
 
 import com.example.positiveonlysocial.data.model.UserSession
 import com.example.positiveonlysocial.data.security.KeychainHelperProtocol
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -91,6 +92,26 @@ class AuthenticationManagerTest {
         // behind it comes back empty.
         assertFalse(manager.isLoggedIn.value)
         assertNull(manager.session.value)
+    }
+
+    @Test
+    fun `cancellation stays cancellation instead of becoming a login failure`() = runTest {
+        // A cancelled login hasn't failed to persist anything — rewriting it as a
+        // SessionPersistenceException would put "we couldn't save your login" in
+        // front of the user for something that never happened, and would swallow
+        // the cancellation on the way.
+        val manager = AuthenticationManager(
+            FakeKeychainHelper(saveFailure = CancellationException("scope went away"))
+        )
+
+        try {
+            manager.login(session)
+            fail("cancellation should propagate")
+        } catch (e: SessionPersistenceException) {
+            fail("cancellation was rewritten as a persistence failure")
+        } catch (e: CancellationException) {
+            assertEquals("scope went away", e.message)
+        }
     }
 
     @Test

--- a/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/data/auth/AuthenticationManagerTest.kt
+++ b/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/data/auth/AuthenticationManagerTest.kt
@@ -1,0 +1,114 @@
+package com.example.positiveonlysocial.data.auth
+
+import com.example.positiveonlysocial.data.model.UserSession
+import com.example.positiveonlysocial.data.security.KeychainHelperProtocol
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+import java.security.GeneralSecurityException
+
+/**
+ * Covers what happens when secure storage refuses the write (issue #503).
+ *
+ * The manager used to log the failure and return normally, which let the caller
+ * walk into the signed-in UI with a session that existed nowhere. Since every
+ * screen loads the session back out of the keychain, that shell rendered blank
+ * everywhere — so a failed write has to be loud.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class AuthenticationManagerTest {
+
+    private val session = UserSession("token123", "testuser", "1", false, null, null)
+
+    /** Records what was written, and can be told to fail the next write. */
+    private class FakeKeychainHelper(
+        private val saveFailure: Exception? = null
+    ) : KeychainHelperProtocol {
+        val storage = mutableMapOf<String, Any?>()
+
+        override fun <T> save(value: T, service: String, account: String) {
+            saveFailure?.let { throw it }
+            storage["$service:$account"] = value
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        override fun <T> load(type: Class<T>, service: String, account: String): T? =
+            storage["$service:$account"] as? T
+
+        override fun delete(service: String, account: String) {
+            storage.remove("$service:$account")
+        }
+    }
+
+    @Test
+    fun `login persists the session and reports being logged in`() = runTest {
+        val keychain = FakeKeychainHelper()
+        val manager = AuthenticationManager(keychain)
+
+        manager.login(session)
+
+        assertEquals(session, manager.session.value)
+        assertTrue(manager.isLoggedIn.value)
+        assertEquals(
+            session,
+            keychain.load(
+                UserSession::class.java,
+                "positive-only-social.Positive-Only-Social",
+                "userSessionToken"
+            )
+        )
+    }
+
+    @Test
+    fun `login throws when the session cannot be persisted`() = runTest {
+        val cause = GeneralSecurityException("keystore is unreadable")
+        val manager = AuthenticationManager(FakeKeychainHelper(saveFailure = cause))
+
+        try {
+            manager.login(session)
+            fail("login should surface a failed session write")
+        } catch (e: SessionPersistenceException) {
+            assertSame(cause, e.cause)
+        }
+    }
+
+    @Test
+    fun `a session that could not be persisted leaves the manager logged out`() = runTest {
+        val manager = AuthenticationManager(
+            FakeKeychainHelper(saveFailure = GeneralSecurityException("keystore is unreadable"))
+        )
+
+        runCatching { manager.login(session) }
+
+        // The critical assertion: no half-logged-in state. A session held only in
+        // memory would let the UI think it is signed in while every keychain read
+        // behind it comes back empty.
+        assertFalse(manager.isLoggedIn.value)
+        assertNull(manager.session.value)
+    }
+
+    @Test
+    fun `logout clears the stored session`() = runTest {
+        val keychain = FakeKeychainHelper()
+        val manager = AuthenticationManager(keychain)
+        manager.login(session)
+
+        manager.logout()
+
+        assertFalse(manager.isLoggedIn.value)
+        assertNull(manager.session.value)
+        assertNull(
+            keychain.load(
+                UserSession::class.java,
+                "positive-only-social.Positive-Only-Social",
+                "userSessionToken"
+            )
+        )
+    }
+}

--- a/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/FeedViewModelSessionTest.kt
+++ b/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/FeedViewModelSessionTest.kt
@@ -1,0 +1,161 @@
+package com.example.positiveonlysocial.models.viewmodels
+
+import com.example.positiveonlysocial.MainDispatcherRule
+import com.example.positiveonlysocial.api.PositiveOnlySocialAPI
+import com.example.positiveonlysocial.data.constants.Constants
+import com.example.positiveonlysocial.data.model.Post
+import com.example.positiveonlysocial.data.model.UserSession
+import com.example.positiveonlysocial.data.security.KeychainHelperProtocol
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import retrofit2.Response
+import java.security.GeneralSecurityException
+
+/**
+ * The feed's reasons for being empty (issue #503).
+ *
+ * A feed with no readable session used to log a line and render an empty list,
+ * which on screen is indistinguishable from a feed that loaded fine and had
+ * nothing in it. These pin the distinction to [FeedViewModel.loadError] and to
+ * [FollowingFeedViewModel.loadError], which is what the screens now show.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class FeedViewModelSessionTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val session = UserSession("token123", "testuser", "1", false, null, null)
+
+    private fun keychainReturning(value: UserSession?): KeychainHelperProtocol = mock {
+        whenever(it.load(any<Class<UserSession>>(), any(), any())).thenReturn(value)
+    }
+
+    private fun keychainThrowing(): KeychainHelperProtocol = mock {
+        whenever(it.load(any<Class<UserSession>>(), any(), any()))
+            .thenThrow(GeneralSecurityException("secure storage is unreadable"))
+    }
+
+    // --- For You feed ---
+
+    @Test
+    fun `fetchFeed with no stored session explains itself and skips the request`() = runTest {
+        val api: PositiveOnlySocialAPI = mock()
+        val viewModel = FeedViewModel(api, keychainReturning(null))
+
+        viewModel.fetchFeed()
+
+        assertEquals(Constants.SESSION_MISSING_MESSAGE, viewModel.loadError.value)
+        assertTrue(viewModel.feedPosts.value.isEmpty())
+        verify(api, never()).getPostsInFeed(any(), any())
+    }
+
+    @Test
+    fun `fetchFeed when secure storage is unreadable explains itself`() = runTest {
+        // The tablet case from issue #503: the keychain read doesn't return null,
+        // it throws. That used to escape as a generic failure (or nothing at all).
+        val api: PositiveOnlySocialAPI = mock()
+        val viewModel = FeedViewModel(api, keychainThrowing())
+
+        viewModel.fetchFeed()
+
+        assertEquals(Constants.SESSION_MISSING_MESSAGE, viewModel.loadError.value)
+        verify(api, never()).getPostsInFeed(any(), any())
+    }
+
+    @Test
+    fun `fetchFeed reports a backend failure`() = runTest {
+        val api: PositiveOnlySocialAPI = mock()
+        whenever(api.getPostsInFeed("token123", 0))
+            .thenReturn(Response.error(500, "boom".toResponseBody()))
+        val viewModel = FeedViewModel(api, keychainReturning(session))
+
+        viewModel.fetchFeed()
+
+        assertNotNull(viewModel.loadError.value)
+    }
+
+    @Test
+    fun `a successful fetch clears a previous error`() = runTest {
+        val api: PositiveOnlySocialAPI = mock()
+        whenever(api.getPostsInFeed("token123", 0))
+            .thenReturn(Response.error(500, "boom".toResponseBody()))
+        val viewModel = FeedViewModel(api, keychainReturning(session))
+
+        viewModel.fetchFeed()
+        assertNotNull(viewModel.loadError.value)
+
+        val posts = listOf(Post("1", "url1", "caption1", "user1", 0))
+        whenever(api.getPostsInFeed("token123", 0)).thenReturn(Response.success(posts))
+        viewModel.refreshFeed()
+
+        assertNull(viewModel.loadError.value)
+        assertEquals(posts, viewModel.feedPosts.value)
+    }
+
+    @Test
+    fun `an empty but successful feed is not an error`() = runTest {
+        val api: PositiveOnlySocialAPI = mock()
+        whenever(api.getPostsInFeed("token123", 0)).thenReturn(Response.success(emptyList()))
+        val viewModel = FeedViewModel(api, keychainReturning(session))
+
+        viewModel.fetchFeed()
+
+        assertTrue(viewModel.feedPosts.value.isEmpty())
+        assertNull(viewModel.loadError.value)
+    }
+
+    // --- Following feed ---
+
+    @Test
+    fun `fetchFollowingFeed with no stored session explains itself`() = runTest {
+        val api: PositiveOnlySocialAPI = mock()
+        val viewModel = FollowingFeedViewModel(api, keychainReturning(null))
+
+        viewModel.fetchFollowingFeed()
+
+        assertEquals(Constants.SESSION_MISSING_MESSAGE, viewModel.loadError.value)
+        verify(api, never()).getFollowedPosts(any(), any(), any())
+    }
+
+    @Test
+    fun `fetchFollowingFeed when secure storage is unreadable explains itself`() = runTest {
+        val api: PositiveOnlySocialAPI = mock()
+        val viewModel = FollowingFeedViewModel(api, keychainThrowing())
+
+        viewModel.fetchFollowingFeed()
+
+        assertEquals(Constants.SESSION_MISSING_MESSAGE, viewModel.loadError.value)
+        verify(api, never()).getFollowedPosts(any(), any(), any())
+    }
+
+    @Test
+    fun `a successful following fetch clears a previous error`() = runTest {
+        val api: PositiveOnlySocialAPI = mock()
+        whenever(api.getFollowedPosts("token123", 0, null))
+            .thenReturn(Response.error(500, "boom".toResponseBody()))
+        val viewModel = FollowingFeedViewModel(api, keychainReturning(session))
+
+        viewModel.fetchFollowingFeed()
+        assertNotNull(viewModel.loadError.value)
+
+        val posts = listOf(Post("3", "url3", "caption3", "user3", 0))
+        whenever(api.getFollowedPosts("token123", 0, null)).thenReturn(Response.success(posts))
+        viewModel.refreshFollowingFeed()
+
+        assertNull(viewModel.loadError.value)
+        assertEquals(posts, viewModel.followingPosts.value)
+    }
+}

--- a/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/FeedViewModelSessionTest.kt
+++ b/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/FeedViewModelSessionTest.kt
@@ -88,6 +88,35 @@ class FeedViewModelSessionTest {
     }
 
     @Test
+    fun `fetchFeed surfaces the backend's own error message`() = runTest {
+        // The error body is a one-shot stream. Reading it for a log line before
+        // handing the response to ApiErrors leaves nothing to parse, and the user
+        // silently gets the generic fallback instead of what the backend said.
+        val api: PositiveOnlySocialAPI = mock()
+        whenever(api.getPostsInFeed("token123", 0)).thenReturn(
+            Response.error(429, """{"error":"You're doing that too often."}""".toResponseBody())
+        )
+        val viewModel = FeedViewModel(api, keychainReturning(session))
+
+        viewModel.fetchFeed()
+
+        assertEquals("You're doing that too often.", viewModel.loadError.value)
+    }
+
+    @Test
+    fun `fetchFollowingFeed surfaces the backend's own error message`() = runTest {
+        val api: PositiveOnlySocialAPI = mock()
+        whenever(api.getFollowedPosts("token123", 0, null)).thenReturn(
+            Response.error(429, """{"error":"You're doing that too often."}""".toResponseBody())
+        )
+        val viewModel = FollowingFeedViewModel(api, keychainReturning(session))
+
+        viewModel.fetchFollowingFeed()
+
+        assertEquals("You're doing that too often.", viewModel.loadError.value)
+    }
+
+    @Test
     fun `a successful fetch clears a previous error`() = runTest {
         val api: PositiveOnlySocialAPI = mock()
         whenever(api.getPostsInFeed("token123", 0))


### PR DESCRIPTION
Fixes #503.

## What was happening

The Profile tab renders the search bar and then nothing — no avatar, no stats row, no buttons. Those all render unconditionally inside `ProfileBody`, so the only way to get that screen is `HomeScreen`'s `currentUsername?.let { ProfileBody(...) }` with a null username. That value is a **keychain read**, no network involved. Not a layout problem, not a screen-size problem (the app has no size-class logic at all), not a connectivity problem: the app simply could not read a session out of local secure storage. The feed falls out the same way — `fetchFeed` bails at `userSession == null`, and `FeedScreen` had no empty state, so you get a bare TabRow.

## Why storage broke on that device

`KeychainHelper` uses `EncryptedSharedPreferences`, encrypted by a `MasterKey` in the AndroidKeyStore. The manifest shipped the **stock, empty** `backup_rules.xml` / `data_extraction_rules.xml` templates — no `<exclude>`, no `<device-transfer>` section, which means "back up and transfer everything". The master key is hardware-bound and never travels. So a tablet set up by restoring or transferring from the phone receives `positive_only_social_secure_prefs.xml` **without the key that decrypts it**, and every `EncryptedSharedPreferences.create` throws from then on — permanently, until app data is cleared.

## Why it looked like a blank screen instead of an error

Every caller swallowed it:

- `AuthenticationManager.login` caught the failed write, logged it, and returned normally.
- `LoginScreen.completeLogin` never checked, and navigated to Home anyway.
- The login API call genuinely succeeds, so the login *appears* to work — you're dropped into a signed-in shell with no session behind it.
- Every view model then logs "No active session found" and renders empty.

## The fix

1. **`res/xml/*`** — exclude the prefs file from both `<cloud-backup>` and `<device-transfer>`. Stops new devices inheriting an undecryptable store.
2. **`KeychainHelper`** — when the store can't be opened, discard the prefs file and the master key alias and rebuild. This is what recovers devices already wedged; (1) alone only helps future installs. The trade-off is documented in the code: being wrong costs one sign-in, staying wedged costs the whole app.
3. **`AuthenticationManager.login`** — throws `SessionPersistenceException` instead of swallowing, and leaves the manager logged out. `LoginScreen` catches it, shows the error, and stays put.
4. **Feed and Profile tab** — say why they're empty instead of rendering nothing. A load failure and "nothing to show" were previously the same blank screen.

## Testing

- `./gradlew test` — passes. 12 new tests in `AuthenticationManagerTest` (write failure throws, leaves the manager logged out, doesn't half-persist) and `FeedViewModelSessionTest` (null session, **keychain read that throws** — the actual #503 shape, backend failure, error cleared on success, empty-but-successful is not an error).
- `./gradlew assembleDebug assembleAndroidTest` — both build.

## Note on iOS

Checked, since the same architecture is there. iOS is **not** exposed to this root cause: its keychain items use `kSecAttrAccessibleWhenUnlockedThisDeviceOnly` with no `kSecAttrSynchronizable`, so they're excluded from backup and transfer entirely — a restored iPad just lands on the Welcome screen, which is correct. It does have related weaker versions of (3) and (4), which I'll raise separately rather than mix into a release-blocking Android fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
