### PR TITLE
Android: theme the empty-feed placeholder, and pin down the prefs filename note

### DIFF
--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/security/KeychainHelper.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/data/security/KeychainHelper.kt
@@ -75,7 +75,10 @@ class KeychainHelper(context: Context) : KeychainHelperProtocol {
     //
     // Kept in sync with the <exclude> entries in res/xml/backup_rules.xml and
     // res/xml/data_extraction_rules.xml, which keep this file (and only this
-    // file) out of cloud backup and device-to-device transfer.
+    // file) out of cloud backup and device-to-device transfer. Those entries
+    // name the file as it lands on disk — "positive_only_social_secure_prefs.xml",
+    // this value plus the .xml suffix SharedPreferences appends — so renaming
+    // here means renaming there too, suffix included.
     private val prefsFilename = "positive_only_social_secure_prefs"
 
     private val encryptedPrefs: SharedPreferences by lazy { openEncryptedPrefs() }

--- a/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/FeedScreen.kt
+++ b/android/PositiveOnlySocial/app/src/main/java/com/example/positiveonlysocial/ui/main/FeedScreen.kt
@@ -155,7 +155,14 @@ private fun LazyItemScope.FeedPlaceholder(loadError: String?) {
         Text(
             text = loadError ?: "No posts yet. Pull down to refresh.",
             textAlign = TextAlign.Center,
-            color = if (loadError != null) MaterialTheme.colorScheme.error else Color.Gray,
+            // Themed rather than a fixed gray: this screen follows the system
+            // light/dark setting, and a hardcoded gray reads as washed out
+            // against a light surface.
+            color = if (loadError != null) {
+                MaterialTheme.colorScheme.error
+            } else {
+                MaterialTheme.colorScheme.onSurfaceVariant
+            },
             modifier = Modifier
                 .padding(24.dp)
                 .testTag("FeedPlaceholder")


### PR DESCRIPTION
@
Addresses the two Copilot review comments on #508 (the `dev` → `main` release PR). Opened against `dev` per the repo workflow; #508 picks these up once this merges.

- **`FeedScreen.kt`** — the empty-feed placeholder drew its text in a fixed `Color.Gray`. The screen follows the system light/dark setting, and that gray is roughly 3.5:1 against a light surface, under the 4.5:1 AA floor for body text. The error branch was already themed; the empty branch now matches it with `onSurfaceVariant`.
- **`KeychainHelper.kt`** — the comment said the filename is kept in sync with the `res/xml` `<exclude>` entries but did not say those entries name the on-disk file, which carries the `.xml` suffix `SharedPreferences` appends. Now spelled out so a future rename does not sync the wrong string.

Comment-and-color changes only; no behavior change beyond the placeholder text color.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@