### PR TITLE
Release: merge dev into main

### DIFF
--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/auth/AuthenticationManager.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/auth/AuthenticationManager.kt
@@ -1,6 +1,7 @@
 package com.example.positiveonlysocial.data.auth
 
 import android.util.Log
+import com.example.positiveonlysocial.data.constants.Constants
 import com.example.positiveonlysocial.data.model.UserSession
 import com.example.positiveonlysocial.data.security.KeychainHelperProtocol
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -10,6 +11,18 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
 private const val TAG = "AuthenticationManager"
+
+/**
+ * Thrown by [AuthenticationManager.login] when a freshly issued session could not
+ * be written to secure storage (issue #503).
+ *
+ * Screens read the session back out of the keychain rather than from memory, so a
+ * session that was never persisted can't load anything. Swallowing the failure
+ * put the user inside a signed-in shell where every screen rendered blank; the
+ * caller must keep them on the login screen and say what happened instead.
+ */
+class SessionPersistenceException(cause: Throwable) :
+    Exception(Constants.SESSION_STORAGE_FAILED_MESSAGE, cause)
 
 /**
  * Manages the user's authentication state and session data.
@@ -116,6 +129,9 @@ class AuthenticationManager(
      * This function is 'suspend' as it performs secure disk I/O.
      *
      * @param sessionData The new session to save and publish.
+     * @throws SessionPersistenceException if the session could not be written to
+     * secure storage. The manager stays logged out in that case, because a
+     * session only this object knows about is one no screen can load with.
      */
     suspend fun login(sessionData: UserSession) {
         // Use mutex.withLock to ensure atomic operation
@@ -127,15 +143,16 @@ class AuthenticationManager(
                     service = keychainService,
                     account = sessionAccount
                 )
-
-                // Publish the new session and state
-                _session.value = sessionData
-                _isLoggedIn.value = true
-
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to save session", e)
-                // Here you might want to propagate the error
+                _session.value = null
+                _isLoggedIn.value = false
+                throw SessionPersistenceException(e)
             }
+
+            // Publish the new session and state
+            _session.value = sessionData
+            _isLoggedIn.value = true
         }
     }
 

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/auth/AuthenticationManager.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/auth/AuthenticationManager.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import com.example.positiveonlysocial.data.constants.Constants
 import com.example.positiveonlysocial.data.model.UserSession
 import com.example.positiveonlysocial.data.security.KeychainHelperProtocol
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -143,6 +144,15 @@ class AuthenticationManager(
                     service = keychainService,
                     account = sessionAccount
                 )
+            } catch (e: CancellationException) {
+                // A cancelled login is not a failed one. Without this, the catch
+                // below would rewrite it as a SessionPersistenceException, which
+                // the login screen shows to the user as "we couldn't save your
+                // login" — a report of something that never happened. Not
+                // reachable while the only call in the try is a blocking write,
+                // but this is a suspend function, so anything suspending added
+                // in here later would make it so silently.
+                throw e
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to save session", e)
                 _session.value = null

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/auth/AuthenticationManager.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/auth/AuthenticationManager.kt
@@ -133,6 +133,14 @@ class AuthenticationManager(
      * @throws SessionPersistenceException if the session could not be written to
      * secure storage. The manager stays logged out in that case, because a
      * session only this object knows about is one no screen can load with.
+     *
+     * A failed write clears [session] and [isLoggedIn] rather than leaving them
+     * untouched, which matters if this is ever used to refresh a live session
+     * rather than to establish a first one. Holding "logged in" while the store
+     * that every screen reads from has just refused a write is the precise state
+     * issue #503 was: signed-in shell, nothing behind it. Whatever was in the
+     * keychain before is not a fallback — when the store is unopenable it can't
+     * be read either, and no screen consults this object's copy.
      */
     suspend fun login(sessionData: UserSession) {
         // Use mutex.withLock to ensure atomic operation

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/constants/Constants.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/constants/Constants.kt
@@ -20,6 +20,17 @@ object Constants {
     const val EMAIL_NOT_VERIFIED_MESSAGE =
         "Please verify your email address first — check your inbox for the verification link."
 
+    // Shown when a session was issued but couldn't be written to secure storage
+    // (issue #503). Every screen reads the session back out of the keychain, so
+    // an unpersisted session can't load anything — the user is told instead of
+    // being dropped into an empty signed-in shell.
+    const val SESSION_STORAGE_FAILED_MESSAGE =
+        "We couldn't save your login on this device. Please try again, or restart the app if this keeps happening."
+
+    // Shown on a screen whose data needs a session that isn't there.
+    const val SESSION_MISSING_MESSAGE =
+        "You're not signed in on this device anymore. Please sign in again."
+
     // Error code the backend returns from login/2fa/ when the challenge is gone
     // (expired, already used, or invalidated). A stable code like the two above,
     // so the login screen can drop back to the password form without depending

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/security/KeychainHelper.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/security/KeychainHelper.kt
@@ -75,7 +75,10 @@ class KeychainHelper(context: Context) : KeychainHelperProtocol {
     //
     // Kept in sync with the <exclude> entries in res/xml/backup_rules.xml and
     // res/xml/data_extraction_rules.xml, which keep this file (and only this
-    // file) out of cloud backup and device-to-device transfer.
+    // file) out of cloud backup and device-to-device transfer. Those entries
+    // name the file as it lands on disk — "positive_only_social_secure_prefs.xml",
+    // this value plus the .xml suffix SharedPreferences appends — so renaming
+    // here means renaming there too, suffix included.
     private val prefsFilename = "positive_only_social_secure_prefs"
 
     private val encryptedPrefs: SharedPreferences by lazy { openEncryptedPrefs() }

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/security/KeychainHelper.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/security/KeychainHelper.kt
@@ -2,12 +2,16 @@ package com.example.positiveonlysocial.data.security
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.util.Log
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
 import com.google.gson.Gson
 import java.io.IOException
 import java.security.GeneralSecurityException
+import java.security.KeyStore
 import androidx.core.content.edit
+
+private const val TAG = "KeychainHelper"
 
 /**
  * Kotlin equivalent of the KeychainHelperProtocol.
@@ -63,25 +67,89 @@ class KeychainHelper(context: Context) : KeychainHelperProtocol {
 
     private val gson = Gson()
 
+    private val appContext = context.applicationContext
+
     // A single, hardcoded file name for all secure preferences.
     // The 'service' and 'account' params will be used to create unique *keys*
     // inside this one encrypted file.
+    //
+    // Kept in sync with the <exclude> entries in res/xml/backup_rules.xml and
+    // res/xml/data_extraction_rules.xml, which keep this file (and only this
+    // file) out of cloud backup and device-to-device transfer.
     private val prefsFilename = "positive_only_social_secure_prefs"
 
-    private val encryptedPrefs: SharedPreferences by lazy {
+    private val encryptedPrefs: SharedPreferences by lazy { openEncryptedPrefs() }
+
+    private fun createEncryptedPrefs(): SharedPreferences {
         // 1. Create the Master Key from the Android Keystore
-        val masterKey = MasterKey.Builder(context.applicationContext)
+        val masterKey = MasterKey.Builder(appContext)
             .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
             .build()
 
         // 2. Create the EncryptedSharedPreferences instance
-        EncryptedSharedPreferences.create(
-            context.applicationContext,
+        return EncryptedSharedPreferences.create(
+            appContext,
             prefsFilename,
             masterKey,
             EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
             EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
         )
+    }
+
+    /**
+     * Opens the encrypted store, discarding and rebuilding it if the existing
+     * one can't be read (issue #503).
+     *
+     * The store is only openable while the AndroidKeyStore still holds the
+     * master key that encrypted it. That pairing breaks when the file outlives
+     * the key — a backup restored onto a new device, a keystore entry
+     * invalidated by a lock-screen credential reset, a vendor keystore that
+     * loses entries across an update. When it does, *every* open throws, so the
+     * app can no longer read or write a session and each screen silently
+     * renders nothing.
+     *
+     * Recovery deliberately throws the contents away rather than trying to
+     * salvage them: undecryptable ciphertext has no salvage path, and what is
+     * stored here is a session token and remember-me tokens, so the whole cost
+     * of being wrong is one sign-in. Being wrong the other way — leaving the
+     * store unopenable — bricks the app until the user clears its data.
+     *
+     * Catching broadly is deliberate for the same reason. Tink surfaces a
+     * damaged keyset as several unrelated types (an [IOException] subclass, a
+     * [GeneralSecurityException], or a plain [RuntimeException] out of the
+     * keystore), and there is no benefit to staying wedged on the ones we
+     * failed to enumerate.
+     */
+    private fun openEncryptedPrefs(): SharedPreferences = try {
+        createEncryptedPrefs()
+    } catch (e: Exception) {
+        Log.w(TAG, "Secure storage is unreadable; discarding it and starting fresh", e)
+        discardUnreadableStore()
+        // Not caught: if a store we just deleted still can't be created, the
+        // device's keystore is broken in a way we can't paper over, and the
+        // callers report it rather than pretending the write succeeded.
+        createEncryptedPrefs()
+    }
+
+    /**
+     * Removes both halves of the broken pairing: the preferences file (which
+     * also holds Tink's data keysets) and the master key that encrypts them.
+     * Each step is independently best-effort — a partial cleanup still leaves
+     * [createEncryptedPrefs] a consistent pair to rebuild from.
+     */
+    private fun discardUnreadableStore() {
+        try {
+            appContext.deleteSharedPreferences(prefsFilename)
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to delete $prefsFilename", e)
+        }
+        try {
+            KeyStore.getInstance("AndroidKeyStore")
+                .apply { load(null) }
+                .deleteEntry(MasterKey.DEFAULT_MASTER_KEY_ALIAS)
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to delete the master key", e)
+        }
     }
 
     /**

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/FeedViewModel.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/FeedViewModel.kt
@@ -79,8 +79,12 @@ class FeedViewModel(
                     currentPage = if (newPosts.isEmpty()) 0 else 1
                     _loadError.value = null
                 } else {
-                    Log.e(TAG, "Failed to refresh feed: ${response.errorBody()?.string()}")
-                    _loadError.value = ApiErrors.messageFor(response, fallback = FEED_LOAD_FAILED)
+                    // Resolve the message before logging: the error body is a
+                    // one-shot stream, so reading it here would leave ApiErrors
+                    // nothing to extract the backend's own wording from.
+                    val message = ApiErrors.messageFor(response, fallback = FEED_LOAD_FAILED)
+                    Log.e(TAG, "Failed to refresh feed: ${response.code()} $message")
+                    _loadError.value = message
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to refresh feed", e)
@@ -118,8 +122,11 @@ class FeedViewModel(
                     }
                     _loadError.value = null
                 } else {
-                    Log.e(TAG, "Failed to fetch feed: ${response.errorBody()?.string()}")
-                    _loadError.value = ApiErrors.messageFor(response, fallback = FEED_LOAD_FAILED)
+                    // See refreshFeed: the message has to be resolved before the
+                    // one-shot error body is read for the log.
+                    val message = ApiErrors.messageFor(response, fallback = FEED_LOAD_FAILED)
+                    Log.e(TAG, "Failed to fetch feed: ${response.code()} $message")
+                    _loadError.value = message
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to fetch feed", e)

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/FeedViewModel.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/FeedViewModel.kt
@@ -3,7 +3,9 @@ package com.example.positiveonlysocial.models.viewmodels
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.positiveonlysocial.api.ApiErrors
 import com.example.positiveonlysocial.api.PositiveOnlySocialAPI
+import com.example.positiveonlysocial.data.constants.Constants
 import com.example.positiveonlysocial.data.model.Post
 import com.example.positiveonlysocial.data.model.UserSession
 import com.example.positiveonlysocial.data.security.KeychainHelperProtocol
@@ -31,6 +33,15 @@ class FeedViewModel(
     val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
 
     /**
+     * Why the feed is empty, when it's empty because something went wrong rather
+     * than because there is nothing to show (issue #503). Every one of these was
+     * previously a log line and nothing else, so a missing session or a failing
+     * backend was indistinguishable from a blank screen.
+     */
+    private val _loadError = MutableStateFlow<String?>(null)
+    val loadError: StateFlow<String?> = _loadError.asStateFlow()
+
+    /**
      * Like / report / retract-report / delete for the posts in this feed, so they
      * can be acted on without opening each one (issue #267). Deleting drops the
      * post from [feedPosts] rather than reloading, which would reshuffle the
@@ -53,9 +64,10 @@ class FeedViewModel(
 
         viewModelScope.launch {
             try {
-                val userSession = keychainHelper.load(UserSession::class.java, service, account)
+                val userSession = loadSession()
                 if (userSession == null) {
                     Log.e(TAG, "No active session found — cannot refresh feed")
+                    _loadError.value = Constants.SESSION_MISSING_MESSAGE
                     return@launch
                 }
 
@@ -65,11 +77,14 @@ class FeedViewModel(
                     _feedPosts.value = newPosts
                     canLoadMore = newPosts.isNotEmpty()
                     currentPage = if (newPosts.isEmpty()) 0 else 1
+                    _loadError.value = null
                 } else {
                     Log.e(TAG, "Failed to refresh feed: ${response.errorBody()?.string()}")
+                    _loadError.value = ApiErrors.messageFor(response, fallback = FEED_LOAD_FAILED)
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to refresh feed", e)
+                _loadError.value = ApiErrors.messageFor(e, fallback = FEED_LOAD_FAILED)
             } finally {
                 _isRefreshing.value = false
             }
@@ -85,9 +100,10 @@ class FeedViewModel(
 
         viewModelScope.launch {
             try {
-                val userSession = keychainHelper.load(UserSession::class.java, service, account)
+                val userSession = loadSession()
                 if (userSession == null) {
                     Log.e(TAG, "No active session found — cannot fetch feed")
+                    _loadError.value = Constants.SESSION_MISSING_MESSAGE
                     return@launch
                 }
 
@@ -100,14 +116,32 @@ class FeedViewModel(
                         _feedPosts.value += newPosts
                         currentPage += 1
                     }
+                    _loadError.value = null
                 } else {
                     Log.e(TAG, "Failed to fetch feed: ${response.errorBody()?.string()}")
+                    _loadError.value = ApiErrors.messageFor(response, fallback = FEED_LOAD_FAILED)
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to fetch feed", e)
+                _loadError.value = ApiErrors.messageFor(e, fallback = FEED_LOAD_FAILED)
             } finally {
                 _isLoadingNextPage.value = false
             }
         }
     }
+
+    /**
+     * The stored session, or null when there isn't one. A keychain read can also
+     * *throw* (secure storage unreadable, issue #503); that is the same "no
+     * usable session" outcome to the caller, so it is reported as one rather
+     * than escaping as a generic network-shaped error.
+     */
+    private fun loadSession(): UserSession? = try {
+        keychainHelper.load(UserSession::class.java, service, account)
+    } catch (e: Exception) {
+        Log.e(TAG, "Failed to read the stored session", e)
+        null
+    }
 }
+
+private const val FEED_LOAD_FAILED = "We couldn't load the feed. Pull down to try again."

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/FeedViewModel.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/FeedViewModel.kt
@@ -9,6 +9,7 @@ import com.example.positiveonlysocial.data.constants.Constants
 import com.example.positiveonlysocial.data.model.Post
 import com.example.positiveonlysocial.data.model.UserSession
 import com.example.positiveonlysocial.data.security.KeychainHelperProtocol
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -86,6 +87,10 @@ class FeedViewModel(
                     Log.e(TAG, "Failed to refresh feed: ${response.code()} $message")
                     _loadError.value = message
                 }
+            } catch (e: CancellationException) {
+                // The scope going away isn't a load failure, and must not leave
+                // an error message behind on the way out.
+                throw e
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to refresh feed", e)
                 _loadError.value = ApiErrors.messageFor(e, fallback = FEED_LOAD_FAILED)
@@ -128,6 +133,8 @@ class FeedViewModel(
                     Log.e(TAG, "Failed to fetch feed: ${response.code()} $message")
                     _loadError.value = message
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to fetch feed", e)
                 _loadError.value = ApiErrors.messageFor(e, fallback = FEED_LOAD_FAILED)

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/FollowingFeedViewModel.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/FollowingFeedViewModel.kt
@@ -3,7 +3,9 @@ package com.example.positiveonlysocial.models.viewmodels
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.positiveonlysocial.api.ApiErrors
 import com.example.positiveonlysocial.api.PositiveOnlySocialAPI
+import com.example.positiveonlysocial.data.constants.Constants
 import com.example.positiveonlysocial.data.model.FollowCategory
 import com.example.positiveonlysocial.data.model.Post
 import com.example.positiveonlysocial.data.model.UserSession
@@ -29,6 +31,13 @@ class FollowingFeedViewModel(
 
     private val _isRefreshing = MutableStateFlow(false)
     val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
+
+    /**
+     * Why the feed is empty, when it's empty because something went wrong rather
+     * than because there is nothing to show (issue #503). Mirrors [FeedViewModel].
+     */
+    private val _loadError = MutableStateFlow<String?>(null)
+    val loadError: StateFlow<String?> = _loadError.asStateFlow()
 
     // Optional group filter (issue #392): null is the whole following feed.
     private val _selectedCategory = MutableStateFlow<FollowCategory?>(null)
@@ -66,9 +75,10 @@ class FollowingFeedViewModel(
 
         viewModelScope.launch {
             try {
-                val userSession = keychainHelper.load(UserSession::class.java, service, account)
+                val userSession = loadSession()
                 if (userSession == null) {
                     Log.e(TAG, "No active session found — cannot refresh following feed")
+                    _loadError.value = Constants.SESSION_MISSING_MESSAGE
                     return@launch
                 }
 
@@ -78,11 +88,14 @@ class FollowingFeedViewModel(
                     _followingPosts.value = newPosts
                     canLoadMore = newPosts.isNotEmpty()
                     currentPage = if (newPosts.isEmpty()) 0 else 1
+                    _loadError.value = null
                 } else {
                     Log.e(TAG, "Failed to refresh following feed: ${response.errorBody()?.string()}")
+                    _loadError.value = ApiErrors.messageFor(response, fallback = FOLLOWING_FEED_LOAD_FAILED)
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to refresh following feed", e)
+                _loadError.value = ApiErrors.messageFor(e, fallback = FOLLOWING_FEED_LOAD_FAILED)
             } finally {
                 _isRefreshing.value = false
             }
@@ -98,9 +111,10 @@ class FollowingFeedViewModel(
 
         viewModelScope.launch {
             try {
-                val userSession = keychainHelper.load(UserSession::class.java, service, account)
+                val userSession = loadSession()
                 if (userSession == null) {
                     Log.e(TAG, "No active session found — cannot fetch following feed")
+                    _loadError.value = Constants.SESSION_MISSING_MESSAGE
                     return@launch
                 }
 
@@ -113,14 +127,28 @@ class FollowingFeedViewModel(
                         _followingPosts.value += newPosts
                         currentPage += 1
                     }
+                    _loadError.value = null
                 } else {
                     Log.e(TAG, "Failed to fetch following feed: ${response.errorBody()?.string()}")
+                    _loadError.value = ApiErrors.messageFor(response, fallback = FOLLOWING_FEED_LOAD_FAILED)
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to fetch following feed", e)
+                _loadError.value = ApiErrors.messageFor(e, fallback = FOLLOWING_FEED_LOAD_FAILED)
             } finally {
                 _isLoadingNextPage.value = false
             }
         }
     }
+
+    /** See [FeedViewModel.loadSession] — a read that throws is "no session" too. */
+    private fun loadSession(): UserSession? = try {
+        keychainHelper.load(UserSession::class.java, service, account)
+    } catch (e: Exception) {
+        Log.e(TAG, "Failed to read the stored session", e)
+        null
+    }
 }
+
+private const val FOLLOWING_FEED_LOAD_FAILED =
+    "We couldn't load this feed. Pull down to try again."

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/FollowingFeedViewModel.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/FollowingFeedViewModel.kt
@@ -90,8 +90,12 @@ class FollowingFeedViewModel(
                     currentPage = if (newPosts.isEmpty()) 0 else 1
                     _loadError.value = null
                 } else {
-                    Log.e(TAG, "Failed to refresh following feed: ${response.errorBody()?.string()}")
-                    _loadError.value = ApiErrors.messageFor(response, fallback = FOLLOWING_FEED_LOAD_FAILED)
+                    // Resolve the message before logging: the error body is a
+                    // one-shot stream, so reading it here would leave ApiErrors
+                    // nothing to extract the backend's own wording from.
+                    val message = ApiErrors.messageFor(response, fallback = FOLLOWING_FEED_LOAD_FAILED)
+                    Log.e(TAG, "Failed to refresh following feed: ${response.code()} $message")
+                    _loadError.value = message
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to refresh following feed", e)
@@ -129,8 +133,11 @@ class FollowingFeedViewModel(
                     }
                     _loadError.value = null
                 } else {
-                    Log.e(TAG, "Failed to fetch following feed: ${response.errorBody()?.string()}")
-                    _loadError.value = ApiErrors.messageFor(response, fallback = FOLLOWING_FEED_LOAD_FAILED)
+                    // See refreshFollowingFeed: the message has to be resolved
+                    // before the one-shot error body is read for the log.
+                    val message = ApiErrors.messageFor(response, fallback = FOLLOWING_FEED_LOAD_FAILED)
+                    Log.e(TAG, "Failed to fetch following feed: ${response.code()} $message")
+                    _loadError.value = message
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to fetch following feed", e)

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/FollowingFeedViewModel.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/models/viewmodels/FollowingFeedViewModel.kt
@@ -10,6 +10,7 @@ import com.example.positiveonlysocial.data.model.FollowCategory
 import com.example.positiveonlysocial.data.model.Post
 import com.example.positiveonlysocial.data.model.UserSession
 import com.example.positiveonlysocial.data.security.KeychainHelperProtocol
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -97,6 +98,10 @@ class FollowingFeedViewModel(
                     Log.e(TAG, "Failed to refresh following feed: ${response.code()} $message")
                     _loadError.value = message
                 }
+            } catch (e: CancellationException) {
+                // The scope going away isn't a load failure, and must not leave
+                // an error message behind on the way out.
+                throw e
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to refresh following feed", e)
                 _loadError.value = ApiErrors.messageFor(e, fallback = FOLLOWING_FEED_LOAD_FAILED)
@@ -139,6 +144,8 @@ class FollowingFeedViewModel(
                     Log.e(TAG, "Failed to fetch following feed: ${response.code()} $message")
                     _loadError.value = message
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to fetch following feed", e)
                 _loadError.value = ApiErrors.messageFor(e, fallback = FOLLOWING_FEED_LOAD_FAILED)

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/auth/LoginScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/auth/LoginScreen.kt
@@ -28,6 +28,7 @@ import com.example.positiveonlysocial.data.auth.AuthenticationManager
 import com.example.positiveonlysocial.data.auth.GoogleSignInFailure
 import com.example.positiveonlysocial.data.auth.GoogleSignInProvider
 import com.example.positiveonlysocial.data.auth.GoogleSignInProviding
+import com.example.positiveonlysocial.data.auth.SessionPersistenceException
 import com.example.positiveonlysocial.data.constants.Constants
 import com.example.positiveonlysocial.data.model.GoogleLoginRequest
 import com.example.positiveonlysocial.data.model.LoginRequest
@@ -104,7 +105,17 @@ fun LoginScreen(
                 userId = userId,
                 isIdentityVerified = false
             )
-            authManager.login(session)
+            // A session that can't be written to secure storage is useless: every
+            // screen loads it back from the keychain, so entering the app anyway
+            // meant a signed-in shell where everything rendered blank (issue
+            // #503). Stay on the login screen and say so instead.
+            try {
+                authManager.login(session)
+            } catch (e: SessionPersistenceException) {
+                errorMessage = e.message ?: Constants.SESSION_STORAGE_FAILED_MESSAGE
+                showingErrorAlert = true
+                return
+            }
 
             // Persist (or clear) the remember-me tokens so WelcomeScreen can
             // silently re-authenticate on the next launch. Mirrors iOS

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/FeedScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/FeedScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyItemScope
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -16,6 +17,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -79,6 +81,7 @@ fun ForYouFeed(
     val posts by viewModel.feedPosts.collectAsState()
     val isLoadingNextPage by viewModel.isLoadingNextPage.collectAsState()
     val isRefreshing by viewModel.isRefreshing.collectAsState()
+    val loadError by viewModel.loadError.collectAsState()
 
     val postActions = viewModel.postActions
     val currentUsername by postActions.currentUsername.collectAsState()
@@ -125,10 +128,38 @@ fun ForYouFeed(
                     }
                 }
             }
+
+            if (posts.isEmpty() && !isLoadingNextPage && !isRefreshing) {
+                item { FeedPlaceholder(loadError) }
+            }
         }
 
         // One set of confirmations for every post in the feed.
         PostActionDialogs(postActions, navController)
+    }
+}
+
+/**
+ * What an empty feed says for itself (issue #503). Before this, a feed that
+ * failed to load — no readable session, an unreachable backend — was
+ * indistinguishable from one that had simply scrolled to its end: both were a
+ * blank screen under the tab bar. Rendered as a lazy item so the pull-to-refresh
+ * gesture still works with nothing in the list.
+ */
+@Composable
+private fun LazyItemScope.FeedPlaceholder(loadError: String?) {
+    Box(
+        modifier = Modifier.fillParentMaxSize(),
+        contentAlignment = androidx.compose.ui.Alignment.Center
+    ) {
+        Text(
+            text = loadError ?: "No posts yet. Pull down to refresh.",
+            textAlign = TextAlign.Center,
+            color = if (loadError != null) MaterialTheme.colorScheme.error else Color.Gray,
+            modifier = Modifier
+                .padding(24.dp)
+                .testTag("FeedPlaceholder")
+        )
     }
 }
 
@@ -145,6 +176,7 @@ fun FollowingFeed(
     val posts by viewModel.followingPosts.collectAsState()
     val isLoadingNextPage by viewModel.isLoadingNextPage.collectAsState()
     val isRefreshing by viewModel.isRefreshing.collectAsState()
+    val loadError by viewModel.loadError.collectAsState()
     val selectedCategory by viewModel.selectedCategory.collectAsState()
 
     val postActions = viewModel.postActions
@@ -215,6 +247,10 @@ fun FollowingFeed(
                         CircularProgressIndicator()
                     }
                 }
+            }
+
+            if (posts.isEmpty() && !isLoadingNextPage && !isRefreshing) {
+                item { FeedPlaceholder(loadError) }
             }
         }
 

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/FeedScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/FeedScreen.kt
@@ -155,7 +155,14 @@ private fun LazyItemScope.FeedPlaceholder(loadError: String?) {
         Text(
             text = loadError ?: "No posts yet. Pull down to refresh.",
             textAlign = TextAlign.Center,
-            color = if (loadError != null) MaterialTheme.colorScheme.error else Color.Gray,
+            // Themed rather than a fixed gray: this screen follows the system
+            // light/dark setting, and a hardcoded gray reads as washed out
+            // against a light surface.
+            color = if (loadError != null) {
+                MaterialTheme.colorScheme.error
+            } else {
+                MaterialTheme.colorScheme.onSurfaceVariant
+            },
             modifier = Modifier
                 .padding(24.dp)
                 .testTag("FeedPlaceholder")

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/HomeScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/HomeScreen.kt
@@ -16,10 +16,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.example.positiveonlysocial.api.PositiveOnlySocialAPI
+import com.example.positiveonlysocial.data.constants.Constants
 import com.example.positiveonlysocial.data.security.KeychainHelperProtocol
 import com.example.positiveonlysocial.models.viewmodels.HomeViewModel
 import com.example.positiveonlysocial.models.viewmodels.HomeViewModelFactory
@@ -130,9 +132,9 @@ fun HomeScreen(
                     }
                 }
             } else {
-                // The signed-in user's own profile. Null only before the stored
-                // session has been read, which is effectively never once signed in.
-                currentUsername?.let { username ->
+                // The signed-in user's own profile.
+                val username = currentUsername
+                if (username != null) {
                     ProfileBody(
                         navController = navController,
                         api = api,
@@ -141,6 +143,28 @@ fun HomeScreen(
                         // Takes the space left under the search bar.
                         modifier = Modifier.weight(1f)
                     )
+                } else {
+                    // No readable session behind this screen. That should be
+                    // unreachable — you can't get here without signing in — but
+                    // when secure storage failed it *was* reachable, and the
+                    // `?.let` that used to be here rendered nothing at all, so
+                    // the whole profile silently vanished (issue #503). Say what
+                    // happened instead of showing an empty tab.
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .weight(1f),
+                        contentAlignment = androidx.compose.ui.Alignment.Center
+                    ) {
+                        Text(
+                            text = Constants.SESSION_MISSING_MESSAGE,
+                            textAlign = TextAlign.Center,
+                            color = MaterialTheme.colorScheme.error,
+                            modifier = Modifier
+                                .padding(24.dp)
+                                .testTag("NoSessionNotice")
+                        )
+                    }
                 }
             }
         }

--- a/android/PositiveOnlySocial/app/src/main/res/xml/backup_rules.xml
+++ b/android/PositiveOnlySocial/app/src/main/res/xml/backup_rules.xml
@@ -1,13 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-   Sample backup rules file; uncomment and customize as necessary.
-   See https://developer.android.com/guide/topics/data/autobackup
-   for details.
-   Note: This file is ignored for devices older than API 31
-   See https://developer.android.com/about/versions/12/backup-restore
+   Auto-backup rules for devices older than Android 12 (API 31); API 31+ uses
+   `data_extraction_rules.xml`, which carries the same exclusion and explains
+   why it exists (issue #503).
 -->
 <full-backup-content>
-    <!--
-   <include domain="sharedpref" path="."/>
-   <exclude domain="sharedpref" path="device.xml"/>
--->
+    <exclude domain="sharedpref" path="positive_only_social_secure_prefs.xml"/>
 </full-backup-content>

--- a/android/PositiveOnlySocial/app/src/main/res/xml/data_extraction_rules.xml
+++ b/android/PositiveOnlySocial/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,19 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-   Sample data extraction rules file; uncomment and customize as necessary.
-   See https://developer.android.com/about/versions/12/backup-restore#xml-changes
-   for details.
+   Backup / device-transfer rules for Android 12 (API 31) and above. The older
+   `backup_rules.xml` carries the same exclusion for earlier releases.
+
+   The one thing that must never travel between devices is the encrypted
+   preferences file behind KeychainHelper (issue #503). It is encrypted with a
+   MasterKey held in the AndroidKeyStore, and that key is hardware-bound: it is
+   never backed up and never transferred. Copy the file to a new device — a
+   cloud restore, or the device-to-device transfer used when setting up a new
+   phone or tablet — and it arrives without the key that decrypts it, so every
+   EncryptedSharedPreferences open throws and the app can neither read nor write
+   a session. Leaving the file behind costs one sign-in; carrying it over
+   wedged the app entirely.
 -->
 <data-extraction-rules>
     <cloud-backup>
-        <!-- TODO: Use <include> and <exclude> to control what is backed up.
-        <include .../>
-        <exclude .../>
-        -->
+        <exclude domain="sharedpref" path="positive_only_social_secure_prefs.xml"/>
     </cloud-backup>
-    <!--
     <device-transfer>
-        <include .../>
-        <exclude .../>
+        <exclude domain="sharedpref" path="positive_only_social_secure_prefs.xml"/>
     </device-transfer>
-    -->
 </data-extraction-rules>

--- a/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/data/auth/AuthenticationManagerTest.kt
+++ b/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/data/auth/AuthenticationManagerTest.kt
@@ -2,6 +2,7 @@ package com.example.positiveonlysocial.data.auth
 
 import com.example.positiveonlysocial.data.model.UserSession
 import com.example.positiveonlysocial.data.security.KeychainHelperProtocol
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -91,6 +92,26 @@ class AuthenticationManagerTest {
         // behind it comes back empty.
         assertFalse(manager.isLoggedIn.value)
         assertNull(manager.session.value)
+    }
+
+    @Test
+    fun `cancellation stays cancellation instead of becoming a login failure`() = runTest {
+        // A cancelled login hasn't failed to persist anything — rewriting it as a
+        // SessionPersistenceException would put "we couldn't save your login" in
+        // front of the user for something that never happened, and would swallow
+        // the cancellation on the way.
+        val manager = AuthenticationManager(
+            FakeKeychainHelper(saveFailure = CancellationException("scope went away"))
+        )
+
+        try {
+            manager.login(session)
+            fail("cancellation should propagate")
+        } catch (e: SessionPersistenceException) {
+            fail("cancellation was rewritten as a persistence failure")
+        } catch (e: CancellationException) {
+            assertEquals("scope went away", e.message)
+        }
     }
 
     @Test

--- a/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/data/auth/AuthenticationManagerTest.kt
+++ b/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/data/auth/AuthenticationManagerTest.kt
@@ -1,0 +1,114 @@
+package com.example.positiveonlysocial.data.auth
+
+import com.example.positiveonlysocial.data.model.UserSession
+import com.example.positiveonlysocial.data.security.KeychainHelperProtocol
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+import java.security.GeneralSecurityException
+
+/**
+ * Covers what happens when secure storage refuses the write (issue #503).
+ *
+ * The manager used to log the failure and return normally, which let the caller
+ * walk into the signed-in UI with a session that existed nowhere. Since every
+ * screen loads the session back out of the keychain, that shell rendered blank
+ * everywhere — so a failed write has to be loud.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class AuthenticationManagerTest {
+
+    private val session = UserSession("token123", "testuser", "1", false, null, null)
+
+    /** Records what was written, and can be told to fail the next write. */
+    private class FakeKeychainHelper(
+        private val saveFailure: Exception? = null
+    ) : KeychainHelperProtocol {
+        val storage = mutableMapOf<String, Any?>()
+
+        override fun <T> save(value: T, service: String, account: String) {
+            saveFailure?.let { throw it }
+            storage["$service:$account"] = value
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        override fun <T> load(type: Class<T>, service: String, account: String): T? =
+            storage["$service:$account"] as? T
+
+        override fun delete(service: String, account: String) {
+            storage.remove("$service:$account")
+        }
+    }
+
+    @Test
+    fun `login persists the session and reports being logged in`() = runTest {
+        val keychain = FakeKeychainHelper()
+        val manager = AuthenticationManager(keychain)
+
+        manager.login(session)
+
+        assertEquals(session, manager.session.value)
+        assertTrue(manager.isLoggedIn.value)
+        assertEquals(
+            session,
+            keychain.load(
+                UserSession::class.java,
+                "positive-only-social.Positive-Only-Social",
+                "userSessionToken"
+            )
+        )
+    }
+
+    @Test
+    fun `login throws when the session cannot be persisted`() = runTest {
+        val cause = GeneralSecurityException("keystore is unreadable")
+        val manager = AuthenticationManager(FakeKeychainHelper(saveFailure = cause))
+
+        try {
+            manager.login(session)
+            fail("login should surface a failed session write")
+        } catch (e: SessionPersistenceException) {
+            assertSame(cause, e.cause)
+        }
+    }
+
+    @Test
+    fun `a session that could not be persisted leaves the manager logged out`() = runTest {
+        val manager = AuthenticationManager(
+            FakeKeychainHelper(saveFailure = GeneralSecurityException("keystore is unreadable"))
+        )
+
+        runCatching { manager.login(session) }
+
+        // The critical assertion: no half-logged-in state. A session held only in
+        // memory would let the UI think it is signed in while every keychain read
+        // behind it comes back empty.
+        assertFalse(manager.isLoggedIn.value)
+        assertNull(manager.session.value)
+    }
+
+    @Test
+    fun `logout clears the stored session`() = runTest {
+        val keychain = FakeKeychainHelper()
+        val manager = AuthenticationManager(keychain)
+        manager.login(session)
+
+        manager.logout()
+
+        assertFalse(manager.isLoggedIn.value)
+        assertNull(manager.session.value)
+        assertNull(
+            keychain.load(
+                UserSession::class.java,
+                "positive-only-social.Positive-Only-Social",
+                "userSessionToken"
+            )
+        )
+    }
+}

--- a/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/FeedViewModelSessionTest.kt
+++ b/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/FeedViewModelSessionTest.kt
@@ -1,0 +1,161 @@
+package com.example.positiveonlysocial.models.viewmodels
+
+import com.example.positiveonlysocial.MainDispatcherRule
+import com.example.positiveonlysocial.api.PositiveOnlySocialAPI
+import com.example.positiveonlysocial.data.constants.Constants
+import com.example.positiveonlysocial.data.model.Post
+import com.example.positiveonlysocial.data.model.UserSession
+import com.example.positiveonlysocial.data.security.KeychainHelperProtocol
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import retrofit2.Response
+import java.security.GeneralSecurityException
+
+/**
+ * The feed's reasons for being empty (issue #503).
+ *
+ * A feed with no readable session used to log a line and render an empty list,
+ * which on screen is indistinguishable from a feed that loaded fine and had
+ * nothing in it. These pin the distinction to [FeedViewModel.loadError] and to
+ * [FollowingFeedViewModel.loadError], which is what the screens now show.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class FeedViewModelSessionTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val session = UserSession("token123", "testuser", "1", false, null, null)
+
+    private fun keychainReturning(value: UserSession?): KeychainHelperProtocol = mock {
+        whenever(it.load(any<Class<UserSession>>(), any(), any())).thenReturn(value)
+    }
+
+    private fun keychainThrowing(): KeychainHelperProtocol = mock {
+        whenever(it.load(any<Class<UserSession>>(), any(), any()))
+            .thenThrow(GeneralSecurityException("secure storage is unreadable"))
+    }
+
+    // --- For You feed ---
+
+    @Test
+    fun `fetchFeed with no stored session explains itself and skips the request`() = runTest {
+        val api: PositiveOnlySocialAPI = mock()
+        val viewModel = FeedViewModel(api, keychainReturning(null))
+
+        viewModel.fetchFeed()
+
+        assertEquals(Constants.SESSION_MISSING_MESSAGE, viewModel.loadError.value)
+        assertTrue(viewModel.feedPosts.value.isEmpty())
+        verify(api, never()).getPostsInFeed(any(), any())
+    }
+
+    @Test
+    fun `fetchFeed when secure storage is unreadable explains itself`() = runTest {
+        // The tablet case from issue #503: the keychain read doesn't return null,
+        // it throws. That used to escape as a generic failure (or nothing at all).
+        val api: PositiveOnlySocialAPI = mock()
+        val viewModel = FeedViewModel(api, keychainThrowing())
+
+        viewModel.fetchFeed()
+
+        assertEquals(Constants.SESSION_MISSING_MESSAGE, viewModel.loadError.value)
+        verify(api, never()).getPostsInFeed(any(), any())
+    }
+
+    @Test
+    fun `fetchFeed reports a backend failure`() = runTest {
+        val api: PositiveOnlySocialAPI = mock()
+        whenever(api.getPostsInFeed("token123", 0))
+            .thenReturn(Response.error(500, "boom".toResponseBody()))
+        val viewModel = FeedViewModel(api, keychainReturning(session))
+
+        viewModel.fetchFeed()
+
+        assertNotNull(viewModel.loadError.value)
+    }
+
+    @Test
+    fun `a successful fetch clears a previous error`() = runTest {
+        val api: PositiveOnlySocialAPI = mock()
+        whenever(api.getPostsInFeed("token123", 0))
+            .thenReturn(Response.error(500, "boom".toResponseBody()))
+        val viewModel = FeedViewModel(api, keychainReturning(session))
+
+        viewModel.fetchFeed()
+        assertNotNull(viewModel.loadError.value)
+
+        val posts = listOf(Post("1", "url1", "caption1", "user1", 0))
+        whenever(api.getPostsInFeed("token123", 0)).thenReturn(Response.success(posts))
+        viewModel.refreshFeed()
+
+        assertNull(viewModel.loadError.value)
+        assertEquals(posts, viewModel.feedPosts.value)
+    }
+
+    @Test
+    fun `an empty but successful feed is not an error`() = runTest {
+        val api: PositiveOnlySocialAPI = mock()
+        whenever(api.getPostsInFeed("token123", 0)).thenReturn(Response.success(emptyList()))
+        val viewModel = FeedViewModel(api, keychainReturning(session))
+
+        viewModel.fetchFeed()
+
+        assertTrue(viewModel.feedPosts.value.isEmpty())
+        assertNull(viewModel.loadError.value)
+    }
+
+    // --- Following feed ---
+
+    @Test
+    fun `fetchFollowingFeed with no stored session explains itself`() = runTest {
+        val api: PositiveOnlySocialAPI = mock()
+        val viewModel = FollowingFeedViewModel(api, keychainReturning(null))
+
+        viewModel.fetchFollowingFeed()
+
+        assertEquals(Constants.SESSION_MISSING_MESSAGE, viewModel.loadError.value)
+        verify(api, never()).getFollowedPosts(any(), any(), any())
+    }
+
+    @Test
+    fun `fetchFollowingFeed when secure storage is unreadable explains itself`() = runTest {
+        val api: PositiveOnlySocialAPI = mock()
+        val viewModel = FollowingFeedViewModel(api, keychainThrowing())
+
+        viewModel.fetchFollowingFeed()
+
+        assertEquals(Constants.SESSION_MISSING_MESSAGE, viewModel.loadError.value)
+        verify(api, never()).getFollowedPosts(any(), any(), any())
+    }
+
+    @Test
+    fun `a successful following fetch clears a previous error`() = runTest {
+        val api: PositiveOnlySocialAPI = mock()
+        whenever(api.getFollowedPosts("token123", 0, null))
+            .thenReturn(Response.error(500, "boom".toResponseBody()))
+        val viewModel = FollowingFeedViewModel(api, keychainReturning(session))
+
+        viewModel.fetchFollowingFeed()
+        assertNotNull(viewModel.loadError.value)
+
+        val posts = listOf(Post("3", "url3", "caption3", "user3", 0))
+        whenever(api.getFollowedPosts("token123", 0, null)).thenReturn(Response.success(posts))
+        viewModel.refreshFollowingFeed()
+
+        assertNull(viewModel.loadError.value)
+        assertEquals(posts, viewModel.followingPosts.value)
+    }
+}

--- a/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/FeedViewModelSessionTest.kt
+++ b/android/PositiveOnlySocial/app/src/test/java/com/example/positiveonlysocial/models/viewmodels/FeedViewModelSessionTest.kt
@@ -88,6 +88,35 @@ class FeedViewModelSessionTest {
     }
 
     @Test
+    fun `fetchFeed surfaces the backend's own error message`() = runTest {
+        // The error body is a one-shot stream. Reading it for a log line before
+        // handing the response to ApiErrors leaves nothing to parse, and the user
+        // silently gets the generic fallback instead of what the backend said.
+        val api: PositiveOnlySocialAPI = mock()
+        whenever(api.getPostsInFeed("token123", 0)).thenReturn(
+            Response.error(429, """{"error":"You're doing that too often."}""".toResponseBody())
+        )
+        val viewModel = FeedViewModel(api, keychainReturning(session))
+
+        viewModel.fetchFeed()
+
+        assertEquals("You're doing that too often.", viewModel.loadError.value)
+    }
+
+    @Test
+    fun `fetchFollowingFeed surfaces the backend's own error message`() = runTest {
+        val api: PositiveOnlySocialAPI = mock()
+        whenever(api.getFollowedPosts("token123", 0, null)).thenReturn(
+            Response.error(429, """{"error":"You're doing that too often."}""".toResponseBody())
+        )
+        val viewModel = FollowingFeedViewModel(api, keychainReturning(session))
+
+        viewModel.fetchFollowingFeed()
+
+        assertEquals("You're doing that too often.", viewModel.loadError.value)
+    }
+
+    @Test
     fun `a successful fetch clears a previous error`() = runTest {
         val api: PositiveOnlySocialAPI = mock()
         whenever(api.getPostsInFeed("token123", 0))

--- a/website/src/components/GoogleSignInButton.test.tsx
+++ b/website/src/components/GoogleSignInButton.test.tsx
@@ -85,6 +85,23 @@ test('the button label follows the page it is on', async () => {
   expect(google_.id.renderButton.mock.calls[0][1]).toMatchObject({ text: 'signup_with' })
 })
 
+// Not a style preference, which is why it is pinned. A visitor signed in to
+// Google gets the personalised button as a cross-origin iframe with a white
+// interior that no stylesheet of ours can repaint, so the auth pages went white
+// to match it. Asking for a dark theme here puts a dark pill inside that white
+// surround and brings back the white box the light pages exist to avoid — a
+// regression nothing else in this suite would catch, since it only appears for
+// signed-in visitors and only in a real browser.
+test('asks for the theme the light auth pages are built around', async () => {
+  const { google, google_ } = fakeGoogle()
+  loadGoogleIdentityServices.mockResolvedValue(google)
+
+  render(<GoogleSignInButton onCredential={vi.fn()} />)
+
+  await waitFor(() => expect(google_.id.renderButton).toHaveBeenCalled())
+  expect(google_.id.renderButton.mock.calls[0][1]).toMatchObject({ theme: 'filled_blue' })
+})
+
 test('hides the button while a sign-in is already in flight', async () => {
   const { google, google_ } = fakeGoogle()
   loadGoogleIdentityServices.mockResolvedValue(google)

--- a/website/src/components/GoogleSignInButton.tsx
+++ b/website/src/components/GoogleSignInButton.tsx
@@ -72,7 +72,14 @@ function GoogleSignInButton({
         })
         google.accounts.id.renderButton(containerRef.current, {
           type: 'standard',
-          theme: 'filled_black',
+          // Paired with the light auth pages, and the pairing is deliberate:
+          // when the visitor is signed in to Google this button arrives as a
+          // cross-origin iframe with a white interior we cannot restyle, so the
+          // page is white to match it. A dark theme here would put a dark pill
+          // inside that white surround and reinstate the white box the light
+          // pages exist to avoid. See the `.auth-google` comment in
+          // LoginPage.css before changing either half.
+          theme: 'filled_blue',
           size: 'large',
           shape: 'pill',
           text,
@@ -108,9 +115,11 @@ function GoogleSignInButton({
       <div
         ref={containerRef}
         className="auth-google__button"
-        // Google renders a `div[role=button]`, which takes no `disabled`
-        // attribute, so it is hidden outright while a request is in flight — a
-        // click that arrived mid-login would start a second one.
+        // Hidden outright while a request is in flight — a click that arrived
+        // mid-login would start a second one. Hiding rather than disabling
+        // because neither thing Google renders here can be disabled: signed
+        // out it is a `div[role=button]`, signed in a cross-origin iframe, and
+        // `disabled` means nothing to either.
         hidden={disabled}
         data-testid="google-sign-in-button"
       />

--- a/website/src/pages/LoginPage.css
+++ b/website/src/pages/LoginPage.css
@@ -1,13 +1,117 @@
 /* ============================================================
-   Shared auth-page styles (used by LoginPage + RegisterPage)
+   Shared auth-page styles (all eight `.auth-page` screens: login,
+   register, check-email, delete-account, request-reset, reset-password,
+   verify-email, verify-reset)
    ============================================================ */
 
+/* The auth pages are light; the rest of the app is dark (see MainApp.css).
+   That split is not a style preference — it is what makes Google sign-in
+   presentable, and the reasoning is recorded above `.auth-google` below.
+
+   Several rules in this file are shared with the dark app: `.modal*` is used
+   by Modal.tsx, SettingsTab, LikesModal and friends; `.spinner` by FeedTab and
+   ProfileView; `.toggle` by SettingsTab; `.auth-input` by NewPostTab. This
+   stylesheet is bundled globally, so lightening those selectors directly would
+   have repainted half the app. Instead every colour below is a token: the dark
+   values live on `:root` and are exactly what the app rendered before this file
+   was themed, and `.auth-page` overrides them for its own subtree. Anything
+   inside an auth page gets the light values by inheritance, and nothing else
+   changes. No auth screen portals its modals out of `.auth-page`, so the
+   override reaches all of them.
+
+   The `fg` ladder is named by weight rather than by role because the same
+   greys are reused across unrelated elements; each step maps 1:1 onto an
+   opacity that was already in this file. */
+:root {
+  --auth-bg: #000000;
+  --auth-surface: #1a1a1a;
+
+  --auth-fg: #ffffff;
+  --auth-fg-strong: rgba(255, 255, 255, 0.75);
+  --auth-fg-muted: rgba(255, 255, 255, 0.7);
+  --auth-fg-soft: rgba(255, 255, 255, 0.6);
+  --auth-fg-subtle: rgba(255, 255, 255, 0.5);
+  --auth-fg-dim: rgba(255, 255, 255, 0.45);
+  --auth-fg-faint: rgba(255, 255, 255, 0.4);
+
+  --auth-border: rgba(255, 255, 255, 0.15);
+  --auth-border-modal: rgba(255, 255, 255, 0.12);
+  --auth-border-cancel: rgba(255, 255, 255, 0.2);
+  --auth-border-cancel-hover: rgba(255, 255, 255, 0.4);
+  --auth-divider-line: rgba(255, 255, 255, 0.15);
+
+  --auth-accent: #5ba4dc;
+  --auth-on-accent: #ffffff;
+  --auth-accent-ring: rgba(91, 164, 220, 0.3);
+
+  --auth-danger: #ff6b6b;
+  --auth-danger-bg: rgba(220, 50, 50, 0.18);
+  --auth-danger-border: rgba(220, 50, 50, 0.4);
+  --auth-success: #4caf50;
+
+  /* Disabled buttons and the unchecked toggle track. */
+  --auth-inert: #444444;
+  --auth-on-inert: #ffffff;
+  --auth-knob: #ffffff;
+
+  --auth-overlay: rgba(0, 0, 0, 0.7);
+}
+
 .auth-page {
+  /* #ffffff exactly, not an off-white: Google's sign-in iframe paints its own
+     white interior, and any near-white here would show as a seam around it. */
+  --auth-bg: #ffffff;
+  --auth-surface: #ffffff;
+
+  --auth-fg: #16181d;
+  --auth-fg-strong: rgba(22, 24, 29, 0.78);
+  --auth-fg-muted: rgba(22, 24, 29, 0.7);
+  --auth-fg-soft: rgba(22, 24, 29, 0.62);
+  /* The bottom of the ladder stops at 0.6 rather than tracking the dark
+     theme's 0.5/0.45/0.4. Everything wearing these three greys is small text —
+     the legal line at 0.8rem, the "or" divider at 0.85rem, the password hints
+     at 0.78rem — and grey-on-white loses contrast far faster than grey-on-black
+     does. At the dark theme's alphas they land at 2.9-4.0:1, under the 4.5:1
+     AA needs at those sizes; 0.6 is where #16181d on #ffffff clears it. They
+     stay distinct steps in the light theme because they sit on different
+     backgrounds, not because the alphas differ. */
+  --auth-fg-subtle: rgba(22, 24, 29, 0.62);
+  --auth-fg-dim: rgba(22, 24, 29, 0.6);
+  --auth-fg-faint: rgba(22, 24, 29, 0.6);
+
+  --auth-border: rgba(22, 24, 29, 0.22);
+  --auth-border-modal: rgba(22, 24, 29, 0.14);
+  --auth-border-cancel: rgba(22, 24, 29, 0.28);
+  --auth-border-cancel-hover: rgba(22, 24, 29, 0.5);
+  --auth-divider-line: rgba(22, 24, 29, 0.14);
+
+  /* Darker than the brand #5ba4dc, which only carries white text on a dark
+     page: on white it drops to ~2.2:1 and fails AA for both button labels and
+     link text. This shade keeps the hue and clears 5:1. */
+  --auth-accent: #1b6ea4;
+  --auth-on-accent: #ffffff;
+  --auth-accent-ring: rgba(27, 110, 164, 0.28);
+
+  --auth-danger: #c62828;
+  --auth-danger-bg: rgba(198, 40, 40, 0.08);
+  --auth-danger-border: rgba(198, 40, 40, 0.32);
+  --auth-success: #2e7d32;
+
+  /* Disabled controls are exempt from the contrast rules, but the dark theme
+     puts white on #444 at ~9:1 and a disabled button whose label has vanished
+     reads as a broken button rather than a waiting one. 0.7 holds ~5:1 and
+     still looks plainly inactive next to the enabled accent. */
+  --auth-inert: #cdd3da;
+  --auth-on-inert: rgba(22, 24, 29, 0.7);
+  --auth-knob: #ffffff;
+
+  --auth-overlay: rgba(22, 24, 29, 0.45);
+
   min-height: 100vh;
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: #000000;
+  background-color: var(--auth-bg);
   padding: 1.5rem;
 }
 
@@ -23,7 +127,7 @@
   align-self: flex-start;
   background: none;
   border: none;
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--auth-fg-soft);
   font-size: 0.9rem;
   cursor: pointer;
   padding: 0;
@@ -31,7 +135,7 @@
 }
 
 .auth-back:hover {
-  color: #ffffff;
+  color: var(--auth-fg);
 }
 
 .auth-logo {
@@ -43,7 +147,7 @@
   margin: 0;
   font-size: 1.75rem;
   font-weight: 700;
-  color: #ffffff;
+  color: var(--auth-fg);
   text-align: center;
 }
 
@@ -54,10 +158,10 @@
   align-items: flex-start;
   gap: 0.75rem;
   padding: 0.85rem 1rem;
-  background: rgba(220, 50, 50, 0.18);
-  border: 1px solid rgba(220, 50, 50, 0.4);
+  background: var(--auth-danger-bg);
+  border: 1px solid var(--auth-danger-border);
   border-radius: 10px;
-  color: #ff6b6b;
+  color: var(--auth-danger);
   font-size: 0.9rem;
 }
 
@@ -69,7 +173,7 @@
 .auth-error__dismiss {
   background: none;
   border: none;
-  color: #ff6b6b;
+  color: var(--auth-danger);
   cursor: pointer;
   font-size: 0.85rem;
   padding: 0;
@@ -92,14 +196,14 @@
 
 .auth-label {
   font-size: 0.875rem;
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--auth-fg-muted);
 }
 
 .auth-input {
-  background: #1a1a1a;
-  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: var(--auth-surface);
+  border: 1px solid var(--auth-border);
   border-radius: 10px;
-  color: #ffffff;
+  color: var(--auth-fg);
   padding: 0.75rem 1rem;
   font-size: 1rem;
   width: 100%;
@@ -109,7 +213,7 @@
 
 .auth-input:focus {
   outline: none;
-  border-color: #5ba4dc;
+  border-color: var(--auth-accent);
 }
 
 .auth-input:disabled {
@@ -143,7 +247,7 @@
   display: inline-block;
   width: 44px;
   height: 26px;
-  background: #444;
+  background: var(--auth-inert);
   border-radius: 999px;
   transition: background 0.2s ease;
   position: relative;
@@ -156,13 +260,13 @@
   left: 3px;
   width: 20px;
   height: 20px;
-  background: #ffffff;
+  background: var(--auth-knob);
   border-radius: 50%;
   transition: transform 0.2s ease;
 }
 
 .toggle input:checked + .toggle__track {
-  background: #5ba4dc;
+  background: var(--auth-accent);
 }
 
 .toggle input:checked + .toggle__track::after {
@@ -174,7 +278,7 @@
 }
 
 .toggle input:focus-visible + .toggle__track {
-  outline: 2px solid #5ba4dc;
+  outline: 2px solid var(--auth-accent);
   outline-offset: 3px;
 }
 
@@ -188,8 +292,8 @@
   font-size: 1rem;
   cursor: pointer;
   border: none;
-  background: #5ba4dc;
-  color: #ffffff;
+  background: var(--auth-accent);
+  color: var(--auth-on-accent);
   transition: opacity 0.15s ease;
 }
 
@@ -197,8 +301,11 @@
   opacity: 0.85;
 }
 
+/* The label colour has to move with the background: white on the dark theme's
+   #444 reads fine, but white on a light grey disabled button does not. */
 .auth-button:disabled {
-  background: #444;
+  background: var(--auth-inert);
+  color: var(--auth-on-inert);
   cursor: not-allowed;
 }
 
@@ -214,8 +321,8 @@
   display: inline-block;
   width: 28px;
   height: 28px;
-  border: 3px solid rgba(91, 164, 220, 0.3);
-  border-top-color: #5ba4dc;
+  border: 3px solid var(--auth-accent-ring);
+  border-top-color: var(--auth-accent);
   border-radius: 50%;
   animation: spin 0.75s linear infinite;
 }
@@ -231,7 +338,7 @@
 .auth-link {
   background: none;
   border: none;
-  color: #5ba4dc;
+  color: var(--auth-accent);
   font-size: 0.9rem;
   cursor: pointer;
   padding: 0;
@@ -251,7 +358,7 @@
 
 .auth-instructions {
   font-size: 0.9rem;
-  color: rgba(255, 255, 255, 0.75);
+  color: var(--auth-fg-strong);
   margin: 0 0 0.25rem;
 }
 
@@ -259,7 +366,7 @@
 
 .auth-mismatch {
   font-size: 0.8rem;
-  color: #ff6b6b;
+  color: var(--auth-danger);
   margin: -0.5rem 0 0;
 }
 
@@ -269,16 +376,16 @@
   font-size: 0.8rem;
   line-height: 1.5;
   text-align: center;
-  color: rgba(255, 255, 255, 0.5);
+  color: var(--auth-fg-subtle);
 }
 
 .auth-legal__link {
-  color: rgba(255, 255, 255, 0.75);
+  color: var(--auth-fg-strong);
   text-decoration: underline;
 }
 
 .auth-legal__link:hover {
-  color: #ffffff;
+  color: var(--auth-fg);
 }
 
 /* ---- Password requirement hints ---- */
@@ -300,18 +407,18 @@
 }
 
 .auth-hint--met {
-  color: #4caf50;
+  color: var(--auth-success);
 }
 
 /* A required-but-unmet requirement is a hard blocker, so it reads red rather
    than the neutral grey used before — grey made it look optional (issue #413).
    Optional suggestions stay neutral so they never look like failures. */
 .auth-hint--unmet {
-  color: #ff6b6b;
+  color: var(--auth-danger);
 }
 
 .auth-hint--optional {
-  color: rgba(255, 255, 255, 0.4);
+  color: var(--auth-fg-faint);
 }
 
 .auth-hint--met::before {
@@ -331,7 +438,7 @@
 .modal-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.7);
+  background: var(--auth-overlay);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -340,8 +447,8 @@
 }
 
 .modal {
-  background: #1a1a1a;
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: var(--auth-surface);
+  border: 1px solid var(--auth-border-modal);
   border-radius: 16px;
   padding: 1.75rem;
   max-width: 480px;
@@ -355,14 +462,14 @@
   margin: 0;
   font-size: 1.2rem;
   font-weight: 700;
-  color: #ffffff;
+  color: var(--auth-fg);
 }
 
 .modal__body {
   margin: 0;
   font-size: 0.9rem;
   line-height: 1.55;
-  color: rgba(255, 255, 255, 0.75);
+  color: var(--auth-fg-strong);
 }
 
 .modal__actions {
@@ -373,9 +480,9 @@
 
 .modal__cancel {
   background: none;
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  border: 1px solid var(--auth-border-cancel);
   border-radius: 8px;
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--auth-fg-muted);
   font-size: 0.95rem;
   padding: 0.55rem 1.2rem;
   cursor: pointer;
@@ -383,14 +490,14 @@
 }
 
 .modal__cancel:hover {
-  border-color: rgba(255, 255, 255, 0.4);
+  border-color: var(--auth-border-cancel-hover);
 }
 
 .modal__confirm {
-  background: #5ba4dc;
+  background: var(--auth-accent);
   border: none;
   border-radius: 8px;
-  color: #ffffff;
+  color: var(--auth-on-accent);
   font-size: 0.95rem;
   font-weight: 600;
   padding: 0.55rem 1.2rem;
@@ -402,14 +509,30 @@
   opacity: 0.85;
 }
 
-/* Google sign-in (issue #10). Google draws the button itself and ships the
-   stylesheet for it, so most of what follows is the space around it — but not
-   all of it. Despite the name, GIS renders the button as ordinary elements in
-   *our* document (a `div[role=button]`, class `.nsm7Bb-HzV7m-LgbsSe`), not in
-   an iframe; the one iframe it appends is 0×0 and carries no UI. Google's
-   internals are therefore reachable from here, which is what lets the last rule
-   in this section repaint part of the button. Reach in only where there is no
-   supported option, and expect the class names to be obfuscated. */
+/* ---- Google sign-in (issue #10) ---- */
+
+/* Why these pages are light.
+ *
+ * GIS renders this button two different ways, and which one you get depends on
+ * the visitor, not on anything we pass:
+ *
+ *   - signed out of Google — real elements in our own document, themeable via
+ *     the `theme` option, and reachable from this stylesheet;
+ *   - signed in to Google — a cross-origin iframe from accounts.google.com
+ *     carrying the personalised "Sign in as <name>" button.
+ *
+ * The iframe paints a white interior and ignores the `theme` we hand it (the
+ * theme does reach it — it is right there in the iframe's query string — it
+ * just does not apply to the surround). Being cross-origin, nothing in this
+ * file can repaint it: not a more specific selector, not `!important`. On the
+ * black page these screens used to have, that surround showed up as a white box
+ * around the button, and no CSS could remove it.
+ *
+ * So the page matches the button instead of the other way round. With the page
+ * at #ffffff the surround is invisible, and `filled_blue` sits on it cleanly.
+ * Anything that darkens these pages brings the white box straight back — the
+ * background colour here is load-bearing, not decorative.
+ */
 .auth-google {
   display: flex;
   flex-direction: column;
@@ -426,7 +549,7 @@
   align-items: center;
   gap: 0.75rem;
   width: 100%;
-  color: rgba(255, 255, 255, 0.45);
+  color: var(--auth-fg-dim);
   font-size: 0.85rem;
 }
 
@@ -435,11 +558,11 @@
   content: '';
   flex: 1;
   height: 1px;
-  background: rgba(255, 255, 255, 0.15);
+  background: var(--auth-divider-line);
 }
 
-/* Google sizes the button to its own label — 187px, not the 420px card — so
-   centring is what keeps it aligned with the full-width controls above. */
+/* Google sizes the button to its own label, not to the 420px card, so centring
+   is what keeps it aligned with the full-width controls above. */
 .auth-google__button {
   display: flex;
   justify-content: center;
@@ -449,26 +572,4 @@
 
 .auth-google__button[hidden] {
   display: none;
-}
-
-/* Google's `filled_black` button is dark (#202124) apart from one thing: it
-   seats the "G" on a hard-coded white 36px plate, the tile from its older
-   button artwork. On a page whose background is pure black that plate is the
-   only white pixels on the screen, so the button reads as a white box with a
-   dark border rather than as a dark button. Clearing the plate leaves the
-   coloured G directly on the pill, which is how Google's own current dark
-   button looks; nothing about the logo itself is altered.
-
-   Two things this selector is doing deliberately:
-
-     - It names Google's obfuscated class, which is not a public API. That is
-       the only handle the plate has. If Google renames it the rule stops
-       matching and the button falls back to today's appearance — the failure
-       is cosmetic, never broken layout, so this is safe to leave in place.
-     - It carries three classes to outrank Google's own two-class rule. Google
-       injects its stylesheet at render time, i.e. *after* this bundled one, so
-       an equal-specificity rule here would lose the tie on document order and
-       silently do nothing. */
-.auth-google__button .nsm7Bb-HzV7m-LgbsSe .nsm7Bb-HzV7m-LgbsSe-Bz112c-haAclf {
-  background-color: transparent;
 }

--- a/website/src/pages/MainApp.css
+++ b/website/src/pages/MainApp.css
@@ -1,7 +1,10 @@
 /* ============================================================
    Shared styles for the authenticated app surface:
    HomePage shell + tabs, PostDetailPage, ProfilePage.
-   Mirrors the dark theme used by the auth pages (LoginPage.css).
+   This surface is dark. The auth pages are not — LoginPage.css turned light so
+   that Google's sign-in iframe, whose white interior we cannot restyle, stops
+   showing as a white box. The shared pieces that both surfaces use (.modal*,
+   .spinner, .toggle, .auth-input) are tokenised there and stay dark here.
    ============================================================ */
 
 .app-shell {


### PR DESCRIPTION
@
Merges the current `dev` branch into `main`.

## What is included

- **Android: fix blank Feed and Profile on a restored device** (#505, fixes #503) — the session store is excluded from cloud backup/data-extraction, a failed keychain write no longer publishes a signed-in state, feed error messages are resolved before the log drains the response body, and cancellation propagates through `AuthenticationManager.login` and the feed catch blocks. Adds `AuthenticationManagerTest` and `FeedViewModelSessionTest`.
- **website: light auth pages** (#504) — reworks `LoginPage.css`/`MainApp.css` and `GoogleSignInButton` so the Google sign-in button renders correctly, with a matching test.

## Notes

- No backend changes and no new migrations, so there is no dual-leaf migration to reconcile in this merge.
- Touched areas are `android/` and `website/` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@