### PR TITLE
Add search results dialog with batched user search

### DIFF
--- a/backend/user_system/tests/test_get_users_matching_fragment_view.py
+++ b/backend/user_system/tests/test_get_users_matching_fragment_view.py
@@ -84,7 +84,8 @@ class GetUsersMatchingFragmentTests(PositiveOnlySocialTestCase):
         # Verify the correct users were returned
         found_usernames = {user['username'] for user in responses}
         self.assertIn(self.first_username, found_usernames)
-        self.assertIn(self.second_username,  found_usernames)
+        self.assertIn(self.second_username, found_usernames)
+
     def test_search_results_are_returned_in_batches_of_ten(self):
         """
         Tests that user search returns ten matching users per batch and that
@@ -98,39 +99,37 @@ class GetUsersMatchingFragmentTests(PositiveOnlySocialTestCase):
         # setUp already created two matching users. Create twelve more so there
         # are fourteen matching users in total.
         for index in range(12):
-            user_fields = self.make_user_with_prefix(
-            f'{username_fragment}_{index:02d}'
-        )
+            user_fields = self.make_user_with_prefix(f'{username_fragment}_{index:02d}')
             matching_usernames.add(user_fields[Fields.username])
 
         expected_usernames = sorted(matching_usernames)
 
         url = reverse(
-        'get_users_matching_fragment',
-        kwargs={'username_fragment': username_fragment},
+            'get_users_matching_fragment',
+            kwargs={'username_fragment': username_fragment},
         )
 
         first_response = self.client.get(
-        url,
-        {'batch': 0},
-        **self.valid_header,
-        )   
+            url,
+            {'batch': 0},
+            **self.valid_header,
+        )
         second_response = self.client.get(
-        url,
-        {'batch': 1},
-        **self.valid_header,
+            url,
+            {'batch': 1},
+            **self.valid_header,
         )
 
         self.assertEqual(first_response.status_code, 200)
         self.assertEqual(second_response.status_code, 200)
 
         first_batch = [
-        user[Fields.username]
-        for user in first_response.json()
+            user[Fields.username]
+            for user in first_response.json()
         ]
         second_batch = [
-        user[Fields.username]
-        for user in second_response.json()
+            user[Fields.username]
+            for user in second_response.json()
         ]
 
         self.assertEqual(first_batch, expected_usernames[:10])
@@ -138,39 +137,38 @@ class GetUsersMatchingFragmentTests(PositiveOnlySocialTestCase):
 
     def test_non_numeric_batch_returns_bad_response(self):
         url = reverse(
-        'get_users_matching_fragment',
-        kwargs={'username_fragment': username_fragment},
+            'get_users_matching_fragment',
+            kwargs={'username_fragment': username_fragment},
         )
 
         response = self.client.get(
-        url,
-        {'batch': 'invalid'},
-        **self.valid_header,
+            url,
+            {'batch': 'invalid'},
+            **self.valid_header,
         )
 
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
-        response.json(),
-        {'error': 'Invalid batch parameter'},
+            response.json(),
+            {'error': 'Invalid batch parameter'},
         )
-
 
     def test_batch_below_zero_returns_bad_response(self):
         url = reverse(
-        'get_users_matching_fragment',
-        kwargs={'username_fragment': username_fragment},
+            'get_users_matching_fragment',
+            kwargs={'username_fragment': username_fragment},
         )
 
         response = self.client.get(
-        url,
-        {'batch': -1},
-        **self.valid_header,
+            url,
+            {'batch': -1},
+            **self.valid_header,
         )
 
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
-        response.json(),
-        {'error': 'Invalid batch parameter'},
+            response.json(),
+            {'error': 'Invalid batch parameter'},
         )
 
     def test_search_fragment_excludes_self(self):

--- a/backend/user_system/tests/test_get_users_matching_fragment_view.py
+++ b/backend/user_system/tests/test_get_users_matching_fragment_view.py
@@ -15,7 +15,7 @@ class GetUsersMatchingFragmentTests(PositiveOnlySocialTestCase):
 
     def setUp(self):
         super().setUp()
-
+        
         # This helper is assumed to create and log in a user,
         # setting self.local_username and self.session_management_token
         super().register_user_and_setup_local_fields()
@@ -85,6 +85,93 @@ class GetUsersMatchingFragmentTests(PositiveOnlySocialTestCase):
         found_usernames = {user['username'] for user in responses}
         self.assertIn(self.first_username, found_usernames)
         self.assertIn(self.second_username,  found_usernames)
+    def test_search_results_are_returned_in_batches_of_ten(self):
+        """
+        Tests that user search returns ten matching users per batch and that
+        requesting the next batch returns the remaining users.
+        """
+        matching_usernames = {
+            self.first_username,
+            self.second_username,
+        }
+
+        # setUp already created two matching users. Create twelve more so there
+        # are fourteen matching users in total.
+        for index in range(12):
+            user_fields = self.make_user_with_prefix(
+            f'{username_fragment}_{index:02d}'
+        )
+            matching_usernames.add(user_fields[Fields.username])
+
+        expected_usernames = sorted(matching_usernames)
+
+        url = reverse(
+        'get_users_matching_fragment',
+        kwargs={'username_fragment': username_fragment},
+        )
+
+        first_response = self.client.get(
+        url,
+        {'batch': 0},
+        **self.valid_header,
+        )   
+        second_response = self.client.get(
+        url,
+        {'batch': 1},
+        **self.valid_header,
+        )
+
+        self.assertEqual(first_response.status_code, 200)
+        self.assertEqual(second_response.status_code, 200)
+
+        first_batch = [
+        user[Fields.username]
+        for user in first_response.json()
+        ]
+        second_batch = [
+        user[Fields.username]
+        for user in second_response.json()
+        ]
+
+        self.assertEqual(first_batch, expected_usernames[:10])
+        self.assertEqual(second_batch, expected_usernames[10:20])
+
+    def test_non_numeric_batch_returns_bad_response(self):
+        url = reverse(
+        'get_users_matching_fragment',
+        kwargs={'username_fragment': username_fragment},
+        )
+
+        response = self.client.get(
+        url,
+        {'batch': 'invalid'},
+        **self.valid_header,
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+        response.json(),
+        {'error': 'Invalid batch parameter'},
+        )
+
+
+    def test_batch_below_zero_returns_bad_response(self):
+        url = reverse(
+        'get_users_matching_fragment',
+        kwargs={'username_fragment': username_fragment},
+        )
+
+        response = self.client.get(
+        url,
+        {'batch': -1},
+        **self.valid_header,
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+        response.json(),
+        {'error': 'Invalid batch parameter'},
+        )
 
     def test_search_fragment_excludes_self(self):
         """

--- a/backend/user_system/views.py
+++ b/backend/user_system/views.py
@@ -3857,8 +3857,8 @@ def get_users_matching_fragment(request, username_fragment):
             {'error': "Invalid batch parameter"},
             status=400,
         )
-    # We only get the first 10 users because we don't support endlessly scrolling through
-    # user results in the search bar.
+    # Results are returned in deterministic batches of ten so the search bar
+    # can show the first batch and the dialog can load the remaining matches.
     users = PositiveOnlySocialUser.objects.filter(
         username__istartswith=username_fragment
     ).exclude(pk=request.user.pk)

--- a/backend/user_system/views.py
+++ b/backend/user_system/views.py
@@ -3841,6 +3841,22 @@ def get_users_matching_fragment(request, username_fragment):
     if not is_valid_pattern(username_fragment, Patterns.short_alphanumeric):
         return log_and_return_json("get_users_matching_fragment", {'error': "Invalid username fragment"}, status=400)
 
+    
+    try:
+        batch = int(request.GET.get('batch', 0))
+    except (TypeError, ValueError):
+        return log_and_return_json(
+            "get_users_matching_fragment",
+            {'error': "Invalid batch parameter"},
+            status=400,
+        )
+
+    if batch < 0:
+        return log_and_return_json(
+            "get_users_matching_fragment",
+            {'error': "Invalid batch parameter"},
+            status=400,
+        )
     # We only get the first 10 users because we don't support endlessly scrolling through
     # user results in the search bar.
     users = PositiveOnlySocialUser.objects.filter(
@@ -3853,7 +3869,9 @@ def get_users_matching_fragment(request, username_fragment):
     # So if I blocked someone, I can still search them.
     # But if someone blocked me, I cannot search them.
     users_who_blocked_me = request.user.blocked_by.all()
-    users = searchable_users(users.exclude(pk__in=users_who_blocked_me), request.user)[:10]
+    users = searchable_users(users.exclude(pk__in=users_who_blocked_me), request.user,).order_by('username', 'pk')
+
+    users = get_queryset_batch(users, batch, 10)
 
     users_data = [
         {

--- a/website/src/api/PositiveOnlySocialAPI.ts
+++ b/website/src/api/PositiveOnlySocialAPI.ts
@@ -207,7 +207,7 @@ export interface PositiveOnlySocialAPI {
   ): Promise<MessageResponse>
 
   // Users & profiles
-  searchUsers(usernameFragment: string): Promise<UserSearchResult[]>
+  searchUsers(usernameFragment: string, batch?: number): Promise<UserSearchResult[]>
   /** Follow a user, optionally categorizing them at the same time (issue
    * #392). Omitting `category` uses the default 'following' bucket. */
   followUser(username: string, category?: FollowCategory): Promise<MessageResponse>

--- a/website/src/api/StatefulStubbedAPI.ts
+++ b/website/src/api/StatefulStubbedAPI.ts
@@ -1683,25 +1683,25 @@ export class StatefulStubbedAPI implements PositiveOnlySocialAPI {
   // ---------------------------------------------------------------------------
 
   async searchUsers(usernameFragment: string, batch = 0): Promise<UserSearchResult[]> {
-  const current = this.requireUser()
-  const batchSize = 10
-  const startingIndex = batch * batchSize
+    const current = this.requireUser()
+    const batchSize = 10
+    const startingIndex = batch * batchSize
 
-  return this.users
-    .filter(
-      (u) =>
-        u.username.toLowerCase().startsWith(usernameFragment.toLowerCase()) &&
-        u.id !== current.id &&
-        !current.blockedBy.has(u.id),
-    )
-    .sort((a, b) => a.username.localeCompare(b.username))
-    .slice(startingIndex, startingIndex + batchSize)
-    .map((u) => ({
-      username: u.username,
-      identity_is_verified: u.isVerified,
-      ...this.authorAvatarFields(u.id),
-    }))
-}
+    return this.users
+      .filter(
+        (u) =>
+          u.username.toLowerCase().startsWith(usernameFragment.toLowerCase()) &&
+          u.id !== current.id &&
+          !current.blockedBy.has(u.id),
+      )
+      .sort((a, b) => a.username.localeCompare(b.username))
+      .slice(startingIndex, startingIndex + batchSize)
+      .map((u) => ({
+        username: u.username,
+        identity_is_verified: u.isVerified,
+        ...this.authorAvatarFields(u.id),
+      }))
+  }
 
   async followUser(username: string, category?: FollowCategory): Promise<MessageResponse> {
     const user = this.requireUser()

--- a/website/src/api/StatefulStubbedAPI.ts
+++ b/website/src/api/StatefulStubbedAPI.ts
@@ -1682,22 +1682,26 @@ export class StatefulStubbedAPI implements PositiveOnlySocialAPI {
   // Users & profiles
   // ---------------------------------------------------------------------------
 
-  async searchUsers(usernameFragment: string): Promise<UserSearchResult[]> {
-    const current = this.requireUser()
-    return this.users
-      .filter(
-        (u) =>
-          u.username.toLowerCase().includes(usernameFragment.toLowerCase()) &&
-          u.id !== current.id &&
-          !current.blockedBy.has(u.id),
-      )
-      .slice(0, 10)
-      .map((u) => ({
-        username: u.username,
-        identity_is_verified: u.isVerified,
-        ...this.authorAvatarFields(u.id),
-      }))
-  }
+  async searchUsers(usernameFragment: string, batch = 0): Promise<UserSearchResult[]> {
+  const current = this.requireUser()
+  const batchSize = 10
+  const startingIndex = batch * batchSize
+
+  return this.users
+    .filter(
+      (u) =>
+        u.username.toLowerCase().startsWith(usernameFragment.toLowerCase()) &&
+        u.id !== current.id &&
+        !current.blockedBy.has(u.id),
+    )
+    .sort((a, b) => a.username.localeCompare(b.username))
+    .slice(startingIndex, startingIndex + batchSize)
+    .map((u) => ({
+      username: u.username,
+      identity_is_verified: u.isVerified,
+      ...this.authorAvatarFields(u.id),
+    }))
+}
 
   async followUser(username: string, category?: FollowCategory): Promise<MessageResponse> {
     const user = this.requireUser()

--- a/website/src/api/client.ts
+++ b/website/src/api/client.ts
@@ -775,14 +775,14 @@ export class ApiClient implements PositiveOnlySocialAPI {
   // ===========================================================================
 
   searchUsers(usernameFragment: string, batch = 0): Promise<UserSearchResult[]> {
-  return this.request<UserSearchResult[]>(
-    'GET',
-    `/users/search/${usernameFragment}/?batch=${batch}`,
-    {
-      auth: true,
-    },
-  )
-}
+    return this.request<UserSearchResult[]>(
+      'GET',
+      `/users/search/${usernameFragment}/?batch=${batch}`,
+      {
+        auth: true,
+      },
+    )
+  }
 
   followUser(username: string, category?: FollowCategory): Promise<MessageResponse> {
     return this.request<MessageResponse>('POST', `/users/${username}/follow/`, {

--- a/website/src/api/client.ts
+++ b/website/src/api/client.ts
@@ -774,11 +774,15 @@ export class ApiClient implements PositiveOnlySocialAPI {
   // USERS & PROFILES
   // ===========================================================================
 
-  searchUsers(usernameFragment: string): Promise<UserSearchResult[]> {
-    return this.request<UserSearchResult[]>('GET', `/users/search/${usernameFragment}/`, {
+  searchUsers(usernameFragment: string, batch = 0): Promise<UserSearchResult[]> {
+  return this.request<UserSearchResult[]>(
+    'GET',
+    `/users/search/${usernameFragment}/?batch=${batch}`,
+    {
       auth: true,
-    })
-  }
+    },
+  )
+}
 
   followUser(username: string, category?: FollowCategory): Promise<MessageResponse> {
     return this.request<MessageResponse>('POST', `/users/${username}/follow/`, {

--- a/website/src/components/ProfileTab.test.tsx
+++ b/website/src/components/ProfileTab.test.tsx
@@ -210,9 +210,161 @@ test('searches users after typing 3+ characters and navigates to a profile', asy
 
   await userEvent.type(screen.getByLabelText('Search for users'), 'bob')
   const result = await screen.findByText('bob')
-  await waitFor(() => expect(mockSearch).toHaveBeenCalledWith('bob'))
+  await waitFor(() => expect(mockSearch).toHaveBeenCalledWith('bob',0))
   await userEvent.click(result)
   expect(screen.getByText('Profile page')).toBeInTheDocument()
+})
+
+test('shows View all results when more search results exist', async () => {
+  mockGetPosts.mockResolvedValue([])
+
+  const firstBatch = Array.from({ length: 10 }, (_, index) => ({
+    username: `bob${index}`,
+    identity_is_verified: false,
+  }))
+
+  mockSearch
+    .mockResolvedValueOnce(firstBatch)
+    .mockResolvedValueOnce([
+      {
+        username: 'bob10',
+        identity_is_verified: false,
+      },
+    ])
+
+  renderTab()
+
+  await userEvent.type(screen.getByLabelText('Search for users'), 'bob')
+
+  expect(await screen.findByText('bob0')).toBeInTheDocument()
+
+  await waitFor(() => {
+    expect(mockSearch).toHaveBeenCalledWith('bob', 0)
+    expect(mockSearch).toHaveBeenCalledWith('bob', 1)
+  })
+
+  expect(screen.getByRole('button', { name: 'View all results' })).toBeInTheDocument()
+})
+
+test('does not show View all results when all search results fit in the first batch', async () => {
+  mockGetPosts.mockResolvedValue([])
+
+  mockSearch.mockResolvedValue([
+    {
+      username: 'bob',
+      identity_is_verified: false,
+    },
+  ])
+
+  renderTab()
+
+  await userEvent.type(screen.getByLabelText('Search for users'), 'bob')
+
+  expect(await screen.findByText('bob')).toBeInTheDocument()
+
+  expect(
+    screen.queryByRole('button', { name: 'View all results' }),
+  ).not.toBeInTheDocument()
+
+  expect(mockSearch).toHaveBeenCalledWith('bob', 0)
+})
+
+test('opens a dialog containing all search results', async () => {
+  mockGetPosts.mockResolvedValue([])
+
+  const firstBatch = Array.from({ length: 10 }, (_, index) => ({
+    username: `bob${index}`,
+    identity_is_verified: false,
+  }))
+
+  const secondBatch = [
+    {
+      username: 'bob10',
+      identity_is_verified: false,
+    },
+    {
+      username: 'bob11',
+      identity_is_verified: false,
+    },
+  ]
+
+  mockSearch
+    .mockResolvedValueOnce(firstBatch)
+    .mockResolvedValueOnce(secondBatch)
+    .mockResolvedValueOnce(secondBatch)
+
+  renderTab()
+
+  await userEvent.type(screen.getByLabelText('Search for users'), 'bob')
+
+  const viewAllButton = await screen.findByRole('button', {
+    name: 'View all results',
+  })
+
+  await userEvent.click(viewAllButton)
+
+  const dialog = await screen.findByRole('dialog', {
+    name: 'Search results',
+  })
+
+  expect(dialog).toBeInTheDocument()
+
+  expect(screen.getAllByText('bob0').length).toBeGreaterThan(0)
+  expect(screen.getByText('bob10')).toBeInTheDocument()
+  expect(screen.getByText('bob11')).toBeInTheDocument()
+
+  await waitFor(() => {
+    expect(mockSearch).toHaveBeenCalledWith('bob', 1)
+  })
+})
+
+test('closes the all search results dialog', async () => {
+  mockGetPosts.mockResolvedValue([])
+
+  const firstBatch = Array.from({ length: 10 }, (_, index) => ({
+    username: `bob${index}`,
+    identity_is_verified: false,
+  }))
+
+  const secondBatch = [
+    {
+      username: 'bob10',
+      identity_is_verified: false,
+    },
+  ]
+
+  mockSearch
+    .mockResolvedValueOnce(firstBatch)
+    .mockResolvedValueOnce(secondBatch)
+    .mockResolvedValueOnce(secondBatch)
+
+  renderTab()
+
+  await userEvent.type(screen.getByLabelText('Search for users'), 'bob')
+
+  await userEvent.click(
+    await screen.findByRole('button', {
+      name: 'View all results',
+    }),
+  )
+
+  expect(
+    await screen.findByRole('dialog', {
+      name: 'Search results',
+    }),
+  ).toBeInTheDocument()
+
+  await userEvent.click(
+    screen.getByRole('button', {
+      name: 'Close search results',
+    }),
+  )
+
+  expect(
+    screen.queryByRole('dialog', {
+      name: 'Search results',
+    }),
+  ).not.toBeInTheDocument()
 })
 
 test('shows an In review badge on a pending post and clears it once approved (#282)', async () => {

--- a/website/src/components/ProfileTab.test.tsx
+++ b/website/src/components/ProfileTab.test.tsx
@@ -210,7 +210,7 @@ test('searches users after typing 3+ characters and navigates to a profile', asy
 
   await userEvent.type(screen.getByLabelText('Search for users'), 'bob')
   const result = await screen.findByText('bob')
-  await waitFor(() => expect(mockSearch).toHaveBeenCalledWith('bob',0))
+  await waitFor(() => expect(mockSearch).toHaveBeenCalledWith('bob', 0))
   await userEvent.click(result)
   expect(screen.getByText('Profile page')).toBeInTheDocument()
 })
@@ -244,6 +244,30 @@ test('shows View all results when more search results exist', async () => {
   })
 
   expect(screen.getByRole('button', { name: 'View all results' })).toBeInTheDocument()
+})
+
+test('keeps first-batch results when checking for more results fails', async () => {
+  mockGetPosts.mockResolvedValue([])
+
+  const firstBatch = Array.from({ length: 10 }, (_, index) => ({
+    username: `bob${index}`,
+    identity_is_verified: false,
+  }))
+
+  mockSearch.mockResolvedValueOnce(firstBatch).mockRejectedValueOnce(new Error('Request failed'))
+
+  renderTab()
+
+  await userEvent.type(screen.getByLabelText('Search for users'), 'bob')
+
+  expect(await screen.findByText('bob0')).toBeInTheDocument()
+
+  await waitFor(() => {
+    expect(mockSearch).toHaveBeenCalledWith('bob', 1)
+  })
+
+  expect(screen.getByText('bob9')).toBeInTheDocument()
+  expect(screen.queryByRole('button', { name: 'View all results' })).not.toBeInTheDocument()
 })
 
 test('does not show View all results when all search results fit in the first batch', async () => {

--- a/website/src/components/ProfileTab.tsx
+++ b/website/src/components/ProfileTab.tsx
@@ -61,10 +61,18 @@ function ProfileTab() {
 
         // If the first batch is full, check whether another result exists.
         if (results.length === 10) {
-          const nextBatch = await apiClient.searchUsers(query, 1)
+          try {
+            const nextBatch = await apiClient.searchUsers(query, 1)
 
-          if (!cancelled && isMounted.current) {
-            setHasMoreResults(nextBatch.length > 0)
+            if (!cancelled && isMounted.current) {
+              setHasMoreResults(nextBatch.length > 0)
+            }
+          } catch {
+            // Keep the successful first batch visible if the optional
+            // check for additional results fails.
+            if (!cancelled && isMounted.current) {
+              setHasMoreResults(false)
+            }
           }
         } else {
           setHasMoreResults(false)

--- a/website/src/components/ProfileTab.tsx
+++ b/website/src/components/ProfileTab.tsx
@@ -32,39 +32,120 @@ function ProfileTab() {
 
   const [searchText, setSearchText] = useState('')
   const [searchResults, setSearchResults] = useState<UserSearchResult[]>([])
+  const [hasMoreResults, setHasMoreResults] = useState(false)
+  const [showAllResults, setShowAllResults] = useState(false)
+  const [allSearchResults, setAllSearchResults] = useState<UserSearchResult[]>([])
+  const [isLoadingAllResults, setIsLoadingAllResults] = useState(false)
 
   // Debounced user search (500ms), only firing for 3+ character queries. The
   // setState lives in the timeout callback (not synchronously in the effect);
   // clearing for short queries is handled in the input's onChange below.
   useEffect(() => {
     const query = searchText.trim()
-    if (query.length < 3) return
+
+    if (query.length < 3) {
+      return
+    }
+
+    let cancelled = false
+
     const id = setTimeout(async () => {
       try {
-        const results = await apiClient.searchUsers(query)
-        if (isMounted.current) setSearchResults(results)
+        const results = await apiClient.searchUsers(query, 0)
+
+        if (cancelled || !isMounted.current) {
+          return
+        }
+
+        setSearchResults(results)
+
+        // If the first batch is full, check whether another result exists.
+        if (results.length === 10) {
+          const nextBatch = await apiClient.searchUsers(query, 1)
+
+          if (!cancelled && isMounted.current) {
+            setHasMoreResults(nextBatch.length > 0)
+          }
+        } else {
+          setHasMoreResults(false)
+        }
       } catch {
-        if (isMounted.current) setSearchResults([])
+        if (!cancelled && isMounted.current) {
+          setSearchResults([])
+          setHasMoreResults(false)
+        }
       }
     }, 500)
-    return () => clearTimeout(id)
+
+    return () => {
+      cancelled = true
+      clearTimeout(id)
+    }
   }, [searchText])
 
   function handleSearchChange(value: string) {
     setSearchText(value)
-    if (value.trim().length < 3) setSearchResults([])
+
+    setShowAllResults(false)
+    setAllSearchResults([])
+    setHasMoreResults(false)
+
+    if (value.trim().length < 3) {
+      setSearchResults([])
+    }
   }
 
   const isSearching = searchText.trim().length > 0
+
+  async function openAllSearchResults() {
+    const query = searchText.trim()
+
+    if (query.length < 3) {
+      return
+    }
+
+    setIsLoadingAllResults(true)
+
+    try {
+      const results: UserSearchResult[] = [...searchResults]
+      let batch = 1
+
+      while (true) {
+        const nextBatch = await apiClient.searchUsers(query, batch)
+
+        results.push(...nextBatch)
+
+        if (nextBatch.length < 10) {
+          break
+        }
+
+        batch += 1
+      }
+
+      if (isMounted.current && searchText.trim() === query) {
+        setAllSearchResults(results)
+        setShowAllResults(true)
+      }
+    } catch {
+      // Keep the existing inline results visible if loading all results fails.
+    } finally {
+      if (isMounted.current) {
+        setIsLoadingAllResults(false)
+      }
+    }
+  }
 
   // Finding yourself in search should reveal the profile already behind this
   // tab, not navigate to /home — we're on /home, so that would look like a
   // dead tap. Clearing the query drops back to the profile body.
   function openSearchResult(resultUsername: string) {
+    setShowAllResults(false)
+
     if (resultUsername === username) {
       handleSearchChange('')
       return
     }
+
     navigate(profilePathFor(resultUsername))
   }
 
@@ -104,6 +185,18 @@ function ProfileTab() {
               )}
             </button>
           ))}
+
+          {hasMoreResults && (
+            <button
+              type="button"
+              className="search-results__view-all"
+              onClick={openAllSearchResults}
+              disabled={isLoadingAllResults}
+            >
+              {isLoadingAllResults ? 'Loading...' : 'View all results'}
+            </button>
+          )}
+
           {searchText.trim().length >= 3 && searchResults.length === 0 && (
             <p className="muted">No users found.</p>
           )}
@@ -114,6 +207,60 @@ function ProfileTab() {
         // No session username cached (the shell already bounces to login); render
         // a message rather than requesting a profile for an empty username.
         <p className="muted">Sign in to see your profile.</p>
+      )}
+
+      {showAllResults && (
+        <div
+          className="search-results-dialog__backdrop"
+          onClick={() => setShowAllResults(false)}
+        >
+          <div
+            className="search-results-dialog"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="search-results-dialog-title"
+            onClick={event => event.stopPropagation()}
+          >
+            <div className="search-results-dialog__header">
+              <h2 id="search-results-dialog-title">Search results</h2>
+
+              <button
+                type="button"
+                aria-label="Close search results"
+                onClick={() => setShowAllResults(false)}
+              >
+                ×
+              </button>
+            </div>
+
+            <div className="user-list">
+              {allSearchResults.map(user => (
+                <button
+                  key={user.username}
+                  type="button"
+                  className="user-list__item"
+                  onClick={() => openSearchResult(user.username)}
+                >
+                  <Avatar
+                    src={user.author_profile_image_url}
+                    originalSrc={user.author_profile_image_original_url}
+                    blurhash={user.author_profile_image_blurhash}
+                    username={user.username}
+                    size="sm"
+                  />
+
+                  <span className="user-list__name">{user.username}</span>
+
+                  {user.identity_is_verified && (
+                    <span className="verified-badge" aria-label="Verified">
+                      ✓
+                    </span>
+                  )}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
       )}
     </div>
   )

--- a/website/src/pages/MainApp.css
+++ b/website/src/pages/MainApp.css
@@ -316,6 +316,7 @@
   line-clamp: 3;
   font-weight: 500;
 }
+
 .search-results__view-all {
   width: 100%;
   padding: 12px;
@@ -348,7 +349,7 @@
   max-height: 80vh;
   overflow-y: auto;
   border-radius: 12px;
-  background: #111
+  background: #111;
 }
 
 .search-results-dialog__header {
@@ -371,6 +372,7 @@
   cursor: pointer;
   font-size: 24px;
 }
+
 /* ---- User search results ---- */
 
 .user-list {

--- a/website/src/pages/MainApp.css
+++ b/website/src/pages/MainApp.css
@@ -316,7 +316,61 @@
   line-clamp: 3;
   font-weight: 500;
 }
+.search-results__view-all {
+  width: 100%;
+  padding: 12px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 600;
+}
 
+.search-results__view-all:disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+
+.search-results-dialog__backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  background: rgba(0, 0, 0, 0.5);
+}
+
+.search-results-dialog {
+  width: 100%;
+  max-width: 500px;
+  max-height: 80vh;
+  overflow-y: auto;
+  border-radius: 12px;
+  background: #111
+}
+
+.search-results-dialog__header {
+  position: sticky;
+  top: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px;
+  background: inherit;
+}
+
+.search-results-dialog__header h2 {
+  margin: 0;
+}
+
+.search-results-dialog__header button {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-size: 24px;
+}
 /* ---- User search results ---- */
 
 .user-list {


### PR DESCRIPTION
Closes #210

## Changes

- Add batched user search support to the backend
- Add deterministic ordering for paginated search results
- Add batch support to the website API client and stub
- Show the first 10 matching users inline
- Show "View all results" when additional matches exist
- Load the remaining results into a search results dialog
- Add frontend and backend regression tests

## Screenshots

### Search results

<img width="1911" height="1022" alt="image" src="https://github.com/user-attachments/assets/f78b6733-ac1e-43ad-ba05-2c0d6acc5171" />


### View all results dialog

<img width="1916" height="1025" alt="image" src="https://github.com/user-attachments/assets/8aa89202-7adc-4076-8d89-527402da4709" />


This is the UI approach I took for handling more than 10 matching users. Please let me know if this matches what you had in mind for #210 or if you'd prefer the interaction/dialog to work differently.

## Testing

- 549 website tests passed
- 1109 backend tests passed
- 9 targeted user search tests passed
- Manually verified:
  - first 10 results display correctly
  - View all results appears when additional users exist
  - all batches load in the dialog
  - dialog scrolling and closing
  - navigation from a dialog result